### PR TITLE
Gallery cleanup

### DIFF
--- a/assets/css/_gallery.scss
+++ b/assets/css/_gallery.scss
@@ -257,11 +257,13 @@ body.safari #gallery {
   transform: translateY(-$gallery-height - 3px);
 }
 
-#gallery-shield {
+.gallery-shield {
   position: absolute;
   display: none;
   left: 0;
-  top: 90px;
+  top: -90px;
+  width: 100vw;
+  height: 100vh;
   cursor: pointer;
   z-index: $z-08-gallery-shield;
 }
@@ -271,6 +273,6 @@ body.gallery-visible #gallery {
   pointer-events: auto;
 }
 
-body.gallery-visible #gallery-shield {
+body.gallery-visible .gallery-shield {
   display: block;
 }

--- a/assets/scripts/app/MiscHTMLStuff.jsx
+++ b/assets/scripts/app/MiscHTMLStuff.jsx
@@ -6,6 +6,7 @@
  * @module MiscHTMLStuff
  */
 import React from 'react'
+import GalleryShield from '../gallery/GalleryShield'
 
 class MiscHTMLStuff extends React.PureComponent {
   render () {
@@ -22,8 +23,8 @@ class MiscHTMLStuff extends React.PureComponent {
             </button>
           </div>
         </div>
+        <GalleryShield />
         <section id="street-section-outer">
-          <div id="gallery-shield" />
           <section id="street-section-inner">
             <section id="street-section-canvas">
               <section id="street-section-left-building" className="street-section-building">

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -1,7 +1,7 @@
 import { hideLoadingScreen, checkIfImagesLoaded } from './load_resources'
 import { initLocale } from './locale'
 import { scheduleNextLiveUpdateCheck } from './live_update'
-import { showGallery, attachGalleryViewEventListeners } from '../gallery/view'
+import { showGallery } from '../gallery/view'
 import { app } from '../preinit/app_settings'
 import { debug } from '../preinit/debug_settings'
 import { system } from '../preinit/system_capabilities'
@@ -82,7 +82,6 @@ function preInit () {
   attachBlockingShieldEventListeners()
   registerKeypresses()
   infoBubble.registerKeypresses()
-  attachGalleryViewEventListeners()
   attachStreetScrollEventListeners()
   attachFetchNonBlockingEventListeners()
 }

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -31,7 +31,7 @@ import { ENV } from './config'
 import { addEventListeners } from './event_listeners'
 import { trackEvent } from './event_tracking'
 import { getMode, setMode, MODES, processMode } from './mode'
-import { processUrl, updatePageUrl, getGalleryUserId } from './page_url'
+import { processUrl, updatePageUrl } from './page_url'
 import { onResize } from './window_resize'
 import { attachBlockingShieldEventListeners } from './blocking_shield'
 import { registerKeypresses } from './keyboard_commands'
@@ -185,7 +185,7 @@ function onEverythingLoaded () {
 
   var mode = getMode()
   if (mode === MODES.USER_GALLERY) {
-    showGallery(getGalleryUserId(), true)
+    showGallery(store.getState().gallery.userId, true)
   } else if (mode === MODES.GLOBAL_GALLERY) {
     showGallery(null, true)
   }

--- a/assets/scripts/app/page_url.js
+++ b/assets/scripts/app/page_url.js
@@ -10,22 +10,13 @@ import {
   URL_NO_USER,
   URL_RESERVED_PREFIX
 } from './routing'
+import { setGalleryUserId } from '../store/actions/gallery'
+import store from '../store'
 
 let errorUrl = ''
 
 export function getErrorUrl () {
   return errorUrl
-}
-
-// TODO: replace with state obj in gallery
-let galleryUserId = null
-
-export function getGalleryUserId () {
-  return galleryUserId
-}
-
-export function setGalleryUserId (value) {
-  galleryUserId = value
 }
 
 export function processUrl () {
@@ -71,7 +62,7 @@ export function processUrl () {
   } else if ((urlParts.length === 1) && urlParts[0]) {
     // User gallery
 
-    galleryUserId = urlParts[0]
+    store.dispatch(setGalleryUserId(urlParts[0]))
 
     setMode(MODES.USER_GALLERY)
   } else if ((urlParts.length === 2) && (urlParts[0] === URL_NO_USER) && urlParts[1]) {
@@ -92,7 +83,7 @@ export function processUrl () {
 
     // if `urlParts[1]` is not an integer, redirect to user's gallery
     if (Number.isInteger(window.parseInt(urlParts[1])) === false) {
-      galleryUserId = urlParts[0]
+      store.dispatch(setGalleryUserId(urlParts[0]))
       setMode(MODES.USER_GALLERY)
     } else {
       street.namespacedId = urlParts[1]
@@ -106,7 +97,8 @@ export function processUrl () {
 export function updatePageUrl (forceGalleryUrl) {
   let url
   if (forceGalleryUrl) {
-    var slug = galleryUserId || 'gallery/'
+    const galleryUserId = store.getState().gallery.userId
+    const slug = galleryUserId || 'gallery/'
     url = '/' + slug
   } else {
     url = getStreetUrl(getStreet())

--- a/assets/scripts/gallery/GalleryShield.jsx
+++ b/assets/scripts/gallery/GalleryShield.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { hideGallery } from './view'
+
+export default class GalleryShield extends React.Component {
+  onClick (event) {
+    hideGallery(false)
+  }
+
+  render () {
+    return (
+      <div className="gallery-shield" onClick={this.onClick} />
+    )
+  }
+}

--- a/assets/scripts/gallery/fetch_data.js
+++ b/assets/scripts/gallery/fetch_data.js
@@ -7,12 +7,9 @@ import { receiveGalleryData, hideGallery } from './view'
 import store from '../store'
 import { setGalleryMode } from '../store/actions/gallery'
 
-function getGalleryUserId () {
-  return store.getState().gallery.userId
-}
-
 export function fetchGalleryData () {
-  const galleryUserId = getGalleryUserId()
+  const galleryUserId = store.getState().gallery.userId
+
   if (galleryUserId) {
     const url = API_URL + 'v1/users/' + galleryUserId + '/streets'
     const options = {

--- a/assets/scripts/gallery/fetch_data.js
+++ b/assets/scripts/gallery/fetch_data.js
@@ -1,6 +1,5 @@
 import { API_URL } from '../app/config'
 import { MODES, processMode, getMode, setMode } from '../app/mode'
-import { getGalleryUserId } from '../app/page_url'
 import { getAuthHeader } from '../users/authentication'
 import { receiveGalleryData, hideGallery } from './view'
 
@@ -8,9 +7,14 @@ import { receiveGalleryData, hideGallery } from './view'
 import store from '../store'
 import { setGalleryMode } from '../store/actions/gallery'
 
+function getGalleryUserId () {
+  return store.getState().gallery.userId
+}
+
 export function fetchGalleryData () {
-  if (getGalleryUserId()) {
-    const url = API_URL + 'v1/users/' + getGalleryUserId() + '/streets'
+  const galleryUserId = getGalleryUserId()
+  if (galleryUserId) {
+    const url = API_URL + 'v1/users/' + galleryUserId + '/streets'
     const options = {
       headers: { 'Authorization': getAuthHeader() }
     }

--- a/assets/scripts/gallery/fetch_street.js
+++ b/assets/scripts/gallery/fetch_street.js
@@ -16,8 +16,12 @@ import { getAuthHeader } from '../users/authentication'
 import { propagateUnits } from '../users/localization'
 import { segmentsChanged } from './view'
 
+let lastRequestedStreetId = null
+
 export function fetchGalleryStreet (streetId) {
   showBlockingShield()
+
+  lastRequestedStreetId = streetId
 
   const url = API_URL + 'v1/streets/' + streetId
   const options = {
@@ -46,9 +50,9 @@ function errorReceiveGalleryStreet () {
 // TODO similar to receiveLastStreet
 function receiveGalleryStreet (transmission) {
   // Reject stale transmissions
-  // if (transmission.id !== store.getState().gallery.selected) {
-  //   return
-  // }
+  if (transmission.id !== lastRequestedStreetId) {
+    return
+  }
 
   setIgnoreStreetChanges(true)
 

--- a/assets/scripts/gallery/fetch_street.js
+++ b/assets/scripts/gallery/fetch_street.js
@@ -14,7 +14,7 @@ import { unpackServerStreetData } from '../streets/xhr'
 import { resizeStreetWidth, recalculateOccupiedWidth } from '../streets/width'
 import { getAuthHeader } from '../users/authentication'
 import { propagateUnits } from '../users/localization'
-import { galleryState, segmentsChanged } from './view'
+import { segmentsChanged } from './view'
 
 export function fetchGalleryStreet (streetId) {
   showBlockingShield()
@@ -40,16 +40,15 @@ export function fetchGalleryStreet (streetId) {
 }
 
 function errorReceiveGalleryStreet () {
-  galleryState.streetId = getStreet().id
   // updateGallerySelection()
 }
 
 // TODO similar to receiveLastStreet
 function receiveGalleryStreet (transmission) {
-  // Is this necessary?
-  if (transmission.id !== galleryState.streetId) {
-    return
-  }
+  // Reject stale transmissions
+  // if (transmission.id !== store.getState().gallery.selected) {
+  //   return
+  // }
 
   setIgnoreStreetChanges(true)
 

--- a/assets/scripts/gallery/view.js
+++ b/assets/scripts/gallery/view.js
@@ -3,10 +3,7 @@ import { showError, ERRORS } from '../app/errors'
 import { onWindowFocus } from '../app/focus'
 import { getAbortEverything } from '../app/initialization'
 import { MODES, getMode, setMode } from '../app/mode'
-import {
-  setGalleryUserId,
-  updatePageUrl
-} from '../app/page_url'
+import { updatePageUrl } from '../app/page_url'
 import { hideStatusMessage } from '../app/status_message'
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
@@ -51,7 +48,6 @@ export function showGallery (userId, instant, signInPromo = false) {
 
   galleryState.streetLoaded = true
   galleryState.streetId = getStreet().id
-  setGalleryUserId(userId)
 
   store.dispatch({
     type: SET_GALLERY_STATE,

--- a/assets/scripts/gallery/view.js
+++ b/assets/scripts/gallery/view.js
@@ -10,7 +10,6 @@ import { system } from '../preinit/system_capabilities'
 import { hideControls } from '../segments/resizing'
 import {
   DEFAULT_NAME,
-  getStreet,
   updateToLatestSchemaVersion
 } from '../streets/data_model'
 import { fetchGalleryData } from './fetch_data'
@@ -21,9 +20,7 @@ import store from '../store'
 import { SET_GALLERY_STATE } from '../store/actions'
 import { setGalleryMode, hideGallery as hideGalleryAction } from '../store/actions/gallery'
 
-export const galleryState = {
-  streetId: null,
-  streetLoaded: false,
+const galleryState = {
   // set to true when the current street is deleted from the gallery
   // this prevents the gallery from being hidden while no street is shown
   noStreetSelected: false
@@ -45,9 +42,6 @@ export function showGallery (userId, instant, signInPromo = false) {
   }
 
   trackEvent('INTERACTION', 'OPEN_GALLERY', userId, null, false)
-
-  galleryState.streetLoaded = true
-  galleryState.streetId = getStreet().id
 
   store.dispatch({
     type: SET_GALLERY_STATE,
@@ -89,7 +83,7 @@ export function hideGallery (instant) {
     return
   }
 
-  if (galleryState.streetLoaded) {
+  if (store.getState().gallery.visible) {
     store.dispatch(hideGalleryAction())
 
     if (instant) {
@@ -149,10 +143,9 @@ export function repeatReceiveGalleryData () {
 }
 
 export function switchGalleryStreet (id) {
-  galleryState.streetId = id
   galleryState.noStreetSelected = false
 
-  fetchGalleryStreet(galleryState.streetId)
+  fetchGalleryStreet(id)
 }
 
 function loadGalleryContents () {

--- a/assets/scripts/gallery/view.js
+++ b/assets/scripts/gallery/view.js
@@ -6,7 +6,6 @@ import { MODES, getMode, setMode } from '../app/mode'
 import { updatePageUrl } from '../app/page_url'
 import { hideStatusMessage } from '../app/status_message'
 import { app } from '../preinit/app_settings'
-import { system } from '../preinit/system_capabilities'
 import { hideControls } from '../segments/resizing'
 import {
   DEFAULT_NAME,
@@ -24,16 +23,6 @@ const galleryState = {
   // set to true when the current street is deleted from the gallery
   // this prevents the gallery from being hidden while no street is shown
   noStreetSelected: false
-}
-
-export function attachGalleryViewEventListeners () {
-  window.addEventListener('stmx:init', function () {
-    document.querySelector('#gallery-shield').addEventListener('pointerdown', onGalleryShieldClick)
-  })
-
-  window.addEventListener('stmx:everything_loaded', function () {
-    updateGalleryShield()
-  })
 }
 
 export function showGallery (userId, instant, signInPromo = false) {
@@ -151,18 +140,4 @@ export function switchGalleryStreet (id) {
 function loadGalleryContents () {
   store.dispatch(setGalleryMode('LOADING'))
   fetchGalleryData()
-}
-
-function onGalleryShieldClick (event) {
-  hideGallery(false)
-}
-
-function updateGalleryShield () {
-  document.querySelector('#gallery-shield').style.width = 0
-  window.setTimeout(function () {
-    document.querySelector('#gallery-shield').style.height =
-      system.viewportHeight + 'px'
-    document.querySelector('#gallery-shield').style.width =
-      document.querySelector('#street-section-outer').scrollWidth + 'px'
-  }, 0)
 }

--- a/assets/scripts/store/actions/gallery.js
+++ b/assets/scripts/store/actions/gallery.js
@@ -27,17 +27,16 @@ export function deleteGalleryStreet (streetId) {
   }
 }
 
-export function setGalleryState (state) {
+export function setGalleryMode (mode) {
   return {
-    ...state,
-    type: SET_GALLERY_STATE
+    type: SET_GALLERY_STATE,
+    mode
   }
 }
 
-export function setGalleryMode (mode, state) {
+export function setGalleryUserId (userId) {
   return {
-    ...state,
-    mode,
-    type: SET_GALLERY_STATE
+    type: SET_GALLERY_STATE,
+    userId
   }
 }


### PR DESCRIPTION
Removes in-transition hacks for Gallery component, and ports the invisible "shield" to React. Should also fix #744.