### PR TITLE
Adds translation to the street metadata line.

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -120,9 +120,9 @@
     "remove": "Drag here to remove"
   },
   "width": {
-    "label": "%s width",
-    "room": "(%s room)",
-    "over": "(%s over)",
+    "label": "{{width}} width",
+    "under": "({{width}} room)",
+    "over": "({{width}} over)",
     "occupied": "Occupied width:",
     "building": "Building-to-building width:",
     "different": "Different width…",
@@ -178,7 +178,7 @@
   },
   "users": {
     "anonymous": "Anonymous",
-    "byline": "by %s"
+    "byline": "by {{user}}"
   },
   "sign-in": {
     "link": "Sign in with Twitter",

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -177,7 +177,8 @@
     }
   },
   "users": {
-    "anonymous": "Anonymous"
+    "anonymous": "Anonymous",
+    "byline": "by %s"
   },
   "sign-in": {
     "link": "Sign in with Twitter",

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -132,8 +132,8 @@
   "datetime": {
     "minutes-ago": "A few minutes ago",
     "seconds-ago": "A few seconds ago",
-    "yesterday": "Yesterday at %s",
-    "today": "Today at %s",
+    "yesterday": "Yesterday at {{time}}",
+    "today": "Today at {{time}}",
     "format-date-no-year": "MMM D",
     "format-date-with-year": "MMM D, YYYY",
     "format-time": "HH:MM"

--- a/assets/scripts/app/messages.js
+++ b/assets/scripts/app/messages.js
@@ -5,10 +5,6 @@ const messages = {
 
   PROMPT_NEW_STREET_NAME: 'New street name:',
   PROMPT_DELETE_STREET: 'Are you sure you want to permanently delete [[name]]? This cannot be undone.',
-  PROMPT_NEW_STREET_WIDTH: 'New street width (from [[minWidth]] to [[maxWidth]]):',
-
-  MENU_SWITCH_TO_IMPERIAL: 'Switch to imperial units (feet)',
-  MENU_SWITCH_TO_METRIC: 'Switch to metric units',
 
   TOOLTIP_REMOVE_SEGMENT: 'Remove segment',
   TOOLTIP_DELETE_STREET: 'Delete street',

--- a/assets/scripts/app/messages.js
+++ b/assets/scripts/app/messages.js
@@ -39,12 +39,7 @@ const messages = {
 
   DEFAULT_STREET_NAME: 'Unnamed St',
 
-  SEGMENT_NAME_EMPTY: 'Empty space',
-
-  DATE_MINUTES_AGO: 'A few minutes ago',
-  DATE_SECONDS_AGO: 'A few seconds ago',
-  DATE_YESTERDAY: 'Yesterday at [[time]]',
-  DATE_TODAY: 'Today at [[time]]'
+  SEGMENT_NAME_EMPTY: 'Empty space'
 }
 
 export function msg (messageId, data) {

--- a/assets/scripts/streets/StreetMetaData.jsx
+++ b/assets/scripts/streets/StreetMetaData.jsx
@@ -56,4 +56,3 @@ StreetMetaData.propTypes = {
   readOnly: React.PropTypes.bool,
   street: React.PropTypes.any
 }
-

--- a/assets/scripts/streets/StreetWidth.jsx
+++ b/assets/scripts/streets/StreetWidth.jsx
@@ -49,18 +49,16 @@ export default class StreetWidth extends React.Component {
 
     let differenceClass = ''
     let differenceString = ''
-    let widthDifference = ''
 
     if (this.state.street.remainingWidth > 0) {
       differenceClass = 'street-width-under'
-      differenceString = t('width.room', '(%s room)')
+      differenceString = t('width.room', '({{width}} room)', { width })
     } else if (this.state.street.remainingWidth < 0) {
       differenceClass = 'street-width-over'
-      differenceString = t('width.over', '(% over)')
+      differenceString = t('width.over', '({{width}} over)', { width })
     }
 
-    widthDifference = replace(differenceString, '%s', width)
-    return { class: differenceClass, width: widthDifference }
+    return { class: differenceClass, width: differenceString }
   }
 
   normalizeStreetWidth (width) {
@@ -210,14 +208,13 @@ export default class StreetWidth extends React.Component {
     // TODO prettifyWidth calls getStreet(). refactor this to use units passed by argument instead
     // TODO work on this so that we can use markup
     const width = prettifyWidth(this.state.street.width, { markup: false })
-    const widthString = t('width.label', '%s width')
-    const widthTranslated = replace(widthString, '%s', width)
+    const widthString = t('width.label', '{{width}} width', { width })
     const difference = this.displayStreetWidthRemaining()
 
     return (
       <span id='street-metadata-width'>
         <span id='street-width-read' title='Change width of the street' onClick={this.clickStreetWidth}>
-          <span id='street-width-read-width'>{widthTranslated}</span>
+          <span id='street-width-read-width'>{widthString}</span>
           &nbsp;
           <span id='street-width-read-difference' className={difference.class}>{difference.width}</span>
         </span>

--- a/assets/scripts/streets/StreetWidth.jsx
+++ b/assets/scripts/streets/StreetWidth.jsx
@@ -4,7 +4,6 @@ import { processWidthInput, prettifyWidth } from '../util/width_units'
 import { getSegmentWidthResolution } from '../segments/resizing'
 import { loseAnyFocus } from '../app/focus'
 import { setInitializing } from '../app/initialization'
-import { msg } from '../app/messages'
 import {
   SETTINGS_UNITS_IMPERIAL,
   SETTINGS_UNITS_METRIC,
@@ -104,33 +103,35 @@ export default class StreetWidth extends React.Component {
     if (this.state.street.width) {
       selectedValue = this.state.street.width
     }
-    return <select ref={(ref) => { this.streetWidth = ref }} onChange={this.changeStreetWidth} id='street-width' value={selectedValue}>
-      <option disabled='true'>Occupied width:</option>
-      <option disabled='true'>{prettifyWidth(this.state.street.occupiedWidth)}</option>
-      <option disabled='true' />
-      <option disabled='true'>Building-to-building width:</option>
-      {defaultWidths}
-      {customWidthBlank}
-      {customWidth}
-      <option value={STREET_WIDTH_CUSTOM} >
-        Different width…
-      </option>
-      <option disabled='true' />
-      <option
-        id='switch-to-imperial-units'
-        value={STREET_WIDTH_SWITCH_TO_IMPERIAL}
-        disabled={this.state.street.units === SETTINGS_UNITS_IMPERIAL}
-      >
-        {msg('MENU_SWITCH_TO_IMPERIAL')}
-      </option>
-      <option
-        id='switch-to-metric-units'
-        value={STREET_WIDTH_SWITCH_TO_METRIC}
-        disabled={this.state.street.units === SETTINGS_UNITS_METRIC}
-      >
-        {msg('MENU_SWITCH_TO_METRIC')}
-      </option>
-    </select>
+    return (
+      <select ref={(ref) => { this.streetWidth = ref }} onChange={this.changeStreetWidth} id='street-width' value={selectedValue}>
+        <option disabled='true'>{t('width.occupied', 'Occupied width:')}</option>
+        <option disabled='true'>{prettifyWidth(this.state.street.occupiedWidth)}</option>
+        <option disabled='true' />
+        <option disabled='true'>{t('width.building', 'Building-to-building width:')}</option>
+        {defaultWidths}
+        {customWidthBlank}
+        {customWidth}
+        <option value={STREET_WIDTH_CUSTOM} >
+          {t('width.different', 'Different width…')}
+        </option>
+        <option disabled='true' />
+        <option
+          id='switch-to-imperial-units'
+          value={STREET_WIDTH_SWITCH_TO_IMPERIAL}
+          disabled={this.state.street.units === SETTINGS_UNITS_IMPERIAL}
+        >
+          {t('width.imperial', 'Switch to imperial units (feet)')}
+        </option>
+        <option
+          id='switch-to-metric-units'
+          value={STREET_WIDTH_SWITCH_TO_METRIC}
+          disabled={this.state.street.units === SETTINGS_UNITS_METRIC}
+        >
+          {t('width.metric', 'Switch to metric units')}
+        </option>
+      </select>
+    )
   }
 
   clickStreetWidth (e) {
@@ -162,16 +163,16 @@ export default class StreetWidth extends React.Component {
         updateUnits(SETTINGS_UNITS_IMPERIAL)
         return
       } else if (newStreetWidth === STREET_WIDTH_CUSTOM) {
-        var promptValue = this.state.street.occupiedWidth
+        let promptValue = this.state.street.occupiedWidth
         if (promptValue < MIN_CUSTOM_STREET_WIDTH) promptValue = MIN_CUSTOM_STREET_WIDTH
         if (promptValue > MAX_CUSTOM_STREET_WIDTH) promptValue = MAX_CUSTOM_STREET_WIDTH
 
-        // TODO string
-        var width = window.prompt(
-          msg('PROMPT_NEW_STREET_WIDTH', {
-            minWidth: prettifyWidth(MIN_CUSTOM_STREET_WIDTH),
-            maxWidth: prettifyWidth(MAX_CUSTOM_STREET_WIDTH)
-          }), prettifyWidth(promptValue))
+        const replacements = {
+          minWidth: prettifyWidth(MIN_CUSTOM_STREET_WIDTH),
+          maxWidth: prettifyWidth(MAX_CUSTOM_STREET_WIDTH)
+        }
+        const promptString = t('prompt.new-width', 'New street width (from {{minWidth}} to {{maxWidth}}):', replacements)
+        let width = window.prompt(promptString, prettifyWidth(promptValue))
 
         if (width) {
           width = this.normalizeStreetWidth(processWidthInput(width))

--- a/assets/scripts/streets/StreetWidth.jsx
+++ b/assets/scripts/streets/StreetWidth.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { replace } from 'lodash'
 import { processWidthInput, prettifyWidth } from '../util/width_units'
 import { getSegmentWidthResolution } from '../segments/resizing'
 import { loseAnyFocus } from '../app/focus'

--- a/assets/scripts/streets/StreetWidth.jsx
+++ b/assets/scripts/streets/StreetWidth.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { replace } from 'lodash'
 import { processWidthInput, prettifyWidth } from '../util/width_units'
 import { getSegmentWidthResolution } from '../segments/resizing'
 import { loseAnyFocus } from '../app/focus'
@@ -12,6 +13,7 @@ import {
 import { segmentsChanged } from '../segments/view'
 import { setStreet, createDomFromData } from './data_model'
 import { resizeStreetWidth } from './width'
+import { t } from '../app/locale'
 
 const STREET_WIDTH_CUSTOM = -1
 const STREET_WIDTH_SWITCH_TO_METRIC = -2
@@ -44,18 +46,22 @@ export default class StreetWidth extends React.Component {
 
   displayStreetWidthRemaining () {
     // TODO work on this so that we can use markup
-    const width = prettifyWidth(Math.abs(this.state.street.remainingWidth), {markup: false})
+    const width = prettifyWidth(Math.abs(this.state.street.remainingWidth), { markup: false })
 
     let differenceClass = ''
+    let differenceString = ''
     let widthDifference = ''
+
     if (this.state.street.remainingWidth > 0) {
       differenceClass = 'street-width-under'
-      widthDifference = '(' + width + ' room)'
+      differenceString = t('width.room', '(%s room)')
     } else if (this.state.street.remainingWidth < 0) {
       differenceClass = 'street-width-over'
-      widthDifference = '(' + width + ' over)'
+      differenceString = t('width.over', '(% over)')
     }
-    return {class: differenceClass, width: widthDifference}
+
+    widthDifference = replace(differenceString, '%s', width)
+    return { class: differenceClass, width: widthDifference }
   }
 
   normalizeStreetWidth (width) {
@@ -202,13 +208,15 @@ export default class StreetWidth extends React.Component {
   render () {
     // TODO prettifyWidth calls getStreet(). refactor this to use units passed by argument instead
     // TODO work on this so that we can use markup
-    const width = prettifyWidth(this.state.street.width, {markup: false}) + ' width'
+    const width = prettifyWidth(this.state.street.width, { markup: false })
+    const widthString = t('width.label', '%s width')
+    const widthTranslated = replace(widthString, '%s', width)
     const difference = this.displayStreetWidthRemaining()
 
     return (
       <span id='street-metadata-width'>
         <span id='street-width-read' title='Change width of the street' onClick={this.clickStreetWidth}>
-          <span id='street-width-read-width'>{width}</span>
+          <span id='street-width-read-width'>{widthTranslated}</span>
           &nbsp;
           <span id='street-width-read-difference' className={difference.class}>{difference.width}</span>
         </span>
@@ -222,4 +230,3 @@ StreetWidth.propTypes = {
   readOnly: React.PropTypes.bool,
   street: React.PropTypes.any
 }
-

--- a/assets/scripts/util/date_format.js
+++ b/assets/scripts/util/date_format.js
@@ -6,6 +6,7 @@ const SECONDS_AGO = 1000 * 60
 
 import moment from 'moment'
 import { msg } from '../app/messages'
+import { t } from '../app/locale'
 
 export function formatDate (dateString) {
   const now = moment()
@@ -14,6 +15,7 @@ export function formatDate (dateString) {
 
   if (diff >= 0) {
     if (diff < SECONDS_AGO) {
+      return t('datetime.seconds-ago')
       return msg('DATE_SECONDS_AGO')
     }
 

--- a/assets/scripts/util/date_format.js
+++ b/assets/scripts/util/date_format.js
@@ -1,40 +1,46 @@
 const DATE_FORMAT_NO_YEAR = 'MMM D'
-const DATE_FORMAT = 'MMM D, YYYY'
+const DATE_FORMAT_WITH_YEAR = 'MMM D, YYYY'
 const TIME_FORMAT = 'HH:MM'
 const MINUTES_AGO = 1000 * 60 * 10
 const SECONDS_AGO = 1000 * 60
 
 import moment from 'moment'
-import { msg } from '../app/messages'
-import { t } from '../app/locale'
+import { t, getLocale } from '../app/locale'
 
 export function formatDate (dateString) {
   const now = moment()
+
+  // Set locale for moment
+  now.locale(getLocale())
+
   const date = moment(dateString)
   const diff = now - date
 
   if (diff >= 0) {
     if (diff < SECONDS_AGO) {
-      return t('datetime.seconds-ago')
-      return msg('DATE_SECONDS_AGO')
+      return t('datetime.seconds-ago', 'A few seconds ago')
     }
 
     if (diff < MINUTES_AGO) {
-      return msg('DATE_MINUTES_AGO')
+      return t('datetime.minutes-ago', 'A few minutes ago')
     }
   }
 
+  const timeFormat = t('datetime.format-time', TIME_FORMAT)
+
   if (now.isSame(date, 'day')) {
-    return msg('DATE_TODAY', {time: date.format(TIME_FORMAT)})
+    return t('datetime.today', 'Today at {{time}}', { time: date.format(timeFormat) })
   }
 
   if (now.clone().subtract(1, 'day').isSame(date, 'day')) {
-    return msg('DATE_YESTERDAY', {time: date.format(TIME_FORMAT)})
+    return t('datetime.yesterday', 'Yesterday at {{time}}', { time: date.format(timeFormat) })
   }
 
   if (now.isSame(date, 'year')) {
-    return date.format(DATE_FORMAT_NO_YEAR)
+    const dateFormat = t('datetime.format-date-no-year', DATE_FORMAT_NO_YEAR)
+    return date.format(dateFormat)
   }
 
-  return date.format(DATE_FORMAT)
+  const dateFormat = t('datetime.format-date-with-year', DATE_FORMAT_WITH_YEAR)
+  return date.format(dateFormat)
 }


### PR DESCRIPTION
- Updates the width, width dropdown, and date/time strings to use locale information via i18next to provide translations.
- Updates the translation file to use i18next's [interpolation syntax](http://i18next.com/translate/interpolation/) e.g. `{{width}} over` instead of `%s over`.

Caveats:
- The original translations for `%s over` etc were lost :( Now I know, don't update strings this way...
- This does not respond dynamically to language settings changes. It will pick up new language settings on the next `render()`.