### PR TITLE
Store active menu state in Redux

### DIFF
--- a/assets/scripts/menus/MenusContainer.jsx
+++ b/assets/scripts/menus/MenusContainer.jsx
@@ -7,6 +7,7 @@ import IdentityMenu from './IdentityMenu'
 import SettingsMenu from './SettingsMenu'
 import ShareMenu from './ShareMenu'
 import { registerKeypress } from '../app/keypress'
+import { showMenu, clearMenus } from '../store/actions/menus'
 
 class MenusContainer extends React.Component {
   constructor (props) {
@@ -17,6 +18,7 @@ class MenusContainer extends React.Component {
     }
 
     this.onMenuDropdownClick = this.onMenuDropdownClick.bind(this)
+    this.handleMenuClear = this.handleMenuClear.bind(this)
     this.hideAllMenus = this.hideAllMenus.bind(this)
   }
 
@@ -30,11 +32,16 @@ class MenusContainer extends React.Component {
 
     // Set up keypress listener to hide menus if visible
     registerKeypress('esc', this.hideAllMenus)
+  }
 
-    // Set up a generic event listener to hide menus if visible.
-    // This is triggered by the exported function `hideAllMenus` from
-    // menu_controller.js, which contain legacy functions from pre-React
-    window.addEventListener('stmx:hide_menus', this.hideAllMenus)
+  componentWillReceiveProps (nextProps) {
+    // If menus are being cleared, handle this. Since active menu is a prop, it
+    // can be cleared from anywhere, so this handles changes in active menu state.
+    // Only call `handleMenuClear` if props have changed from an active menu
+    // state to a no-menu state, this prevents side effects from running needlessly.
+    if (this.props.activeMenu && !nextProps.activeMenu) {
+      this.handleMenuClear()
+    }
   }
 
   /**
@@ -49,23 +56,29 @@ class MenusContainer extends React.Component {
     this.setState({
       activeMenuPos: activeMenu ? clickedItem.position : [0, 0]
     })
-    this.props.dispatch({ type: 'SHOW_MENU', name: activeMenu })
+    this.props.dispatch(showMenu(activeMenu))
+  }
+
+  /**
+   * Handles component state and DOM changes when menus are cleared. Called from
+   * `componentWillReceiveProps()` which will check if props have actually changed.
+   */
+  handleMenuClear () {
+    this.setState({
+      activeMenuPos: [0, 0]
+    })
+
+    // Force document.body to become the active element.
+    // NOTE: prop change check is performed in `componentWillReceiveProps()`
+    // because we do not want to re-focus needlessly on document.body if there
+    // were no menus to hide.
+    document.body.focus()
   }
 
   hideAllMenus () {
     // Only act if there is currently an active menu.
     if (this.props.activeMenu) {
-      this.setState({
-        activeMenuPos: [0, 0]
-      })
-
-      this.props.dispatch({ type: 'CLEAR_MENUS' })
-
-      // Force document.body to become the active element. Do not re-focus on
-      // document.body if there were no menus to hide. This is sometimes
-      // triggered by actions that do not check if a menu has closed, so we don't
-      // want it to refocus needlessly.
-      document.body.focus()
+      this.props.dispatch(clearMenus())
     }
   }
 

--- a/assets/scripts/menus/MenusContainer.jsx
+++ b/assets/scripts/menus/MenusContainer.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import MenuBar from './MenuBar'
 import HelpMenu from './HelpMenu'
 import ContactMenu from './ContactMenu'
@@ -7,12 +8,11 @@ import SettingsMenu from './SettingsMenu'
 import ShareMenu from './ShareMenu'
 import { registerKeypress } from '../app/keypress'
 
-export default class MenusContainer extends React.Component {
+class MenusContainer extends React.Component {
   constructor (props) {
     super(props)
 
     this.state = {
-      activeMenu: null,
       activeMenuPos: [0, 0]
     }
 
@@ -45,20 +45,21 @@ export default class MenusContainer extends React.Component {
    */
   onMenuDropdownClick (clickedItem) {
     // If the clicked menu is already active, it's toggled off.
-    const activeMenu = this.state.activeMenu === clickedItem.name ? null : clickedItem.name
+    const activeMenu = (this.props.activeMenu === clickedItem.name) ? null : clickedItem.name
     this.setState({
-      activeMenu: activeMenu,
       activeMenuPos: activeMenu ? clickedItem.position : [0, 0]
     })
+    this.props.dispatch({ type: 'SHOW_MENU', name: activeMenu })
   }
 
   hideAllMenus () {
     // Only act if there is currently an active menu.
-    if (this.state.activeMenu) {
+    if (this.props.activeMenu) {
       this.setState({
-        activeMenu: null,
         activeMenuPos: [0, 0]
       })
+
+      this.props.dispatch({ type: 'CLEAR_MENUS' })
 
       // Force document.body to become the active element. Do not re-focus on
       // document.body if there were no menus to hide. This is sometimes
@@ -69,7 +70,8 @@ export default class MenusContainer extends React.Component {
   }
 
   render () {
-    const { activeMenu, activeMenuPos } = this.state
+    const { activeMenu } = this.props
+    const { activeMenuPos } = this.state
 
     return (
       <div>
@@ -83,3 +85,20 @@ export default class MenusContainer extends React.Component {
     )
   }
 }
+
+MenusContainer.propTypes = {
+  dispatch: React.PropTypes.func.isRequired,
+  activeMenu: React.PropTypes.string
+}
+
+MenusContainer.defaultProps = {
+  activeMenu: ''
+}
+
+function mapStateToProps (state) {
+  return {
+    activeMenu: state.menus.activeMenu
+  }
+}
+
+export default connect(mapStateToProps)(MenusContainer)

--- a/assets/scripts/menus/menu_controller.js
+++ b/assets/scripts/menus/menu_controller.js
@@ -1,18 +1,18 @@
+import store from '../store'
+import { clearMenus } from '../store/actions/menus'
+
 /**
  * Determine if any of the menus are currently visible.
  * Returns a boolean value.
  */
 export function isAnyMenuVisible () {
-  const els = document.querySelectorAll('.menu.visible')
-  return !(els.length === 0)
+  const activeMenu = store.getState().menus.activeMenu
+  return Boolean(activeMenu)
 }
 
 /**
- * Hides all menus.
- * Menu state is controlled via the React component MenusContainer, so for
- * functions outside of React, this function sends an event that the component
- * listens for.
+ * Hides all menus by dispatching a CLEAR_MENUS action to Redux store.
  */
 export function hideAllMenus () {
-  window.dispatchEvent(new CustomEvent('stmx:hide_menus'))
+  store.dispatch(clearMenus())
 }

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -42,6 +42,10 @@ export const SET_DEBUG_FLAGS = 'SET_DEBUG_FLAGS'
 export const SHOW_DIALOG = 'SHOW_DIALOG'
 export const CLEAR_DIALOGS = 'CLEAR_DIALOGS'
 
+/* menus */
+export const SHOW_MENU = 'SHOW_MENU'
+export const CLEAR_MENUS = 'CLEAR_MENUS'
+
 /* settings */
 export const SET_USER_SETTINGS = 'SET_USER_SETTINGS'
 

--- a/assets/scripts/store/actions/menus.js
+++ b/assets/scripts/store/actions/menus.js
@@ -1,0 +1,14 @@
+import { SHOW_MENU, CLEAR_MENUS } from './index'
+
+export function showMenu (name) {
+  return {
+    type: SHOW_MENU,
+    name
+  }
+}
+
+export function clearMenus () {
+  return {
+    type: CLEAR_MENUS
+  }
+}

--- a/assets/scripts/store/reducers/index.js
+++ b/assets/scripts/store/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux'
 import app from './app'
 import debug from './debug'
 import dialogs from './dialogs'
+import menus from './menus'
 import system from './system'
 import settings from './settings'
 import user from './user'
@@ -10,6 +11,7 @@ const reducers = combineReducers({
   app,
   debug,
   dialogs,
+  menus,
   settings,
   system,
   user

--- a/assets/scripts/store/reducers/menus.js
+++ b/assets/scripts/store/reducers/menus.js
@@ -1,0 +1,20 @@
+import { SHOW_MENU, CLEAR_MENUS } from '../actions'
+
+const initialState = {
+  activeMenu: null
+}
+
+const menus = (state = initialState, action) => {
+  switch (action.type) {
+    case SHOW_MENU:
+      return {
+        activeMenu: action.name
+      }
+    case CLEAR_MENUS:
+      return initialState
+    default:
+      return state
+  }
+}
+
+export default menus


### PR DESCRIPTION
This stores active menu id in Redux instead of in the `MenusContainer` component state. This is done to address the behavior of two functions `isAnyMenuVisible()` and `hideAllMenus()`, both exported from `menus_controller.js`.

Sometimes, other parts of Streetmix needs to know if a menu is open, and it does so by querying class names from the DOM. This is not ideal because it tightly couples the styling to logic. Preferably, we query application state to know if a menu is open. As a result, we need to move active menu state from the `MenusContainer` component and in to Redux. `MenusContainer` will receive the active menu from props and render the correct active menu.

Because we can hide all menus by clearing the active menu ID from the Redux store, we also no longer need to fire the `stmx:hide_menus` event that `MenusContainer` was listening for. This was also a poor way of communicating state changes across components now that we have Redux. As a result `hideAllMenus()` dispatches a change to the Redux store directly and `MenusContainer` will handle the cleanup as props changes.
