### PR TITLE
Visual update to keyboard keys

### DIFF
--- a/assets/css/_chrome.scss
+++ b/assets/css/_chrome.scss
@@ -127,21 +127,17 @@ body.controls-fade-out .segment:not(.unmovable).hover .hover-bk {
 // Keyboard button
 .key {
   display: inline-block;
-  position: relative;
-  top: -2px;
-  padding: 1px 6px;
-  border-top: 1px solid rgb(240, 240, 240);
-  border-left: 1px solid rgb(240, 240, 240);
-  border-bottom: 1px solid rgb(200, 200, 200);
-  border-right: 1px solid rgb(200, 200, 200);
-  border-radius: 2px;
-  font-size: 11px;
-  font-style: italic;
-  background: rgb(220, 220, 220);
+  padding: 0.2em 0.75em;
+  margin: 0 0.25em;
+  border: #ccc 1px solid;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: bold;
+  // Mac OS X default monospace font has different sized left/right arrows, so use Menlo instead
+  font-family: 'Menlo', monospace;
+  background: #f4f4f4;
   color: rgb(64, 64, 64);
-
-  // Spacing of multiple keys in series
-  + .key {
-    margin-left: 0.25em;
-  }
+  text-shadow: #fff 0 1px 0;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 0 0 #fff inset;
+  white-space: nowrap;
 }

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -15,9 +15,9 @@
     },
     "help": {
       "keyboard-label": "Keyboard shortcuts:",
-      "remove": "Remove a segment you’re pointing at<br> (hold <span class='key'>Shift</span> to remove all)",
-      "move": "Move around the street (hold <span class='key'>Shift</span> to jump to edges)",
-      "change": "Change width of a segment you’re pointing at<br> (hold <span class='key'>Shift</span> for more precision)"
+      "remove": "Remove a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> to remove all)",
+      "move": "Move around the street<br />(hold <kbd class='key'>Shift</kbd> to jump to edges)",
+      "change": "Change width of a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> for more precision)"
     },
     "share": {
       "sign-in": "<a href='/twitter-sign-in?redirectUri=/just-signed-in'>Sign in with Twitter</a> for nicer links to your streets and your personal street gallery",

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -45,23 +45,23 @@ class HelpMenu extends React.PureComponent {
             <tbody>
               <tr>
                 <td>
-                  <span className="key">{t('key.backspace', 'Backspace')}</span>
+                  <kbd className="key">{t('key.backspace', 'Backspace')}</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.remove', 'Remove a segment you’re pointing at<br />(hold <span class="key">Shift</span> to remove all)') }} />
+                <td dangerouslySetInnerHTML={{ __html: t('menu.help.remove', 'Remove a segment you’re pointing at<br />(hold <kbd class="key">Shift</kbd> to remove all)') }} />
               </tr>
               <tr>
                 <td>
-                  <span className="key">-</span>
-                  <span className="key">+</span>
+                  <kbd className="key">-</kbd>
+                  <kbd className="key">+</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.move', 'Change width of a segment you’re pointing at<br />(hold <span class="key">Shift</span> for more precision)') }} />
+                <td dangerouslySetInnerHTML={{ __html: t('menu.help.move', 'Change width of a segment you’re pointing at<br />(hold <kbd class="key">Shift</kbd> for more precision)') }} />
               </tr>
               <tr>
                 <td>
-                  <span className="key">&larr;</span>
-                  <span className="key">&rarr;</span>
+                  <kbd className="key">&larr;</kbd>
+                  <kbd className="key">&rarr;</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.change', 'Move around the street(hold <span class="key">Shift</span> to jump to edges)') }} />
+                <td dangerouslySetInnerHTML={{ __html: t('menu.help.change', 'Move around the street<br />(hold <kbd class="key">Shift</kbd> to jump to edges)') }} />
               </tr>
             </tbody>
           </table>

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -54,14 +54,14 @@ class HelpMenu extends React.PureComponent {
                   <kbd className="key">-</kbd>
                   <kbd className="key">+</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.move', 'Change width of a segment you’re pointing at<br />(hold <kbd class="key">Shift</kbd> for more precision)') }} />
+                <td dangerouslySetInnerHTML={{ __html: t('menu.help.change', 'Move around the street<br />(hold <kbd class="key">Shift</kbd> to jump to edges)') }} />
               </tr>
               <tr>
                 <td>
                   <kbd className="key">&larr;</kbd>
                   <kbd className="key">&rarr;</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.change', 'Move around the street<br />(hold <kbd class="key">Shift</kbd> to jump to edges)') }} />
+                <td dangerouslySetInnerHTML={{ __html: t('menu.help.move', 'Change width of a segment you’re pointing at<br />(hold <kbd class="key">Shift</kbd> for more precision)') }} />
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Time to give these keyboard keys a visual update...

(current)
<img width="434" alt="screenshot 2018-01-15 12 27 27" src="https://user-images.githubusercontent.com/2553268/34955185-4d5cbd6e-f9f1-11e7-8d67-5ebded0640e8.png">

(proposed)
<img width="406" alt="screenshot 2018-01-15 12 37 50" src="https://user-images.githubusercontent.com/2553268/34955186-4d6df8ea-f9f1-11e7-867f-262ffd9d45c8.png">

- Use the more [semantically correct `<kbd>` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd) as opposed to `<span>`. We still use the `class="key"` to differentiate between keyboard keys and other kinds of input. Note that translation strings will need to be updated, although the `<span class="key">` continues to work for now.
- Increase spacing and contrast to improve legibility
- Use a more legible font (monospace, bold)
- Single-character keys should be fixed-width so that they display at the same size
- Add a missing `<br />` in the middle string. Note for translations: while this made sense in English, different line lengths may make this line break not relevant in other languages.
