### PR TITLE
StreetName: port hover-state message into React for translation

### DIFF
--- a/assets/css/_street-name.scss
+++ b/assets/css/_street-name.scss
@@ -121,19 +121,17 @@ body:not(.touch-support):not(.read-only) #street-name {
     > div {
       border-color: rgb(220, 220, 220);
     }
-
-    &::after {
-      color: black;
-      // TODO message
-      content: 'Click to rename';
-      position: absolute;
-      left: 0;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      line-height: 60px * $street-name-size;
-      font-family: sans-serif;
-      font-size: 12px;
-    }
   }
+}
+
+.street-name-hover-prompt {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  line-height: 60px * $street-name-size;
+  font-family: sans-serif;
+  font-size: 12px;
+  color: black;
 }

--- a/assets/css/_street-name.scss
+++ b/assets/css/_street-name.scss
@@ -121,6 +121,6 @@ body.windows .street-name-text {
   font-family: sans-serif;
   font-size: 12px;
   color: black;
-  background-color: rgba(255,255,255,0.8);
+  background-color: rgba(255, 255, 255, 0.8);
   cursor: pointer;
 }

--- a/assets/css/_street-name.scss
+++ b/assets/css/_street-name.scss
@@ -111,19 +111,6 @@ body.windows .street-name-text {
   pointer-events: auto;
 }
 
-body:not(.touch-support):not(.read-only) #street-name {
-  cursor: pointer;
-
-  &:hover {
-    color: rgb(220, 220, 220);
-    background: white;
-
-    > div {
-      border-color: rgb(220, 220, 220);
-    }
-  }
-}
-
 .street-name-hover-prompt {
   position: absolute;
   left: 0;
@@ -134,4 +121,6 @@ body:not(.touch-support):not(.read-only) #street-name {
   font-family: sans-serif;
   font-size: 12px;
   color: black;
+  background-color: rgba(255,255,255,0.8);
+  cursor: pointer;
 }

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { needsUnicodeFont } from '../util/unicode'
+import { t } from '../app/locale'
 
 const MAX_STREET_NAME_WIDTH = 50
 
@@ -60,7 +61,9 @@ class StreetName extends React.PureComponent {
     if (this.props.isStreetReadOnly || !this.props.isHoverable) return null
     if (typeof this.props.onClick === 'function' && this.state.isHovered) {
       return (
-        <div className="street-name-hover-prompt">Click to rename!</div>
+        <div className="street-name-hover-prompt">
+          {t('street.rename', 'Click to rename')}
+        </div>
       )
     }
 

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -82,8 +82,8 @@ class StreetName extends React.PureComponent {
         onClick={this.props.onClick || null}
         id={this.props.id}
       >
-        <div className={classString}>{StreetName.normalizeStreetName(this.props.name)}</div>
         {this.renderHoverPrompt()}
+        <div className={classString}>{StreetName.normalizeStreetName(this.props.name)}</div>
       </div>
     )
   }

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -49,7 +49,6 @@ class StreetName extends React.PureComponent {
   }
 
   onMouseEnter = () => {
-    console.log('seeing it')
     this.setState({ isHovered: true })
   }
 
@@ -79,7 +78,7 @@ class StreetName extends React.PureComponent {
         ref={this.props.childRef}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
-        onClick={this.props.onClick || null}
+        onClick={this.props.onClick}
         id={this.props.id}
       >
         {this.renderHoverPrompt()}

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -1,16 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import { needsUnicodeFont } from '../util/unicode'
 
 const MAX_STREET_NAME_WIDTH = 50
 
-export default class StreetName extends React.PureComponent {
+class StreetName extends React.PureComponent {
   static propTypes = {
-    name: PropTypes.string
+    id: PropTypes.string,
+    name: PropTypes.string,
+    childRef: PropTypes.func,
+    onClick: PropTypes.func,
+    isStreetReadOnly: PropTypes.bool,
+    isHoverable: PropTypes.bool
   }
 
   static defaultProps = {
-    name: ''
+    name: '',
+    isStreetReadOnly: false,
+    isHoverable: false
   }
 
   /**
@@ -31,20 +39,58 @@ export default class StreetName extends React.PureComponent {
     return name
   }
 
-  /**
-   * For a parent component that needs to know the dimensions of this component
-   */
-  getBoundingClientRect () {
-    return this.el.getBoundingClientRect()
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      isHovered: false
+    }
+  }
+
+  onMouseEnter = () => {
+    console.log('seeing it')
+    this.setState({ isHovered: true })
+  }
+
+  onMouseLeave = () => {
+    this.setState({ isHovered: false })
+  }
+
+  renderHoverPrompt = () => {
+    if (this.props.isStreetReadOnly || !this.props.isHoverable) return null
+    if (typeof this.props.onClick === 'function' && this.state.isHovered) {
+      return (
+        <div className="street-name-hover-prompt">Click to rename!</div>
+      )
+    }
+
+    return null
   }
 
   render () {
     let classString = 'street-name-text ' + (!needsUnicodeFont(this.props.name) ? '' : 'fallback-unicode-font')
 
     return (
-      <div className="street-name" ref={(ref) => { this.el = ref }} {...this.props}>
+      <div
+        className="street-name"
+        ref={this.props.childRef}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+        onClick={this.props.onClick || null}
+        id={this.props.id}
+      >
         <div className={classString}>{StreetName.normalizeStreetName(this.props.name)}</div>
+        {this.renderHoverPrompt()}
       </div>
     )
   }
 }
+
+function mapStateToProps (state) {
+  return {
+    isStreetReadOnly: state.app.readOnly,
+    isHoverable: !state.system.touch
+  }
+}
+
+export default connect(mapStateToProps)(StreetName)

--- a/assets/scripts/streets/StreetNameCanvas.jsx
+++ b/assets/scripts/streets/StreetNameCanvas.jsx
@@ -53,6 +53,7 @@ class StreetNameCanvas extends React.Component {
 
   updateCoords = () => {
     const rect = this.streetName.getBoundingClientRect()
+
     const coords = {
       left: rect.left,
       width: rect.width
@@ -97,7 +98,7 @@ class StreetNameCanvas extends React.Component {
       <div id="street-name-canvas" className={this.determineClassNames().join(' ')}>
         <StreetName
           id="street-name"
-          ref={(ref) => { this.streetName = ref }}
+          childRef={(ref) => { this.streetName = ref }}
           name={this.props.street.name}
           onClick={this.onClickStreetName}
         />


### PR DESCRIPTION
The "Click to rename" message that appears when hovering over the primary StreetName component is done in CSS, which makes it unreachable by the translation framework. This ports the original CSS pseudo element into React so that the message can be translated.

Resolves #741.