### PR TITLE
Make StreetName component dumber

### DIFF
--- a/assets/scripts/app/WelcomePanel.jsx
+++ b/assets/scripts/app/WelcomePanel.jsx
@@ -195,7 +195,7 @@ class WelcomePanel extends React.Component {
                 React's warning that <div> elements from StreetName and
                 Avatar components cannot exist inside a <p> */}
             <div className='paragraph'>
-              This is <StreetName street={street} />
+              This is <StreetName name={street.name} />
               {(() => {
                 // Display street creator if creatorId is available.
                 if (street.creatorId) {

--- a/assets/scripts/gallery/view.js
+++ b/assets/scripts/gallery/view.js
@@ -207,7 +207,7 @@ export function receiveGalleryData (transmission) {
     nameEl.className = 'street-name-wrap'
     anchorEl.appendChild(nameEl)
 
-    ReactDOM.render(<StreetName street={galleryStreet} />, nameEl)
+    ReactDOM.render(<StreetName name={galleryStreet.name} />, nameEl)
 
     var dateEl = document.createElement('span')
     dateEl.classList.add('date')

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -1,45 +1,9 @@
 import React from 'react'
-import { msg } from '../app/messages'
-import { setAndSaveStreet } from './data_model'
 import { needsUnicodeFont } from '../util/unicode'
-import { updateStreetName } from './name'
 
 const MAX_STREET_NAME_WIDTH = 50
 
-export default class StreetName extends React.Component {
-  constructor (props) {
-    super(props)
-
-    this.lastSentCoords = null
-
-    this.clickStreetName = this.clickStreetName.bind(this)
-    this.updateCoords = this.updateCoords.bind(this)
-  }
-
-  componentDidMount () {
-    window.addEventListener('resize', this.updateCoords)
-  }
-
-  componentWillUnmount () {
-    window.removeEventListener('resize', this.updateCoords)
-  }
-
-  updateCoords () {
-    const rect = this.streetName.getBoundingClientRect()
-    const coords = {
-      left: rect.left,
-      width: rect.width
-    }
-    if (!this.lastSentCoords || coords.left !== this.lastSentCoords.left || coords.width !== this.lastSentCoords.width) {
-      this.lastSentCoords = coords
-      this.props.handleResize(coords)
-    }
-  }
-
-  componentDidUpdate (nextProps, nextState) {
-    this.updateCoords()
-  }
-
+export default class StreetName extends React.PureComponent {
   /**
    * Some processing needed to display street name
    *
@@ -60,56 +24,21 @@ export default class StreetName extends React.Component {
     return name
   }
 
-  /**
-   * Check if street name requires a Unicode font to render correctly
-   *
-   * @static
-   * @params {string} name - Street name to check
-   */
-  needsUnicodeFont () {
-    if (!this.props.street.name) {
-      return false
-    }
-    return needsUnicodeFont(this.props.street.name)
-  }
-
-  clickStreetName () {
-    if (!this.props.editable) {
-      return
-    }
-
-    const newName = window.prompt(msg('PROMPT_NEW_STREET_NAME'), this.props.street.name)
-
-    if (newName) {
-      const street = Object.assign({}, this.props.street)
-      street.name = StreetName.normalizeStreetName(newName)
-      setAndSaveStreet(street)
-      updateStreetName()
-    }
-  }
-
   render () {
-    let classString = 'street-name-text ' + (!this.needsUnicodeFont() ? '' : 'fallback-unicode-font')
+    let classString = 'street-name-text ' + (!needsUnicodeFont(this.props.name) ? '' : 'fallback-unicode-font')
+
     return (
       <div
-        ref={(ref) => { this.streetName = ref }}
-        id={this.props.id}
+        ref={(ref) => { this.el = ref }}
         className='street-name'
-        onClick={this.clickStreetName}
+        {...this.props}
       >
-        <div className={classString}>{StreetName.normalizeStreetName(this.props.street.name)}</div>
+        <div className={classString}>{StreetName.normalizeStreetName(this.props.name)}</div>
       </div>
     )
   }
 }
 
 StreetName.propTypes = {
-  id: React.PropTypes.string,
-  editable: React.PropTypes.bool,
-  street: React.PropTypes.any,
-  handleResize: React.PropTypes.func
-}
-
-StreetName.defaultProps = {
-  handleResize: function () { } // no-op
+  name: React.PropTypes.string.isRequired
 }

--- a/assets/scripts/streets/StreetNameCanvas.jsx
+++ b/assets/scripts/streets/StreetNameCanvas.jsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { connect } from 'react-redux'
 import StreetName from './StreetName'
 import StreetMetaData from './StreetMetaData'
-import { getStreet } from './data_model'
+import { getStreet, setAndSaveStreet } from './data_model'
+import { msg } from '../app/messages'
+import { updateStreetName } from './name'
 
 class StreetNameCanvas extends React.Component {
   constructor (props) {
@@ -16,12 +18,17 @@ class StreetNameCanvas extends React.Component {
       streetNameWidth: 0
     }
 
+    this.lastSentCoords = null
+
+    this.updateCoords = this.updateCoords.bind(this)
     this.streetUpdated = this.streetUpdated.bind(this)
     this.updatePositions = this.updatePositions.bind(this)
-    this.onResizeStreetName = this.onResizeStreetName.bind(this)
+    this.handleResizeStreetName = this.handleResizeStreetName.bind(this)
+    this.onClickStreetName = this.onClickStreetName.bind(this)
   }
 
   componentDidMount () {
+    window.addEventListener('resize', this.updateCoords)
     window.addEventListener('stmx:set_street', this.streetUpdated)
     window.addEventListener('stmx:width_updated', this.streetUpdated)
     window.addEventListener('stmx:menu_bar_resized', this.updatePositions)
@@ -29,9 +36,14 @@ class StreetNameCanvas extends React.Component {
   }
 
   componentWillUnmount () {
+    window.removeEventListener('resize', this.updateCoords)
     window.removeEventListener('stmx:set_street', this.streetUpdated)
     window.removeEventListener('stmx:width_updated', this.streetUpdated)
     window.removeEventListener('stmx:menu_bar_resized', this.updatePositions)
+  }
+
+  componentDidUpdate (nextProps, nextState) {
+    this.updateCoords()
   }
 
   streetUpdated (e) {
@@ -39,11 +51,23 @@ class StreetNameCanvas extends React.Component {
     this.setState({street})
   }
 
-  onResizeStreetName (coords) {
+  handleResizeStreetName (coords) {
     this.setState({
       streetNameLeftPos: coords.left,
       streetNameWidth: coords.width
     })
+  }
+
+  updateCoords () {
+    const rect = this.streetName.el.getBoundingClientRect()
+    const coords = {
+      left: rect.left,
+      width: rect.width
+    }
+    if (!this.lastSentCoords || coords.left !== this.lastSentCoords.left || coords.width !== this.lastSentCoords.width) {
+      this.lastSentCoords = coords
+      this.handleResizeStreetName(coords)
+    }
   }
 
   updatePositions (event) {
@@ -62,15 +86,27 @@ class StreetNameCanvas extends React.Component {
     return classNames
   }
 
+  onClickStreetName () {
+    if (!this.props.editable) return
+
+    const newName = window.prompt(msg('PROMPT_NEW_STREET_NAME'), this.state.street.name)
+
+    if (newName) {
+      const street = Object.assign({}, this.state.street)
+      street.name = StreetName.normalizeStreetName(newName)
+      setAndSaveStreet(street)
+      updateStreetName()
+    }
+  }
+
   render () {
     return (
       <div id='street-name-canvas' className={this.determineClassNames().join(' ')}>
         <StreetName
           id='street-name'
           ref={(ref) => { this.streetName = ref }}
-          street={this.state.street}
-          editable={this.props.editable}
-          handleResize={this.onResizeStreetName}
+          name={this.state.street.name}
+          onClick={this.onClickStreetName}
         />
         <StreetMetaData id='street-metadata' street={this.state.street} />
       </div>


### PR DESCRIPTION
The `StreetName` component usually only needs to know about the name itself and nothing else about the street. Since the click / resize handler logic in `StreetName` is only used in one place (`StreetNameCanvas`) that logic was moved out to be in `StreetNameCanvas` only.