### PR TITLE
Add Redux state store to Streetmix

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/app.js
+++ b/app.js
@@ -77,17 +77,11 @@ app.get('/.well-known/status', resources.well_known_status.get)
 // Process stylesheets via Sass and PostCSS / Autoprefixer
 app.use('/assets/css/styles.css', middleware.styles)
 
-// Build JavaScript bundle via browserify
-var babelOpts = {
-  presets: ['es2015', 'react'],
-  plugins: ['transform-object-rest-spread']
-}
-
 app.get('/assets/scripts/main.js', browserify(path.join(__dirname, '/assets/scripts/main.js'), {
   cache: true,
   precompile: true,
   extensions: [ '.jsx' ],
-  transform: [[babelOpts, babelify], envify({
+  transform: [babelify, envify({
     APP_HOST_PORT: config.get('app_host_port'),
     FACEBOOK_APP_ID: config.get('facebook_app_id'),
     API_URL: config.get('restapi_proxy_baseuri_rel'),

--- a/app.js
+++ b/app.js
@@ -78,11 +78,16 @@ app.get('/.well-known/status', resources.well_known_status.get)
 app.use('/assets/css/styles.css', middleware.styles)
 
 // Build JavaScript bundle via browserify
+var babelOpts = {
+  presets: ['es2015', 'react'],
+  plugins: ['transform-object-rest-spread']
+}
+
 app.get('/assets/scripts/main.js', browserify(path.join(__dirname, '/assets/scripts/main.js'), {
   cache: true,
   precompile: true,
   extensions: [ '.jsx' ],
-  transform: [[{ presets: ['es2015', 'react'] }, babelify], envify({
+  transform: [[babelOpts, babelify], envify({
     APP_HOST_PORT: config.get('app_host_port'),
     FACEBOOK_APP_ID: config.get('facebook_app_id'),
     API_URL: config.get('restapi_proxy_baseuri_rel'),

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { app } from '../preinit/app_settings'
 import MenusContainer from '../menus/MenusContainer'
 import StreetNameCanvas from '../streets/StreetNameCanvas'
 import WelcomePanel from './WelcomePanel'
@@ -10,7 +9,7 @@ export default class App extends React.PureComponent {
     return (
       <div>
         <MenusContainer />
-        <StreetNameCanvas allowEditing={!app.readOnly} />
+        <StreetNameCanvas />
         <WelcomePanel />
         <Palette />
       </div>

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -6,6 +6,7 @@
 import Raven from 'raven-js'
 import React from 'react'
 import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
 
 // Polyfills
 import 'babel-polyfill'
@@ -17,6 +18,7 @@ import './vendor/modernizr-custom'
 import './vendor/polyfills/customevent' // customEvent in IE
 
 // Main object
+import store from './store'
 import { initialize } from './app/initialization'
 import { startListening } from './app/keypress'
 import { system } from './preinit/system_capabilities'
@@ -47,7 +49,10 @@ function setScaleForPhone () {
 setScaleForPhone()
 
 // Temp: mount React components
-ReactDOM.render(<App />, document.getElementById('react-app'))
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>, document.getElementById('react-app'))
 ReactDOM.render(<DebugInfo />, document.getElementById('debug'))
 
 // Start listening for keypresses

--- a/assets/scripts/preinit/app_settings.js
+++ b/assets/scripts/preinit/app_settings.js
@@ -7,8 +7,15 @@
  */
 import { debug } from './debug_settings'
 import { system } from './system_capabilities'
+import store from '../store'
+import { SET_APP_FLAGS } from '../store/actions'
 
 // Just set readOnly
 export const app = {
   readOnly: (system.phone || debug.forceReadOnly)
 }
+
+store.dispatch({
+  type: SET_APP_FLAGS,
+  ...app
+})

--- a/assets/scripts/preinit/debug_settings.js
+++ b/assets/scripts/preinit/debug_settings.js
@@ -8,6 +8,8 @@
  * Later scripts may use these settings.
  *
  */
+import store from '../store'
+import { SET_DEBUG_FLAGS } from '../store/actions'
 
 export const debug = {
   hoverPolygon: false,
@@ -17,6 +19,9 @@ export const debug = {
   forceUnsupportedBrowser: false,
   forceNonRetina: false,
   forceNoInternet: false,
+  forceReadOnly: false,
+  forceTouch: false,
+  forceLiveUpdate: false,
   secretSegments: false,
   experimental: false
 }
@@ -49,12 +54,8 @@ if (url.match(/[?&]debug-force-non-retina&?/)) {
   debug.forceNonRetina = true
 }
 
-if (url.match(/[?&]debug-secret-segments&?/)) {
-  debug.secretSegments = true
-}
-
-if (url.match(/[?&]debug-hover-polygon&?/)) {
-  debug.hoverPolygon = true
+if (url.match(/[?&]debug-force-no-internet&?/)) {
+  debug.forceNoInternet = true
 }
 
 if (url.match(/[?&]debug-force-read-only&?/)) {
@@ -69,10 +70,15 @@ if (url.match(/[?&]debug-force-live-update&?/)) {
   debug.forceLiveUpdate = true
 }
 
-if (url.match(/[?&]debug-force-no-internet&?/)) {
-  debug.forceNoInternet = true
+if (url.match(/[?&]debug-secret-segments&?/)) {
+  debug.secretSegments = true
 }
 
 if (url.match(/[?&]debug-experimental&?/)) {
   debug.experimental = true
 }
+
+store.dispatch({
+  type: SET_DEBUG_FLAGS,
+  ...debug
+})

--- a/assets/scripts/preinit/system_capabilities.js
+++ b/assets/scripts/preinit/system_capabilities.js
@@ -8,6 +8,8 @@
 /* global Modernizr */
 import { NO_INTERNET_MODE } from '../app/config'
 import { debug } from './debug_settings'
+import store from '../store'
+import { SET_SYSTEM_FLAGS } from '../store/actions'
 
 // Default settings
 export const system = {
@@ -35,7 +37,7 @@ if (debug.forceNoInternet || NO_INTERNET_MODE === true) {
 if (debug.forceTouch) {
   system.touch = true
 } else {
-  system.touch = Modernizr.touch
+  system.touch = Modernizr.touch || false
 }
 
 // Get system prefixes for page visibility API, page hidden and visibility state
@@ -87,3 +89,8 @@ if ((navigator.userAgent.indexOf('Safari') !== -1) &&
   (navigator.userAgent.indexOf('Chrome') === -1)) {
   system.safari = true
 }
+
+store.dispatch({
+  type: SET_SYSTEM_FLAGS,
+  ...system
+})

--- a/assets/scripts/preinit/system_capabilities.js
+++ b/assets/scripts/preinit/system_capabilities.js
@@ -23,7 +23,10 @@ export const system = {
   hiDpi: 1.0,
   cssTransform: false,
   ipAddress: null,
-  apiUrl: null
+  pageVisibility: false,
+  hiddenProperty: false,
+  visibilityState: false,
+  visibilityChange: false
 }
 
 // NOTE:

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -32,6 +32,9 @@
  * > have to write them!
  */
 
+/* app */
+export const SET_APP_FLAGS = 'SET_APP_FLAGS'
+
 /* debug */
 export const SET_DEBUG_FLAGS = 'SET_DEBUG_FLAGS'
 

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -32,5 +32,8 @@
  * > have to write them!
  */
 
+/* debug */
+export const SET_DEBUG_FLAGS = 'SET_DEBUG_FLAGS'
+
 /* system */
 export const SET_SYSTEM_FLAGS = 'SET_SYSTEM_FLAGS'

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -1,0 +1,36 @@
+/**
+ * Redux store actions.
+ *
+ * A "best practice" for large applications is to store actions as string
+ * constants. The following text is copied from Redux documentation:
+ * http://redux.js.org/docs/recipes/ReducingBoilerplate.html#actions
+ *
+ *  > Why is this beneficial? It is often claimed that constants are unnecessary,
+ *  > and for small projects, this might be correct. For larger projects, there
+ *  > are some benefits to defining action types as constants:
+ *
+ *  >   - It helps keep the naming consistent because all action types are
+ *  >     gathered in a single place.
+ *  >   - Sometimes you want to see all existing actions before working on a
+ *  >     new feature. It may be that the action you need was already added by
+ *  >     somebody on the team, but you didn't know.
+ *  >   - The list of action types that were added, removed, and changed in a
+ *  >     Pull Request helps everyone on the team keep track of scope and
+ *  >     implementation of new features.
+ *  >   - If you make a typo when importing an action constant, you will get
+ *  >     `undefined`. Redux will immediately throw when dispatching such an
+ *  >     action, and you'll find the mistake sooner.
+ *
+ * Following that suggestion, we will collect and export all actions as string
+ * constants from this module.
+ *
+ * We are not currently exporting action creators (see that documentation to
+ * learn more about them). This may change in the future as the need arises,
+ * but for now all scripts can dispatch to the store directly.
+ *
+ * > Action creators have often been criticized as boilerplate. Well, you don't
+ * > have to write them!
+ */
+
+/* system */
+export const SET_SYSTEM_FLAGS = 'SET_SYSTEM_FLAGS'

--- a/assets/scripts/store/index.js
+++ b/assets/scripts/store/index.js
@@ -1,0 +1,15 @@
+// Initiate Redux store
+import { createStore } from 'redux'
+
+// This is where other Redux-related libs are added, e.g.
+// react-router-redux if we use it in the future.
+
+// Import the root reducer
+import reducers from './reducers'
+
+// For Redux devtools extension.
+// https://github.com/zalmoxisus/redux-devtools-extension
+const devtools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+const store = createStore(reducers, devtools)
+
+export default store

--- a/assets/scripts/store/reducers/app.js
+++ b/assets/scripts/store/reducers/app.js
@@ -1,0 +1,18 @@
+import { SET_APP_FLAGS } from '../actions'
+
+const initialState = {
+  readOnly: false
+}
+
+const app = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_APP_FLAGS:
+      const obj = Object.assign({}, state, action)
+      delete obj.type // Do not save action type.
+      return obj
+    default:
+      return state
+  }
+}
+
+export default app

--- a/assets/scripts/store/reducers/debug.js
+++ b/assets/scripts/store/reducers/debug.js
@@ -1,0 +1,29 @@
+import { SET_DEBUG_FLAGS } from '../actions'
+
+const initialState = {
+  hoverPolygon: false,
+  canvasRectangles: false,
+  forceLeftHandTraffic: false,
+  forceMetric: false,
+  forceUnsupportedBrowser: false,
+  forceNonRetina: false,
+  forceNoInternet: false,
+  forceReadOnly: false,
+  forceTouch: false,
+  forceLiveUpdate: false,
+  secretSegments: false,
+  experimental: false
+}
+
+const debug = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_DEBUG_FLAGS:
+      const obj = Object.assign({}, state, action)
+      delete obj.type // Do not save action type.
+      return obj
+    default:
+      return state
+  }
+}
+
+export default debug

--- a/assets/scripts/store/reducers/index.js
+++ b/assets/scripts/store/reducers/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux'
+import app from './app'
 import debug from './debug'
 import system from './system'
 
 const reducers = combineReducers({
+  app,
   debug,
   system
 })

--- a/assets/scripts/store/reducers/index.js
+++ b/assets/scripts/store/reducers/index.js
@@ -1,7 +1,9 @@
 import { combineReducers } from 'redux'
+import debug from './debug'
 import system from './system'
 
 const reducers = combineReducers({
+  debug,
   system
 })
 

--- a/assets/scripts/store/reducers/index.js
+++ b/assets/scripts/store/reducers/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux'
+import system from './system'
+
+const reducers = combineReducers({
+  system
+})
+
+export default reducers

--- a/assets/scripts/store/reducers/system.js
+++ b/assets/scripts/store/reducers/system.js
@@ -20,12 +20,8 @@ const initialState = {
 const system = (state = initialState, action) => {
   switch (action.type) {
     case SET_SYSTEM_FLAGS:
-      // This action allows setting arbitrary properties directly to the state
-      // object. The only property we don't want to copy is `type`, which is
-      // only used here to specify the action type. Make sure we combine incoming
-      // properties with existing properties.
       const obj = Object.assign({}, state, action)
-      delete obj.type
+      delete obj.type // Do not save action type.
       return obj
     default:
       return state

--- a/assets/scripts/store/reducers/system.js
+++ b/assets/scripts/store/reducers/system.js
@@ -1,0 +1,32 @@
+import { SET_SYSTEM_FLAGS } from '../actions'
+
+const initialState = {
+  touch: false,
+  phone: false,
+  safari: false,
+  windows: false,
+  noInternet: false,
+  viewportWidth: null,
+  viewportHeight: null,
+  hiDpi: 1.0,
+  cssTransform: false,
+  ipAddress: null,
+  apiUrl: null
+}
+
+const system = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_SYSTEM_FLAGS:
+      // This action allows setting arbitrary properties directly to the state
+      // object. The only property we don't want to copy is `type`, which is
+      // only used here to specify the action type. Make sure we combine incoming
+      // properties with existing properties.
+      const obj = Object.assign({}, state, action)
+      delete obj.type
+      return obj
+    default:
+      return state
+  }
+}
+
+export default system

--- a/assets/scripts/store/reducers/system.js
+++ b/assets/scripts/store/reducers/system.js
@@ -11,7 +11,10 @@ const initialState = {
   hiDpi: 1.0,
   cssTransform: false,
   ipAddress: null,
-  apiUrl: null
+  pageVisibility: false,
+  hiddenProperty: false,
+  visibilityState: false,
+  visibilityChange: false
 }
 
 const system = (state = initialState, action) => {

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -74,7 +74,7 @@ export default class StreetName extends React.Component {
   }
 
   clickStreetName () {
-    if (!this.props.allowEditing) {
+    if (!this.props.editable) {
       return
     }
 
@@ -105,7 +105,7 @@ export default class StreetName extends React.Component {
 
 StreetName.propTypes = {
   id: React.PropTypes.string,
-  allowEditing: React.PropTypes.bool,
+  editable: React.PropTypes.bool,
   street: React.PropTypes.any,
   handleResize: React.PropTypes.func
 }

--- a/assets/scripts/streets/StreetNameCanvas.jsx
+++ b/assets/scripts/streets/StreetNameCanvas.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import StreetName from './StreetName'
 import StreetMetaData from './StreetMetaData'
 import { getStreet } from './data_model'
 
-export default class StreetNameCanvas extends React.Component {
+class StreetNameCanvas extends React.Component {
   constructor (props) {
     super(props)
 
@@ -66,11 +67,9 @@ export default class StreetNameCanvas extends React.Component {
       <div id='street-name-canvas' className={this.determineClassNames().join(' ')}>
         <StreetName
           id='street-name'
-          ref={(ref) => {
-            this.streetName = ref
-          }}
+          ref={(ref) => { this.streetName = ref }}
           street={this.state.street}
-          allowEditing={this.props.allowEditing}
+          editable={this.props.editable}
           handleResize={this.onResizeStreetName}
         />
         <StreetMetaData id='street-metadata' street={this.state.street} />
@@ -80,5 +79,17 @@ export default class StreetNameCanvas extends React.Component {
 }
 
 StreetNameCanvas.propTypes = {
-  allowEditing: React.PropTypes.bool
+  editable: React.PropTypes.bool
 }
+
+StreetNameCanvas.defaultProps = {
+  editable: true
+}
+
+function mapStateToProps (state) {
+  return {
+    editable: !state.app.readOnly
+  }
+}
+
+export default connect(mapStateToProps)(StreetNameCanvas)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "async": "2.1.5",
     "autoprefixer": "6.7.6",
+    "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-polyfill": "6.23.0",
     "babel-preset-es2015": "6.22.0",
     "babel-preset-react": "6.23.0",
@@ -65,6 +66,8 @@
     "raven-js": "3.12.0",
     "react": "15.4.2",
     "react-dom": "15.4.2",
+    "react-redux": "5.0.3",
+    "redux": "3.6.0",
     "request": "2.79.0",
     "requireindex": "1.1.0",
     "sendgrid": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
@@ -646,6 +650,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
@@ -1380,15 +1391,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.6, concat-stream@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
-  dependencies:
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
-concat-stream@~1.5.0, concat-stream@~1.5.1:
+concat-stream@^1.4.6, concat-stream@^1.5.0, concat-stream@~1.5.0, concat-stream@~1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
   dependencies:
@@ -3046,6 +3049,10 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
+hoist-non-react-statics@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3173,7 +3180,7 @@ inherits@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-1.0.2.tgz#ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -3226,7 +3233,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@^2.2.0:
+invariant@^2.0.0, invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3665,6 +3672,10 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+lodash-es@^4.2.0, lodash-es@^4.2.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -3776,7 +3787,7 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4705,17 +4716,17 @@ qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
-qs@6.2.1, qs@^6.1.0:
+qs@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
+
+qs@^6.1.0, qs@~6.3.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.1.tgz#918c0b3bcd36679772baf135b1acb4c1651ed79d"
 
 qs@~0.5.2:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/qs/-/qs-0.5.6.tgz#31b1ad058567651c526921506b9a8793911a0384"
-
-qs@~6.3.0:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.1.tgz#918c0b3bcd36679772baf135b1acb4c1651ed79d"
 
 querystring-es3@~0.2.0:
   version "0.2.1"
@@ -4791,6 +4802,16 @@ react-dom@15.4.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
 
+react-redux@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.3.tgz#86c3b68d56e74294a42e2a740ab66117ef6c019f"
+  dependencies:
+    hoist-non-react-statics "^1.0.3"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    lodash-es "^4.2.0"
+    loose-envify "^1.1.0"
+
 react@15.4.2:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
@@ -4850,7 +4871,7 @@ readable-stream@^1.1.13, readable-stream@~1.1.8, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.0, readable-stream@^2.1.5:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
   dependencies:
@@ -4902,6 +4923,15 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redux@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.2"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -5075,11 +5105,11 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@~2.2.6, rimraf@~2.2.8:
+rimraf@2, rimraf@~2.2.6, rimraf@~2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
 
-rimraf@^2.5.2:
+rimraf@^2.2.8, rimraf@^2.5.2:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -5608,6 +5638,10 @@ supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+symbol-observable@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
 syntax-error@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.3.0.tgz#1ed9266c4d40be75dc55bf9bb1cb77062bb96ca1"
@@ -5845,7 +5879,7 @@ type-is@~1.6.14, type-is@~1.6.6:
     media-typer "0.3.0"
     mime-types "~2.1.13"
 
-typedarray@^0.0.6, typedarray@~0.0.5:
+typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 


### PR DESCRIPTION
Here is a first stab at putting some "system" variables into Redux, as a way of migrating to a standard application state framework as opposed to exporting variables owned by arbitrary modules and passing them around to other modules. This first implementation of the Redux state tree contains the `system`, `debug`, and `app` variables which are set when Streetmix loads.

The original variables are not removed; they are still exported because all the code that depends on them have not been updated to take advantage of the Redux state tree. (After some initial experimentation and false starts, this is not as easy as it looks and so parts of the application will need to be upgraded to use Redux bit by bit. One example that's really obvious in this PR is that the only property in `app` depends on properties in `system` and `debug` and I'm not yet certain how to update one branch of a Redux state tree in response to changes in another branch.)

This also allows us to reconnect the `StreetNameCanvas` component to Redux so that its `editable` prop (formerly `allowEditing`) is dependent on application state instead of a strange-looking prop from its parent component, `App`. Ideally, this is how we want to move forward with React components, e.g. current street data is in Redux, so components that rely on `getStreet()` for state can be connected to the Redux state, instead.

This will be the next step, if this first step toward Redux implementation looks good.