### PR TITLE
Port user settings to the Redux store

### DIFF
--- a/assets/scripts/app/DebugInfo.jsx
+++ b/assets/scripts/app/DebugInfo.jsx
@@ -7,14 +7,14 @@
  * @requires keypress
  */
 import React from 'react'
+import { connect } from 'react-redux'
 import { cloneDeep } from 'lodash'
 import { getStreet } from '../streets/data_model'
 import { getUndoStack } from '../streets/undo_stack'
-import { getSettings } from '../users/settings'
 import { registerKeypress, deregisterKeypress } from './keypress'
 import { loseAnyFocus } from './focus'
 
-export default class DebugInfo extends React.Component {
+class DebugInfo extends React.Component {
   constructor (props) {
     super(props)
 
@@ -25,6 +25,7 @@ export default class DebugInfo extends React.Component {
 
     this.showDebugInfo = this.showDebugInfo.bind(this)
     this.hideDebugInfo = this.hideDebugInfo.bind(this)
+    this.getTextareaContent = this.getTextareaContent.bind(this)
   }
 
   componentDidMount () {
@@ -35,7 +36,6 @@ export default class DebugInfo extends React.Component {
   getTextareaContent () {
     const debugStreetData = cloneDeep(getStreet())
     const debugUndo = cloneDeep(getUndoStack())
-    const debugSettings = cloneDeep(getSettings())
 
     // Some things just shouldn't be seen...
     for (let i in debugStreetData.segments) {
@@ -51,7 +51,7 @@ export default class DebugInfo extends React.Component {
     // Create a JSON object, this parses better in editors
     const debugObj = {
       'DATA': debugStreetData,
-      'SETTINGS': debugSettings,
+      'SETTINGS': this.props.settings,
       'UNDO': debugUndo
     }
 
@@ -103,3 +103,15 @@ export default class DebugInfo extends React.Component {
     )
   }
 }
+
+DebugInfo.propTypes = {
+  settings: React.PropTypes.object.isRequired
+}
+
+function mapStateToProps (state) {
+  return {
+    settings: state.user
+  }
+}
+
+export default connect(mapStateToProps)(DebugInfo)

--- a/assets/scripts/app/WelcomePanel.jsx
+++ b/assets/scripts/app/WelcomePanel.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
@@ -12,7 +13,6 @@ import {
 import { getStreet } from '../streets/data_model'
 import StreetName from '../streets/StreetName'
 import { isSignedIn } from '../users/authentication'
-import { getSettings } from '../users/settings'
 import { registerKeypress, deregisterKeypress } from './keypress'
 import { MODES, getMode } from './mode'
 import { goNewStreet } from './routing'
@@ -25,7 +25,7 @@ const WELCOME_FIRST_TIME_EXISTING_STREET = 3
 
 const LOCAL_STORAGE_SETTINGS_WELCOME_DISMISSED = 'settings-welcome-dismissed'
 
-export default class WelcomePanel extends React.Component {
+class WelcomePanel extends React.Component {
   constructor (props) {
     super(props)
 
@@ -85,11 +85,9 @@ export default class WelcomePanel extends React.Component {
 
     // If welcomeType is WELCOME_NEW_STREET, there is an additional state
     // property that determines which of the new street modes is selected
-    const settings = getSettings()
-
     let selectedNewStreetType
 
-    switch (settings.newStreetPreference) {
+    switch (this.props.newStreetPreference) {
       case NEW_STREET_EMPTY:
         selectedNewStreetType = 'new-street-empty'
         break
@@ -256,8 +254,7 @@ export default class WelcomePanel extends React.Component {
               {(() => {
                 // Display this button only if there is a previous street to copy
                 // from that is not the same as the current street
-                const settings = getSettings()
-                if (settings.priorLastStreetId && settings.priorLastStreetId !== getStreet().id) {
+                if (this.props.priorLastStreetId && this.props.priorLastStreetId !== getStreet().id) {
                   return (
                     <li>
                       <input
@@ -309,3 +306,21 @@ export default class WelcomePanel extends React.Component {
     )
   }
 }
+
+WelcomePanel.propTypes = {
+  newStreetPreference: React.PropTypes.number,
+  priorLastStreetId: React.PropTypes.string
+}
+
+WelcomePanel.defaultProps = {
+  priorLastStreetId: null
+}
+
+function mapStateToProps (state) {
+  return {
+    newStreetPreference: state.user.newStreetPreference,
+    priorLastStreetId: state.user.priorLastStreetId
+  }
+}
+
+export default connect(mapStateToProps)(WelcomePanel)

--- a/assets/scripts/app/event_listeners.js
+++ b/assets/scripts/app/event_listeners.js
@@ -9,7 +9,7 @@ import {
   onBodyMouseMove,
   onBodyMouseUp
 } from '../segments/drag_and_drop'
-import { onStorageChange } from '../users/settings'
+import { onStorageChange } from '../users/authentication'
 import { onGlobalKeyDown } from './keyboard_commands'
 import { onResize } from './window_resize'
 

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -48,9 +48,9 @@ class SaveAsImageDialog extends React.Component {
     this.updatePreview()
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  componentWillReceiveProps (nextProps) {
     // When props change, update image.
-    if (!isEqual(prevProps, this.props)) {
+    if (isEqual(nextProps, this.props) === false) {
       this.setState({ isLoading: true })
 
       // Update preview when props change; make a slight delay because there is

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -11,7 +11,7 @@ import Dialog from './Dialog'
 import { trackEvent } from '../app/event_tracking'
 import { getStreet } from '../streets/data_model'
 import { getStreetImage } from '../streets/image'
-import { saveSettingsLocally, getSettings } from '../users/settings'
+import { getSettings, setSettings } from '../users/settings'
 import { normalizeSlug } from '../util/helpers'
 import { t } from '../app/locale'
 
@@ -91,16 +91,17 @@ export default class SaveAsImageDialog extends React.Component {
   }
 
   updateOptions () {
-    const settings = getSettings()
-    settings.saveAsImageTransparentSky = this.state.optionTransparentSky
-    settings.saveAsImageSegmentNamesAndWidths = this.state.optionSegmentNames
-    settings.saveAsImageStreetName = this.state.optionStreetName
-
-    saveSettingsLocally()
-
     this.setState({ isLoading: true })
 
-    window.setTimeout(this.updatePreview, 50)
+    // setState is async, we need to refresh with current options after it's set
+    window.setTimeout(() => {
+      setSettings({
+        saveAsImageTransparentSky: this.state.optionTransparentSky,
+        saveAsImageSegmentNamesAndWidths: this.state.optionSegmentNames,
+        saveAsImageStreetName: this.state.optionStreetName
+      })
+      this.updatePreview()
+    }, 50)
   }
 
   updatePreview () {

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -53,7 +53,7 @@ ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>, document.getElementById('react-app'))
-ReactDOM.render(<DebugInfo />, document.getElementById('debug'))
+ReactDOM.render(<DebugInfo store={store} />, document.getElementById('debug'))
 
 // Start listening for keypresses
 startListening()

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -44,3 +44,6 @@ export const CLEAR_DIALOGS = 'CLEAR_DIALOGS'
 
 /* system */
 export const SET_SYSTEM_FLAGS = 'SET_SYSTEM_FLAGS'
+
+/* user */
+export const SET_USER_SETTINGS = 'SET_USER_SETTINGS'

--- a/assets/scripts/store/reducers/index.js
+++ b/assets/scripts/store/reducers/index.js
@@ -3,12 +3,14 @@ import app from './app'
 import debug from './debug'
 import dialogs from './dialogs'
 import system from './system'
+import user from './user'
 
 const reducers = combineReducers({
   app,
   debug,
   dialogs,
-  system
+  system,
+  user
 })
 
 export default reducers

--- a/assets/scripts/store/reducers/user.js
+++ b/assets/scripts/store/reducers/user.js
@@ -1,0 +1,27 @@
+import { SET_USER_SETTINGS } from '../actions'
+// import { NEW_STREET_DEFAULT } from '../../streets/creation'
+
+const initialState = {
+  lastStreetId: null,
+  lastStreetNamespacedId: null,
+  lastStreetCreatorId: null,
+  priorLastStreetId: null, // Do not save
+  newStreetPreference: 1,
+
+  saveAsImageTransparentSky: false,
+  saveAsImageSegmentNamesAndWidths: false,
+  saveAsImageStreetName: false
+}
+
+const user = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_USER_SETTINGS:
+      const obj = Object.assign({}, state, action)
+      delete obj.type // Do not save action type.
+      return obj
+    default:
+      return state
+  }
+}
+
+export default user

--- a/assets/scripts/store/reducers/user.js
+++ b/assets/scripts/store/reducers/user.js
@@ -1,12 +1,13 @@
 import { SET_USER_SETTINGS } from '../actions'
+// Note: turning this constant on runs too much side-effect code too early.
 // import { NEW_STREET_DEFAULT } from '../../streets/creation'
 
 const initialState = {
   lastStreetId: null,
   lastStreetNamespacedId: null,
   lastStreetCreatorId: null,
-  priorLastStreetId: null, // Do not save
-  newStreetPreference: 1,
+  priorLastStreetId: null, // NOTE: Do not save to localstorage or server side, only used for current client session
+  newStreetPreference: 1, // TODO: use NEW_STREET_DEFAULT constant
 
   saveAsImageTransparentSky: false,
   saveAsImageSegmentNamesAndWidths: false,

--- a/assets/scripts/streets/creation.js
+++ b/assets/scripts/streets/creation.js
@@ -1,5 +1,5 @@
 import { segmentsChanged } from '../segments/view'
-import { saveSettingsLocally, getSettings } from '../users/settings'
+import { getSettings, setSettings } from '../users/settings'
 import {
   setLastStreet,
   getStreet,
@@ -34,15 +34,19 @@ export function makeDefaultStreet () {
 }
 
 export function onNewStreetDefaultClick () {
-  getSettings().newStreetPreference = NEW_STREET_DEFAULT
-  saveSettingsLocally()
+  const settings = getSettings()
+  setSettings({
+    newStreetPreference: NEW_STREET_DEFAULT
+  })
 
   makeDefaultStreet()
 }
 
 export function onNewStreetEmptyClick () {
-  getSettings().newStreetPreference = NEW_STREET_EMPTY
-  saveSettingsLocally()
+  const settings = getSettings()
+  setSettings({
+    newStreetPreference: NEW_STREET_EMPTY
+  })
 
   setIgnoreStreetChanges(true)
   prepareEmptyStreet()

--- a/assets/scripts/streets/creation.js
+++ b/assets/scripts/streets/creation.js
@@ -1,5 +1,5 @@
 import { segmentsChanged } from '../segments/view'
-import { getSettings, setSettings } from '../users/settings'
+import { setSettings } from '../users/settings'
 import {
   setLastStreet,
   getStreet,
@@ -34,7 +34,6 @@ export function makeDefaultStreet () {
 }
 
 export function onNewStreetDefaultClick () {
-  const settings = getSettings()
   setSettings({
     newStreetPreference: NEW_STREET_DEFAULT
   })
@@ -43,7 +42,6 @@ export function onNewStreetDefaultClick () {
 }
 
 export function onNewStreetEmptyClick () {
-  const settings = getSettings()
   setSettings({
     newStreetPreference: NEW_STREET_EMPTY
   })

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -402,7 +402,6 @@ export function setStreetId (newId, newNamespacedId) {
 
 export function updateLastStreetInfo () {
   const street = getStreet()
-  const settings = getSettings()
   setSettings({
     lastStreetId: street.id,
     lastStreetNamespacedId: street.namespacedId,

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -22,10 +22,10 @@ import {
 } from '../users/authentication'
 import { propagateUnits } from '../users/localization'
 import {
-  saveSettingsLocally,
   confirmSaveStreetToServerInitial,
   saveSettingsToServer,
-  getSettings
+  getSettings,
+  setSettings
 } from '../users/settings'
 import {
   isblockingAjaxRequestInProgress,
@@ -401,13 +401,13 @@ export function setStreetId (newId, newNamespacedId) {
 }
 
 export function updateLastStreetInfo () {
-  var street = getStreet()
-  let settings = getSettings()
-  settings.lastStreetId = street.id
-  settings.lastStreetNamespacedId = street.namespacedId
-  settings.lastStreetCreatorId = street.creatorId
-
-  saveSettingsLocally()
+  const street = getStreet()
+  const settings = getSettings()
+  setSettings({
+    lastStreetId: street.id,
+    lastStreetNamespacedId: street.namespacedId,
+    lastStreetCreatorId: street.creatorId
+  })
 }
 
 export function scheduleSavingStreetToServer () {
@@ -476,13 +476,14 @@ function receiveLastStreet (transmission) {
 
 export function sendDeleteStreetToServer (id) {
   // Prevents new street submenu from showing the last street
-  let settings = getSettings()
+  const settings = getSettings()
   if (settings.lastStreetId === id) {
-    settings.lastStreetId = null
-    settings.lastStreetCreatorId = null
-    settings.lastStreetNamespacedId = null
+    setSettings({
+      lastStreetId: null,
+      lastStreetCreatorId: null,
+      lastStreetNamespacedId: null
+    })
 
-    saveSettingsLocally()
     saveSettingsToServer()
   }
 

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -12,7 +12,6 @@ import { receiveUserDetails } from './profile_image_cache'
 import { checkIfSignInAndGeolocationLoaded } from './localization'
 import {
   loadSettings,
-  saveSettingsLocally,
   LOCAL_STORAGE_SIGN_IN_ID,
   getSettings
 } from './settings'
@@ -166,11 +165,12 @@ export function onSignOutClick (event) {
 }
 
 function signOut (quiet) {
-  let settings = getSettings()
-  settings.lastStreetId = null
-  settings.lastStreetNamespacedId = null
-  settings.lastStreetCreatorId = null
-  saveSettingsLocally()
+  const settings = getSettings()
+  setSettings({
+    lastStreetId: null,
+    lastStreetNamespacedId: null,
+    lastStreetCreatorId: null
+  })
 
   removeSignInCookies()
   window.localStorage.removeItem(LOCAL_STORAGE_SIGN_IN_ID)

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -10,14 +10,11 @@ import { setPromoteStreet } from '../streets/remix'
 import { fetchStreetFromServer } from '../streets/xhr'
 import { receiveUserDetails } from './profile_image_cache'
 import { checkIfSignInAndGeolocationLoaded } from './localization'
-import {
-  loadSettings,
-  LOCAL_STORAGE_SIGN_IN_ID,
-  getSettings
-} from './settings'
+import { loadSettings, getSettings, setSettings } from './settings'
 
 const USER_ID_COOKIE = 'user_id'
 const SIGN_IN_TOKEN_COOKIE = 'login_token'
+const LOCAL_STORAGE_SIGN_IN_ID = 'sign-in'
 
 let signInData = null
 
@@ -43,6 +40,16 @@ export function goReloadClearSignIn () {
   removeSignInCookies()
 
   window.location.reload()
+}
+
+export function onStorageChange () {
+  if (isSignedIn() && !window.localStorage[LOCAL_STORAGE_SIGN_IN_ID]) {
+    setMode(MODES.FORCE_RELOAD_SIGN_OUT)
+    processMode()
+  } else if (!isSignedIn() && window.localStorage[LOCAL_STORAGE_SIGN_IN_ID]) {
+    setMode(MODES.FORCE_RELOAD_SIGN_IN)
+    processMode()
+  }
 }
 
 function saveSignInDataLocally () {

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -172,7 +172,6 @@ export function onSignOutClick (event) {
 }
 
 function signOut (quiet) {
-  const settings = getSettings()
   setSettings({
     lastStreetId: null,
     lastStreetNamespacedId: null,


### PR DESCRIPTION
Making a little more progress - porting another state variable to Redux!

In this PR, `getSettings()` just reads from Redux store. Previously settings could be updated by writing directly to the `settings` object properties, but this isn't possible with Redux. As a result its counterpart  `setSettings()` now exists, and it's fundamentally a bound action creator, although it still lives in `user/settings.js` and not in `store/actions/`. I do like that it prevents having to export `store` and action types to other modules.

React components that depended on `getSettings()` now reads the store via props. This allows the `SaveAsImageDialogBox` to not need to remember image options in its own state (and the app store is the canonical source of truth).