### PR TITLE
Fix palette bugs!!!

### DIFF
--- a/assets/css/_palette.scss
+++ b/assets/css/_palette.scss
@@ -46,9 +46,6 @@ body.read-only .palette-container {
   right: 0;
   overflow-x: scroll;
   overflow-y: hidden;
-}
-
-.palette-canvas {
   white-space: nowrap;
 }
 

--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -119,10 +119,11 @@ body:not(.segment-resize-dragging) .segment.outside .image {
 
 .segment.segment-in-palette:hover {
   background: fade-out($sky-colour, 0.05);
+  z-index: 1;
 
   canvas {
     transform: scale(1.15);
-    transform-origin: 14% 75px;
+    transform-origin: 50% 75px;
   }
 }
 

--- a/assets/scripts/app/Palette.jsx
+++ b/assets/scripts/app/Palette.jsx
@@ -108,7 +108,7 @@ class Palette extends React.Component {
           <button id="redo" onClick={redo}>{t('btn.redo', 'Redo')}</button>
         </div>
         <Scrollable className="palette" setRef={this.setScrollableRef} ref={(ref) => { this.scrollable = ref }}>
-          <div className="palette-canvas">{this.props.everythingLoaded && paletteItems}</div>
+          <React.Fragment>{this.props.everythingLoaded && paletteItems}</React.Fragment>
         </Scrollable>
       </div>
     )

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -75,10 +75,11 @@ export default class Segment extends React.Component {
     const dimensions = getVariantInfoDimensions(variantInfo, segmentWidth, multiplier)
     const totalWidth = dimensions.right - dimensions.left
 
-    const canvasWidth = totalWidth * TILE_SIZE * system.hiDpi
+    // Canvas width and height must fit the div width in the palette to prevent extra right padding
+    const canvasWidth = this.props.forPalette ? width * system.hiDpi : totalWidth * TILE_SIZE * system.hiDpi
     const canvasHeight = CANVAS_BASELINE * system.hiDpi
     const canvasStyle = {
-      width: (totalWidth * TILE_SIZE),
+      width: this.props.forPalette ? width : totalWidth * TILE_SIZE,
       height: CANVAS_BASELINE,
       left: (dimensions.left * TILE_SIZE * multiplier)
     }
@@ -87,7 +88,10 @@ export default class Segment extends React.Component {
       <div
         style={{
           width: width,
-          zIndex: SEGMENT_INFO[this.props.type].zIndex
+          // In a street, certain segments have stacking priority over others (expressed as z-index).
+          // In a palette, segments are side-by-side so they don't need stacking priority.
+          // Setting a z-index here will clobber a separate z-index (applied via CSS) when hovered by mouse pointer
+          zIndex: (this.props.forPalette) ? null : SEGMENT_INFO[this.props.type].zIndex
         }}
         className={'segment' + (this.props.isUnmovable ? ' unmovable' : '') + (this.props.forPalette ? ' segment-in-palette' : '')}
         data-segment-type={this.props.type}

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -294,8 +294,7 @@ function handleSegmentMoveStart () {
     draggingMove.originalVariantString = variantString
   }
 
-  var pos = getElAbsolutePos(draggingMove.originalEl)
-
+  var pos = getElAbsolutePos(draggingMove.originalEl, true)
   draggingMove.elX = pos[0]
   draggingMove.elY = pos[1]
 

--- a/assets/scripts/util/helpers.js
+++ b/assets/scripts/util/helpers.js
@@ -2,21 +2,31 @@ import { tween } from 'shifty'
 
 /**
  * Gets the absolute position in pixels of a given element,
- * taking into account its CSS transformed position.
+ * taking into account its CSS transformed position, and optionally,
+ * the scroll position of parent elements
  *
  * @param {Node} element
+ * @param {Boolean} includeScroll - if true, takes into account
+ *    scroll position of parent elements
  * @returns {Array} [x, y] where x is number of pixels from the
  *    left side of the viewport and y is the number of pixels
  *    from the top of the viewport.
  */
-export function getElAbsolutePos (el) {
+export function getElAbsolutePos (el, includeScroll = false) {
   let pos = [0, 0]
 
   do {
     pos[0] += el.offsetLeft + (el.cssTransformLeft || 0)
     pos[1] += el.offsetTop + (el.cssTransformTop || 0)
 
-    el = el.offsetParent
+    const parent = el.offsetParent
+
+    if (includeScroll && parent) {
+      pos[0] -= parent.scrollLeft
+      pos[1] -= parent.scrollTop
+    }
+
+    el = parent
   } while (el)
 
   return pos


### PR DESCRIPTION
**1. Remove extra padding that happens on the right side of the palette.**

Before:

![before - padding](https://user-images.githubusercontent.com/2553268/35129474-cf4627e4-fc89-11e7-91ce-bcff92b33566.gif)

After:

![after - no more padding](https://user-images.githubusercontent.com/2553268/35129475-d0ad8604-fc89-11e7-85ec-eb5d2db7458c.gif)

That extra space is caused by the canvas size of the segment being wider than it needed to be. For segments in palettes, we tell the canvas size to be the same width as the parent element.

**2. Remove the wrapping element around palette segments.**

This was previously necessary when creating a list of elements, but with `<React.Fragment>` this is no longer required. This simplifies a nesting layer of `<div>` wrappers.

**3. Fix a bug where dragging a palette segment out when the palette is scrolled over causes the segment to appear too far right from the mouse cursor.**

Before:

![before - position bug](https://user-images.githubusercontent.com/2553268/35129565-3aba38d0-fc8a-11e7-9af6-f82f73139364.gif)

After:

![after - yay](https://user-images.githubusercontent.com/2553268/35129566-3bb1b42a-fc8a-11e7-95a2-520997906762.gif)

This is because `getElAbsolutePos()` did not take into account the scroll position of parent elements. This function has been augmented to allow this to be taken into account, however, a second argument to the function must be set to true because allowing it everywhere breaks other parts of the app.

---

Very open to other suggestions about how to fix some of these issues if the cure seems worse than the disease.
