### PR TITLE
Port Flash to React component

### DIFF
--- a/app/views/main.jade
+++ b/app/views/main.jade
@@ -3,9 +3,6 @@ extends _layout
 block main
   #flash
 
-  //- Mount point for React DebugInfo component
-  #debug
-
   include ./ui/blocking
   include ./ui/gallery
 

--- a/app/views/main.jade
+++ b/app/views/main.jade
@@ -1,8 +1,6 @@
 extends _layout
 
 block main
-  #flash
-
   include ./ui/blocking
   include ./ui/gallery
 

--- a/assets/css/_live-update.scss
+++ b/assets/css/_live-update.scss
@@ -1,4 +1,4 @@
-#flash {
+.flash {
   display: none;
   position: absolute;
   left: 0;

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -4,16 +4,21 @@ import StreetNameCanvas from '../streets/StreetNameCanvas'
 import WelcomePanel from './WelcomePanel'
 import Palette from './Palette'
 import DialogRoot from '../dialogs/DialogRoot'
+import DebugInfo from './DebugInfo'
 
 export default class App extends React.PureComponent {
   render () {
     return (
       <div>
-        <MenusContainer />
-        <StreetNameCanvas />
-        <WelcomePanel />
-        <Palette />
-        <DialogRoot />
+        <div className='main-screen'>
+          <MenusContainer />
+          <StreetNameCanvas />
+          <WelcomePanel />
+          <Palette />
+          <DialogRoot />
+        </div>
+
+        <DebugInfo />
       </div>
     )
   }

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -4,6 +4,7 @@ import StreetNameCanvas from '../streets/StreetNameCanvas'
 import WelcomePanel from './WelcomePanel'
 import Palette from './Palette'
 import DialogRoot from '../dialogs/DialogRoot'
+import Flash from './Flash'
 import DebugInfo from './DebugInfo'
 
 export default class App extends React.PureComponent {
@@ -18,6 +19,7 @@ export default class App extends React.PureComponent {
           <DialogRoot />
         </div>
 
+        <Flash />
         <DebugInfo />
       </div>
     )

--- a/assets/scripts/app/Flash.jsx
+++ b/assets/scripts/app/Flash.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+export default class Flash extends React.PureComponent {
+  componentDidMount () {
+    window.addEventListener('stmx:live_update', (event) => {
+      this.flash()
+    })
+  }
+
+  flash () {
+    this.el.classList.add('visible')
+
+    window.setTimeout(() => {
+      this.el.classList.add('fading-out')
+    }, 100)
+
+    window.setTimeout(() => {
+      this.el.classList.remove('visible')
+      this.el.classList.remove('fading-out')
+    }, 1000)
+  }
+
+  render () {
+    return <div className='flash' ref={(ref) => { this.el = ref }} />
+  }
+}

--- a/assets/scripts/app/live_update.js
+++ b/assets/scripts/app/live_update.js
@@ -3,8 +3,6 @@ import { getFetchStreetUrl, unpackServerStreetData } from '../streets/xhr'
 
 const LIVE_UPDATE_DELAY = 5000
 
-const flashEl = document.getElementById('flash')
-
 export function scheduleNextLiveUpdateCheck () {
   window.setTimeout(checkForLiveUpdate, LIVE_UPDATE_DELAY)
 }
@@ -39,18 +37,5 @@ function receiveLiveUpdateStreet (transmission) {
     updateEverything(true)
   }, 1000)
 
-  flash()
-}
-
-function flash () {
-  flashEl.classList.add('visible')
-
-  window.setTimeout(function () {
-    flashEl.classList.add('fading-out')
-  }, 100)
-
-  window.setTimeout(function () {
-    flashEl.classList.remove('visible')
-    flashEl.classList.remove('fading-out')
-  }, 1000)
+  window.dispatchEvent(new window.CustomEvent('stmx:live_update'))
 }

--- a/assets/scripts/app/live_update.js
+++ b/assets/scripts/app/live_update.js
@@ -34,7 +34,7 @@ function receiveLiveUpdateCheck (response) {
 function receiveLiveUpdateStreet (transmission) {
   window.setTimeout(function () {
     unpackServerStreetData(transmission, null, null, false)
-    updateEverything(true)
+    updateEverything(true, false) // When receiving a street, don't save again
   }, 1000)
 
   window.dispatchEvent(new window.CustomEvent('stmx:live_update'))

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -23,7 +23,6 @@ import { initialize } from './app/initialization'
 import { startListening } from './app/keypress'
 import { system } from './preinit/system_capabilities'
 import App from './app/App'
-import DebugInfo from './app/DebugInfo'
 
 // Error tracking
 // Load this before all other modules. Only load when run in production.
@@ -53,7 +52,6 @@ ReactDOM.render(
   <Provider store={store}>
     <App />
   </Provider>, document.getElementById('react-app'))
-ReactDOM.render(<DebugInfo store={store} />, document.getElementById('debug'))
 
 // Start listening for keypresses
 startListening()

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -498,7 +498,15 @@ export function prepareEmptyStreet () {
   setUpdateTimeToNow()
 }
 
-export function updateEverything (dontScroll) {
+/**
+ * @todo: documentation
+ *
+ * @param {Boolean} dontScroll - document this
+ * @param {Boolean} save - if set to `false`, calling this function will not
+ *          cause a re-save of street to the server. (e.g. in the case of
+ *          live update feature.) Default is `true`.
+ */
+export function updateEverything (dontScroll, save = true) {
   setIgnoreStreetChanges(true)
   propagateUnits()
   // TODO Verify that we don't need to dispatch an update width event here
@@ -510,5 +518,7 @@ export function updateEverything (dontScroll) {
   updateUndoButtons()
   _lastStreet = trimStreetData(street)
 
-  scheduleSavingStreetToServer()
+  if (save === true) {
+    scheduleSavingStreetToServer()
+  }
 }


### PR DESCRIPTION
This is a little-used bit of functionality for the live-update feature. Porting it is low hanging fruit.

- Moves the HTML & animation to React component.
- Live Update interacts with the Flash component via an event - this decouples the live update from the view.
- Fixes a bug where if the live update flag is on (without a corresponding read-only flag, which is likely how you'd use it anyway) it causes an endless read/write loop to the server (#666)