### PR TITLE
Change "Geolocation" label to "Add location" #739 Part 2

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -117,7 +117,8 @@
       "search": "Search for a location",
       "clear-search": "Clear search",
       "zoom-in": "Zoom in",
-      "zoom-out": "Zoom out"
+      "zoom-out": "Zoom out",
+      "Add location": "Add location"
     }
   },
   "prompt": {

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -118,7 +118,7 @@
       "clear-search": "Clear search",
       "zoom-in": "Zoom in",
       "zoom-out": "Zoom out",
-      "Add location": "Add location"
+      "add-location": "Add location"
     }
   },
   "prompt": {


### PR DESCRIPTION
Does this need to be added in here? I feel like I also should not have a space in the first part, but I'm not sure how the label will know to reference the correct button if it's not the same as the other file.