### PR TITLE
Set error boundary on all dialogs, resolves #778

### DIFF
--- a/assets/css/_dialogs.scss
+++ b/assets/css/_dialogs.scss
@@ -67,6 +67,19 @@ $dialog-box-default-width: 790px;
       color: rgb(120, 120, 120);
     }
   }
+
+  button:not(.close),
+  a.button-like {
+    margin: 0 auto;
+    display: inline-block !important;
+    padding: 0.75em 2em;
+    margin-top: 1em;
+  }
+}
+
+.dialog-error {
+  padding: 1.5em 3em;
+  max-width: 400px;
 }
 
 // Content of #about dialog box

--- a/assets/css/_dialogs.scss
+++ b/assets/css/_dialogs.scss
@@ -133,12 +133,7 @@
   width: 700px;
 
   p {
-    font-size: 16px;
     text-align: center;
-
-    a {
-      font-size: 16px;
-    }
   }
 
   input[type='checkbox'] {
@@ -148,6 +143,7 @@
   }
 
   label {
+    font-size: 16px;
     padding-left: 1px;
     user-select: none;
   }
@@ -162,7 +158,6 @@
   flex-direction: column;
   justify-content: center;
   height: 300px;
-  margin-bottom: 20px;
 }
 
 .save-as-image-preview-loading {
@@ -187,7 +182,7 @@
 }
 
 .donate-dialog {
-  width: 560px;
+  width: 500px;
   text-align: center;
 }
 
@@ -198,12 +193,6 @@
 .donate-dialog-lede {
   font-size: 1.25em;
   margin: 1em 0;
-}
-
-// Override .button-like specificity
-.button-like.donate-dialog-button {
-  padding: 1em 1.5em;
-  margin-top: 1em;
 }
 
 // Feature flag dialog

--- a/assets/css/_dialogs.scss
+++ b/assets/css/_dialogs.scss
@@ -5,8 +5,6 @@
 
 // Base styles for dialog boxes
 
-$dialog-box-default-width: 790px;
-
 .dialog-box-container {
   display: flex;
   align-items: center;
@@ -39,7 +37,6 @@ $dialog-box-default-width: 790px;
 
   position: relative;
   box-sizing: border-box;
-  width: $dialog-box-default-width;
   // balance the dialog by making it slightly north of center
   margin-top: -6%;
   background: white;
@@ -66,6 +63,10 @@ $dialog-box-default-width: 790px;
     a:hover {
       color: rgb(120, 120, 120);
     }
+  }
+
+  button.close {
+    z-index: $z-09-dialog-box;
   }
 
   button:not(.close),
@@ -129,6 +130,8 @@ $dialog-box-default-width: 790px;
 // Content of Save as Image dialog box
 // TODO: Less nesting
 .save-as-image-dialog {
+  width: 700px;
+
   p {
     font-size: 16px;
     text-align: center;

--- a/assets/css/_geolocation.scss
+++ b/assets/css/_geolocation.scss
@@ -1,6 +1,7 @@
 .geolocate-dialog {
   width: 90vw;
   height: 80vh;
+  margin: -1rem -2rem; /* overrides padding from .dialog-box */
   padding: 0;
 }
 

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -76,6 +76,10 @@
     "dismiss": "Dismiss"
   },
   "dialogs": {
+    "error": {
+      "heading": "Oops!",
+      "text": "Something unexpected happened 😢. We’ve logged the error, but if you can remember what happened on the way here, <a href=\"https://github.com/streetmix/streetmix/issues/new\" target=\"_blank\">please tell us about it</a>. This could also be a temporary problem, so please try one more time."
+    },
     "welcome": {
       "heading": "Welcome to Streetmix.",
       "new": {

--- a/assets/scripts/dialogs/AboutDialog.jsx
+++ b/assets/scripts/dialogs/AboutDialog.jsx
@@ -2,11 +2,9 @@
  * About Streetmix (dialog box)
  *
  * Handles the "About" dialog box.
- * Instantiates an instance of Dialog
  *
  */
 import React from 'react'
-import Dialog from './Dialog'
 import Avatar from '../users/Avatar'
 import { trackEvent } from '../app/event_tracking'
 import { t } from '../app/locale'
@@ -18,7 +16,7 @@ export default class AboutDialog extends React.PureComponent {
 
   render () {
     return (
-      <Dialog className="about-dialog">
+      <React.Fragment>
         <h1>{t('dialogs.about.heading', 'About Streetmix.')}</h1>
         <div className="about-dialog-left">
           <p className="about-dialog-description">
@@ -73,7 +71,7 @@ export default class AboutDialog extends React.PureComponent {
             <a href="https://github.com/streetmix/streetmix/blob/master/CONTRIBUTING.md" target="_blank">{t('dialogs.about.github-link', 'Contribute to open source')}</a>
           </p>
         </div>
-      </Dialog>
+      </React.Fragment>
     )
   }
 }

--- a/assets/scripts/dialogs/AboutDialog.jsx
+++ b/assets/scripts/dialogs/AboutDialog.jsx
@@ -16,7 +16,7 @@ export default class AboutDialog extends React.PureComponent {
 
   render () {
     return (
-      <React.Fragment>
+      <div className="about-dialog">
         <h1>{t('dialogs.about.heading', 'About Streetmix.')}</h1>
         <div className="about-dialog-left">
           <p className="about-dialog-description">
@@ -71,7 +71,7 @@ export default class AboutDialog extends React.PureComponent {
             <a href="https://github.com/streetmix/streetmix/blob/master/CONTRIBUTING.md" target="_blank">{t('dialogs.about.github-link', 'Contribute to open source')}</a>
           </p>
         </div>
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { registerKeypress, deregisterKeypress } from '../app/keypress'
 import { clearDialogs } from '../store/actions/dialogs'
+import { t } from '../app/locale'
 
 class Dialog extends React.PureComponent {
   static propTypes = {
@@ -23,6 +24,14 @@ class Dialog extends React.PureComponent {
     disableShieldExit: false
   }
 
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      error: null
+    }
+  }
+
   componentDidMount () {
     // Set up keypress listener to close dialogs if open
     registerKeypress('esc', this.unmountDialog)
@@ -30,6 +39,12 @@ class Dialog extends React.PureComponent {
 
   componentWillUnmount () {
     deregisterKeypress('esc', this.unmountDialog)
+  }
+
+  componentDidCatch (error, info) {
+    this.setState({
+      error
+    })
   }
 
   unmountDialog = () => {
@@ -49,17 +64,37 @@ class Dialog extends React.PureComponent {
     }
 
     let shieldClassName = 'dialog-box-shield'
-    if (this.props.disableShieldExit) {
+    if (this.props.disableShieldExit && !this.state.error) {
       shieldClassName += ' dialog-box-shield-unclickable'
     }
 
     return (
       <div className="dialog-box-container" ref={(ref) => { this.dialogEl = ref }}>
         <div className={shieldClassName} onClick={this.onClickShield} />
-        <div className={className}>
-          <button className="close" onClick={this.unmountDialog}>×</button>
-          {this.props.children}
-        </div>
+        {this.state.error ? (
+          <div className="dialog-box dialog-error">
+            <h1>{t('dialogs.error.heading', 'Oops!')}</h1>
+            <p>
+              {t('dialogs.error.text', 'Something unexpected happened 😢, please try again.')}
+            </p>
+            <p style={{ textAlign: 'center' }}>
+              <button onClick={this.unmountDialog} title={t('btn.close', 'Close')}>
+                {t('btn.close', 'Close')}
+              </button>
+            </p>
+          </div>
+        ) : (
+          <div className={className}>
+            <button
+              className="close"
+              onClick={this.unmountDialog}
+              title={t('btn.close', 'Close')}
+            >
+              ×
+            </button>
+            {this.props.children}
+          </div>
+        )}
       </div>
     )
   }

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -92,7 +92,7 @@ class Dialog extends React.PureComponent {
             >
               ×
             </button>
-            {this.props.children}
+            {React.cloneElement(this.props.children, { closeDialog: this.props.clearDialogs })}
           </div>
         )}
       </div>

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -12,7 +12,6 @@ import { t } from '../app/locale'
 export default class Dialog extends React.PureComponent {
   static propTypes = {
     closeDialog: PropTypes.func.isRequired,
-    className: PropTypes.string,
     children: PropTypes.node.isRequired,
     disableShieldExit: PropTypes.bool
   }
@@ -52,11 +51,6 @@ export default class Dialog extends React.PureComponent {
   }
 
   render () {
-    let className = 'dialog-box'
-    if (this.props.className !== undefined) {
-      className += ` ${this.props.className}`
-    }
-
     let shieldClassName = 'dialog-box-shield'
     if (this.props.disableShieldExit && !this.state.error) {
       shieldClassName += ' dialog-box-shield-unclickable'
@@ -78,7 +72,7 @@ export default class Dialog extends React.PureComponent {
             </p>
           </div>
         ) : (
-          <div className={className}>
+          <div className="dialog-box">
             <button
               className="close"
               onClick={this.props.closeDialog}

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -17,7 +17,6 @@ export default class Dialog extends React.PureComponent {
   }
 
   static defaultProps = {
-    className: '',
     disableShieldExit: false
   }
 

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -6,14 +6,12 @@
  */
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 import { registerKeypress, deregisterKeypress } from '../app/keypress'
-import { clearDialogs } from '../store/actions/dialogs'
 import { t } from '../app/locale'
 
-class Dialog extends React.PureComponent {
+export default class Dialog extends React.PureComponent {
   static propTypes = {
-    clearDialogs: PropTypes.func.isRequired,
+    closeDialog: PropTypes.func.isRequired,
     className: PropTypes.string,
     children: PropTypes.node.isRequired,
     disableShieldExit: PropTypes.bool
@@ -34,11 +32,11 @@ class Dialog extends React.PureComponent {
 
   componentDidMount () {
     // Set up keypress listener to close dialogs if open
-    registerKeypress('esc', this.unmountDialog)
+    registerKeypress('esc', this.props.closeDialog)
   }
 
   componentWillUnmount () {
-    deregisterKeypress('esc', this.unmountDialog)
+    deregisterKeypress('esc', this.props.closeDialog)
   }
 
   componentDidCatch (error, info) {
@@ -47,13 +45,9 @@ class Dialog extends React.PureComponent {
     })
   }
 
-  unmountDialog = () => {
-    this.props.clearDialogs()
-  }
-
   onClickShield = () => {
     if (!this.props.disableShieldExit) {
-      this.unmountDialog()
+      this.props.closeDialog()
     }
   }
 
@@ -78,7 +72,7 @@ class Dialog extends React.PureComponent {
               {t('dialogs.error.text', 'Something unexpected happened 😢, please try again.')}
             </p>
             <p style={{ textAlign: 'center' }}>
-              <button onClick={this.unmountDialog} title={t('btn.close', 'Close')}>
+              <button onClick={this.props.closeDialog} title={t('btn.close', 'Close')}>
                 {t('btn.close', 'Close')}
               </button>
             </p>
@@ -87,23 +81,15 @@ class Dialog extends React.PureComponent {
           <div className={className}>
             <button
               className="close"
-              onClick={this.unmountDialog}
+              onClick={this.props.closeDialog}
               title={t('btn.close', 'Close')}
             >
               ×
             </button>
-            {React.cloneElement(this.props.children, { closeDialog: this.props.clearDialogs })}
+            {React.cloneElement(this.props.children, { closeDialog: this.props.closeDialog })}
           </div>
         )}
       </div>
     )
   }
 }
-
-function mapDispatchToProps (dispatch) {
-  return {
-    clearDialogs: () => { dispatch(clearDialogs()) }
-  }
-}
-
-export default connect(null, mapDispatchToProps)(Dialog)

--- a/assets/scripts/dialogs/DialogRoot.jsx
+++ b/assets/scripts/dialogs/DialogRoot.jsx
@@ -44,21 +44,20 @@ const DIALOG_COMPONENTS = {
   }
 }
 
-const DialogRoot = ({ name, props }) => {
+const DialogRoot = ({ name }) => {
   if (!name) return null
 
   const SpecificDialog = DIALOG_COMPONENTS[name].component
 
   return (
     <Dialog {...DIALOG_COMPONENTS[name].props}>
-      <SpecificDialog {...props} />
+      <SpecificDialog />
     </Dialog>
   )
 }
 
 DialogRoot.propTypes = {
-  name: PropTypes.string,
-  props: PropTypes.object
+  name: PropTypes.string
 }
 
 export default connect(

--- a/assets/scripts/dialogs/DialogRoot.jsx
+++ b/assets/scripts/dialogs/DialogRoot.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { clearDialogs } from '../store/actions/dialogs'
 
 // Import all dialogs here
 import Dialog from './Dialog'
@@ -44,22 +45,30 @@ const DIALOG_COMPONENTS = {
   }
 }
 
-const DialogRoot = ({ name }) => {
+const DialogRoot = ({ name, clearDialogs }) => {
   if (!name) return null
 
   const SpecificDialog = DIALOG_COMPONENTS[name].component
 
   return (
-    <Dialog {...DIALOG_COMPONENTS[name].props}>
+    <Dialog {...DIALOG_COMPONENTS[name].props} closeDialog={clearDialogs}>
       <SpecificDialog />
     </Dialog>
   )
 }
 
 DialogRoot.propTypes = {
-  name: PropTypes.string
+  name: PropTypes.string,
+  clearDialogs: PropTypes.func
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    clearDialogs: () => { dispatch(clearDialogs()) }
+  }
 }
 
 export default connect(
-  state => state.dialogs
+  state => state.dialogs,
+  mapDispatchToProps
 )(DialogRoot)

--- a/assets/scripts/dialogs/DialogRoot.jsx
+++ b/assets/scripts/dialogs/DialogRoot.jsx
@@ -13,35 +13,22 @@ import SaveAsImageDialog from './SaveAsImageDialog'
 
 const DIALOG_COMPONENTS = {
   ABOUT: {
-    component: AboutDialog,
-    props: {
-      className: 'about-dialog'
-    }
+    component: AboutDialog
   },
   DONATE: {
     component: DonateDialog,
     props: {
-      className: 'donate-dialog',
       disableShieldExit: true
     }
   },
   FEATURE_FLAGS: {
-    component: FeatureFlagDialog,
-    props: {
-      className: 'feature-flag-dialog'
-    }
+    component: FeatureFlagDialog
   },
   GEOLOCATE: {
-    component: GeolocateDialog,
-    props: {
-      className: 'geolocate-dialog'
-    }
+    component: GeolocateDialog
   },
   SAVE_AS_IMAGE: {
-    component: SaveAsImageDialog,
-    props: {
-      className: 'save-as-image-dialog'
-    }
+    component: SaveAsImageDialog
   }
 }
 

--- a/assets/scripts/dialogs/DialogRoot.jsx
+++ b/assets/scripts/dialogs/DialogRoot.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
 // Import all dialogs here
+import Dialog from './Dialog'
 import AboutDialog from './AboutDialog'
 import DonateDialog from './DonateDialog'
 import FeatureFlagDialog from './FeatureFlagDialog'
@@ -10,18 +11,49 @@ import GeolocateDialog from './GeolocateDialog'
 import SaveAsImageDialog from './SaveAsImageDialog'
 
 const DIALOG_COMPONENTS = {
-  ABOUT: AboutDialog,
-  DONATE: DonateDialog,
-  FEATURE_FLAGS: FeatureFlagDialog,
-  GEOLOCATE: GeolocateDialog,
-  SAVE_AS_IMAGE: SaveAsImageDialog
+  ABOUT: {
+    component: AboutDialog,
+    props: {
+      className: 'about-dialog'
+    }
+  },
+  DONATE: {
+    component: DonateDialog,
+    props: {
+      className: 'donate-dialog',
+      disableShieldExit: true
+    }
+  },
+  FEATURE_FLAGS: {
+    component: FeatureFlagDialog,
+    props: {
+      className: 'feature-flag-dialog'
+    }
+  },
+  GEOLOCATE: {
+    component: GeolocateDialog,
+    props: {
+      className: 'geolocate-dialog'
+    }
+  },
+  SAVE_AS_IMAGE: {
+    component: SaveAsImageDialog,
+    props: {
+      className: 'save-as-image-dialog'
+    }
+  }
 }
 
 const DialogRoot = ({ name, props }) => {
   if (!name) return null
 
-  const SpecificDialog = DIALOG_COMPONENTS[name]
-  return <SpecificDialog {...props} />
+  const SpecificDialog = DIALOG_COMPONENTS[name].component
+
+  return (
+    <Dialog {...DIALOG_COMPONENTS[name].props}>
+      <SpecificDialog {...props} />
+    </Dialog>
+  )
 }
 
 DialogRoot.propTypes = {

--- a/assets/scripts/dialogs/DialogRoot.jsx
+++ b/assets/scripts/dialogs/DialogRoot.jsx
@@ -13,33 +13,33 @@ import SaveAsImageDialog from './SaveAsImageDialog'
 
 const DIALOG_COMPONENTS = {
   ABOUT: {
-    component: AboutDialog
+    contents: AboutDialog
   },
   DONATE: {
-    component: DonateDialog,
-    props: {
-      disableShieldExit: true
-    }
+    contents: DonateDialog,
+    disableShieldExit: true
   },
   FEATURE_FLAGS: {
-    component: FeatureFlagDialog
+    contents: FeatureFlagDialog
   },
   GEOLOCATE: {
-    component: GeolocateDialog
+    contents: GeolocateDialog
   },
   SAVE_AS_IMAGE: {
-    component: SaveAsImageDialog
+    contents: SaveAsImageDialog
   }
 }
 
-const DialogRoot = ({ name, clearDialogs }) => {
+const DialogRoot = (props) => {
+  const { name, clearDialogs } = props
+
   if (!name) return null
 
-  const SpecificDialog = DIALOG_COMPONENTS[name].component
+  const { contents: DialogContents, ...restProps } = DIALOG_COMPONENTS[name]
 
   return (
-    <Dialog {...DIALOG_COMPONENTS[name].props} closeDialog={clearDialogs}>
-      <SpecificDialog />
+    <Dialog {...restProps} closeDialog={clearDialogs}>
+      <DialogContents />
     </Dialog>
   )
 }

--- a/assets/scripts/dialogs/DonateDialog.jsx
+++ b/assets/scripts/dialogs/DonateDialog.jsx
@@ -42,7 +42,7 @@ export default class DonateDialog extends React.PureComponent {
 
   render () {
     return (
-      <React.Fragment>
+      <div className="donate-dialog">
         <h1>Streetmix needs your help!</h1>
         <div className="donate-dialog-text">
           <p className="donate-dialog-lede">
@@ -65,7 +65,7 @@ export default class DonateDialog extends React.PureComponent {
         <p>
           <a href="#" onClick={this.onClickClose}>No thanks</a>
         </p>
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/assets/scripts/dialogs/DonateDialog.jsx
+++ b/assets/scripts/dialogs/DonateDialog.jsx
@@ -2,13 +2,11 @@
  * Donate (dialog box)
  *
  * Handles the "Donate" dialog box.
- * Instantiates an instance of Dialog
  *
  */
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import Dialog from './Dialog'
 import { trackEvent } from '../app/event_tracking'
 import { clearDialogs } from '../store/actions/dialogs'
 
@@ -46,7 +44,7 @@ class DonateDialog extends React.PureComponent {
 
   render () {
     return (
-      <Dialog className="donate-dialog" disableShieldExit>
+      <React.Fragment>
         <h1>Streetmix needs your help!</h1>
         <div className="donate-dialog-text">
           <p className="donate-dialog-lede">
@@ -69,7 +67,7 @@ class DonateDialog extends React.PureComponent {
         <p>
           <a href="#" onClick={this.onClickClose}>No thanks</a>
         </p>
-      </Dialog>
+      </React.Fragment>
     )
   }
 }

--- a/assets/scripts/dialogs/DonateDialog.jsx
+++ b/assets/scripts/dialogs/DonateDialog.jsx
@@ -6,16 +6,14 @@
  */
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 import { trackEvent } from '../app/event_tracking'
-import { clearDialogs } from '../store/actions/dialogs'
 
 const LOCALSTORAGE_DONATE_DISMISSED = 'settings-donate-dismissed'
 const LOCALSTORAGE_DONATE_DELAYED_TIMESTAMP = 'settings-donate-delayed-timestamp'
 
-class DonateDialog extends React.PureComponent {
+export default class DonateDialog extends React.PureComponent {
   static propTypes = {
-    clearDialogs: PropTypes.func.isRequired
+    closeDialog: PropTypes.func.isRequired
   }
 
   componentDidMount () {
@@ -25,13 +23,13 @@ class DonateDialog extends React.PureComponent {
   onClickDonateButton = (event) => {
     trackEvent('Interaction', 'Clicked donate button', null, null, false)
     this.setSettingsDonateDismissed(true)
-    this.props.clearDialogs()
+    this.props.closeDialog()
   }
 
   onClickClose = (event) => {
     trackEvent('Interaction', 'Clicked close donate dialog link', null, null, false)
     this.setSettingsDonateDelayed(true)
-    this.props.clearDialogs()
+    this.props.closeDialog()
   }
 
   setSettingsDonateDismissed (value = true) {
@@ -71,11 +69,3 @@ class DonateDialog extends React.PureComponent {
     )
   }
 }
-
-function mapDispatchToProps (dispatch) {
-  return {
-    clearDialogs: () => { dispatch(clearDialogs()) }
-  }
-}
-
-export default connect(null, mapDispatchToProps)(DonateDialog)

--- a/assets/scripts/dialogs/FeatureFlagDialog.jsx
+++ b/assets/scripts/dialogs/FeatureFlagDialog.jsx
@@ -59,7 +59,7 @@ class FeatureFlagDialog extends React.Component {
 
   render () {
     return (
-      <React.Fragment>
+      <div className="feature-flag-dialog">
         <h1>Feature flags</h1>
 
         <table>
@@ -73,7 +73,7 @@ class FeatureFlagDialog extends React.Component {
             Close
           </button>
         </p>
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/assets/scripts/dialogs/FeatureFlagDialog.jsx
+++ b/assets/scripts/dialogs/FeatureFlagDialog.jsx
@@ -24,6 +24,10 @@ class FeatureFlagDialog extends React.Component {
       const deets = item[1]
       const htmlLabel = `feature-flag__input--${id.toLowerCase().replace(/_/g, '-')}`
       const labelClassNames = []
+
+      // Bail if a defined flag is not in the store (e.g. in tests with mock stores)
+      if (!this.props.flags[id]) return
+
       const isNotDefault = deets.defaultValue !== this.props.flags[id].value
 
       if (deets.disabled) {

--- a/assets/scripts/dialogs/FeatureFlagDialog.jsx
+++ b/assets/scripts/dialogs/FeatureFlagDialog.jsx
@@ -2,13 +2,11 @@
  * Feature flags (dialog box)
  *
  * Secret menu.
- * Instantiates an instance of Dialog
  *
  */
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import Dialog from './Dialog'
 import { FEATURE_FLAGS } from '../app/flag_data'
 import { setFeatureFlag } from '../store/actions/flags'
 import { clearDialogs } from '../store/actions/dialogs'
@@ -58,7 +56,7 @@ class FeatureFlagDialog extends React.Component {
 
   render () {
     return (
-      <Dialog className="feature-flag-dialog">
+      <React.Fragment>
         <h1>Feature flags</h1>
 
         <table>
@@ -72,7 +70,7 @@ class FeatureFlagDialog extends React.Component {
             Close
           </button>
         </p>
-      </Dialog>
+      </React.Fragment>
     )
   }
 }

--- a/assets/scripts/dialogs/FeatureFlagDialog.jsx
+++ b/assets/scripts/dialogs/FeatureFlagDialog.jsx
@@ -9,13 +9,12 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FEATURE_FLAGS } from '../app/flag_data'
 import { setFeatureFlag } from '../store/actions/flags'
-import { clearDialogs } from '../store/actions/dialogs'
 
 class FeatureFlagDialog extends React.Component {
   static propTypes = {
     flags: PropTypes.object.isRequired,
     setFeatureFlag: PropTypes.func.isRequired,
-    clearDialogs: PropTypes.func.isRequired
+    closeDialog: PropTypes.func.isRequired
   }
 
   renderFlagList = () => {
@@ -70,7 +69,7 @@ class FeatureFlagDialog extends React.Component {
         </table>
 
         <p>
-          <button onClick={this.props.clearDialogs}>
+          <button onClick={this.props.closeDialog}>
             Close
           </button>
         </p>
@@ -87,8 +86,7 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    setFeatureFlag: (flag, value) => { dispatch(setFeatureFlag(flag, value)) },
-    clearDialogs: () => { dispatch(clearDialogs()) }
+    setFeatureFlag: (flag, value) => { dispatch(setFeatureFlag(flag, value)) }
   }
 }
 

--- a/assets/scripts/dialogs/GeolocateDialog.jsx
+++ b/assets/scripts/dialogs/GeolocateDialog.jsx
@@ -243,7 +243,7 @@ class GeolocateDialog extends React.Component {
     const tileUrl = (window.devicePixelRatio > 1) ? MAP_TILES_2X : MAP_TILES
 
     return (
-      <React.Fragment>
+      <div className="geolocate-dialog">
         <div className="geolocate-input-container">
           <SearchAddress setSearchResults={this.setSearchResults} />
         </div>
@@ -266,7 +266,7 @@ class GeolocateDialog extends React.Component {
           {popup}
           {markers}
         </Map>
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/assets/scripts/dialogs/GeolocateDialog.jsx
+++ b/assets/scripts/dialogs/GeolocateDialog.jsx
@@ -17,8 +17,7 @@ const REVERSE_GEOCODE_ENDPOINT = `${REVERSE_GEOCODE_API}?api_key=${PELIAS_API_KE
 const MAP_TILES = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png'
 const MAP_TILES_2X = 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png'
 const MAP_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="https://carto.com/attribution">CARTO</a>'
-
-const zoomLevel = 12
+const MAP_INITIAL_ZOOM = 12
 
 /* Override icon paths in stock Leaflet's stylesheet */
 delete L.Icon.Default.prototype._getIconUrl
@@ -252,7 +251,7 @@ class GeolocateDialog extends React.Component {
         <Map
           center={this.state.mapCenter}
           zoomControl={false}
-          zoom={zoomLevel}
+          zoom={MAP_INITIAL_ZOOM}
           onClick={this.onClickMap}
           useFlyTo
           ref={(ref) => { this.map = ref }}

--- a/assets/scripts/dialogs/GeolocateDialog.jsx
+++ b/assets/scripts/dialogs/GeolocateDialog.jsx
@@ -9,7 +9,6 @@ import SearchAddress from '../streets/SearchAddress'
 import { getRemixOnFirstEdit } from '../streets/remix'
 import { setMapState } from '../store/actions/map'
 import { addLocation, saveStreetName } from '../store/actions/street'
-import { clearDialogs } from '../store/actions/dialogs'
 import { t } from '../app/locale'
 
 const REVERSE_GEOCODE_API = `https://${PELIAS_HOST_NAME}/v1/reverse`
@@ -46,7 +45,7 @@ class GeolocateDialog extends React.Component {
     addressInformationLabel: PropTypes.string,
     street: PropTypes.object,
     saveStreetName: PropTypes.func,
-    clearDialogs: PropTypes.func
+    closeDialog: PropTypes.func
   }
 
   constructor (props) {
@@ -189,7 +188,7 @@ class GeolocateDialog extends React.Component {
 
     this.props.addLocation(location)
     this.props.saveStreetName(location.hierarchy.street, false)
-    this.props.clearDialogs()
+    this.props.closeDialog()
   }
 
   // If addressInformation does not have a street, return false
@@ -286,8 +285,7 @@ function mapDispatchToProps (dispatch) {
   return {
     setMapState: (...args) => { dispatch(setMapState(...args)) },
     addLocation: (...args) => { dispatch(addLocation(...args)) },
-    saveStreetName: (...args) => { dispatch(saveStreetName(...args)) },
-    clearDialogs: () => { dispatch(clearDialogs()) }
+    saveStreetName: (...args) => { dispatch(saveStreetName(...args)) }
   }
 }
 

--- a/assets/scripts/dialogs/GeolocateDialog.jsx
+++ b/assets/scripts/dialogs/GeolocateDialog.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux'
 import { Map, TileLayer, ZoomControl, Marker, Popup } from 'react-leaflet'
 import * as sharedstreets from 'sharedstreets'
 import { PELIAS_HOST_NAME, PELIAS_API_KEY } from '../app/config'
-import Dialog from './Dialog'
 import SearchAddress from '../streets/SearchAddress'
 import { getRemixOnFirstEdit } from '../streets/remix'
 import { setMapState } from '../store/actions/map'
@@ -246,7 +245,7 @@ class GeolocateDialog extends React.Component {
     const tileUrl = (window.devicePixelRatio > 1) ? MAP_TILES_2X : MAP_TILES
 
     return (
-      <Dialog className="geolocate-dialog">
+      <React.Fragment>
         <div className="geolocate-input-container">
           <SearchAddress setSearchResults={this.setSearchResults} />
         </div>
@@ -269,7 +268,7 @@ class GeolocateDialog extends React.Component {
           {popup}
           {markers}
         </Map>
-      </Dialog>
+      </React.Fragment>
     )
   }
 }

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -2,14 +2,12 @@
  * Save as Image (dialog box)
  *
  * Handles interaction on the "Save as image" dialog box.
- * Instantiates an instance of Dialog
  *
  */
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { isEqual } from 'lodash'
-import Dialog from './Dialog'
 import { trackEvent } from '../app/event_tracking'
 import { getStreetImage } from '../streets/image'
 import { setSettings } from '../store/actions/settings'
@@ -133,7 +131,7 @@ class SaveAsImageDialog extends React.Component {
 
   render () {
     return (
-      <Dialog className="save-as-image-dialog">
+      <React.Fragment>
         <h1>{t('dialogs.save.heading', 'Save as image')}</h1>
         <p>
           <input
@@ -206,7 +204,7 @@ class SaveAsImageDialog extends React.Component {
           </a>
         </p>
         <footer dangerouslySetInnerHTML={{ __html: t('dialogs.save.license', 'This Streetmix-created image may be reused anywhere, for any purpose, under the<br /><a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.') }} />
-      </Dialog>
+      </React.Fragment>
     )
   }
 }

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -131,7 +131,7 @@ class SaveAsImageDialog extends React.Component {
 
   render () {
     return (
-      <React.Fragment>
+      <div className="save-as-image-dialog">
         <h1>{t('dialogs.save.heading', 'Save as image')}</h1>
         <p>
           <input
@@ -204,7 +204,7 @@ class SaveAsImageDialog extends React.Component {
           </a>
         </p>
         <footer dangerouslySetInnerHTML={{ __html: t('dialogs.save.license', 'This Streetmix-created image may be reused anywhere, for any purpose, under the<br /><a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.') }} />
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/assets/scripts/dialogs/__tests__/AboutDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/AboutDialog.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import React from 'react'
+import AboutDialog from '../AboutDialog'
+import { shallow } from 'enzyme'
+
+describe('AboutDialog', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<AboutDialog />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/dialogs/__tests__/Dialog.test.js
+++ b/assets/scripts/dialogs/__tests__/Dialog.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+import React from 'react'
+import Dialog from '../Dialog'
+import { shallow } from 'enzyme'
+
+describe('Dialog', () => {
+  it('renders without crashing', () => {
+    const Contents = 'foo'
+    const wrapper = shallow(
+      <Dialog closeDialog={jest.fn()}><Contents /></Dialog>
+    )
+    expect(wrapper.exists()).toEqual(true)
+  })
+
+  it('listens for "escape" key when mounted')
+  it('removes listener for "escape" key when unmounted')
+  it('closes the dialog box when "escape" is pressed')
+  it('closes the dialog when the background shield is clicked')
+  it('does not close the dialog when the background shield is clicked, when `disableShieldExit` is `true`')
+  it('closes the dialog when the background shield is clicked, when error state is true, even if `disableShieldExit` is `true`')
+  it('catches an error in child components and handles it')
+  it('closes the dialog box when the "x" button is pressed')
+  it('passes the closeDialog function to the child component')
+})

--- a/assets/scripts/dialogs/__tests__/DonateDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/DonateDialog.test.js
@@ -5,11 +5,7 @@ import { shallow } from 'enzyme'
 
 describe('DonateDialog', () => {
   it('renders without crashing', () => {
-    const wrapper = shallow(
-      <DonateDialog.WrappedComponent
-        clearDialogs={jest.fn()}
-      />
-    )
+    const wrapper = shallow(<DonateDialog closeDialog={jest.fn()} />)
     expect(wrapper.exists()).toEqual(true)
   })
 })

--- a/assets/scripts/dialogs/__tests__/DonateDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/DonateDialog.test.js
@@ -1,0 +1,15 @@
+/* eslint-env jest */
+import React from 'react'
+import DonateDialog from '../DonateDialog'
+import { shallow } from 'enzyme'
+
+describe('DonateDialog', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(
+      <DonateDialog.WrappedComponent
+        clearDialogs={jest.fn()}
+      />
+    )
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/dialogs/__tests__/FeatureFlagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/FeatureFlagDialog.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import React from 'react'
+import FeatureFlagDialog from '../FeatureFlagDialog'
+import { shallow } from 'enzyme'
+
+describe('FeatureFlagDialog', () => {
+  it('renders without crashing', () => {
+    const props = {
+      flags: {}
+    }
+    const wrapper = shallow(
+      <FeatureFlagDialog.WrappedComponent
+        {...props}
+        setFeatureFlag={jest.fn()}
+        clearDialogs={jest.fn()}
+        flags={{}}
+      />
+    )
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/dialogs/__tests__/FeatureFlagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/FeatureFlagDialog.test.js
@@ -18,4 +18,11 @@ describe('FeatureFlagDialog', () => {
     )
     expect(wrapper.exists()).toEqual(true)
   })
+
+  it('renders a list of flags and values from state')
+  it('renders a disabled flag')
+  it('renders a flag whose value differs from the default value')
+  it('sets a feature flag when the checkbox is clicked')
+  it('sets a feature flag when the label is clicked')
+  it('closes the dialog when "Close" button is clicked')
 })

--- a/assets/scripts/dialogs/__tests__/FeatureFlagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/FeatureFlagDialog.test.js
@@ -12,7 +12,7 @@ describe('FeatureFlagDialog', () => {
       <FeatureFlagDialog.WrappedComponent
         {...props}
         setFeatureFlag={jest.fn()}
-        clearDialogs={jest.fn()}
+        closeDialog={jest.fn()}
         flags={{}}
       />
     )

--- a/assets/scripts/dialogs/__tests__/GeolocateDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeolocateDialog.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import React from 'react'
+import GeolocateDialog from '../GeolocateDialog'
+import { shallow } from 'enzyme'
+
+// Mock dependencies that could break tests
+jest.mock('../../streets/remix', () => {})
+
+describe('GeolocateDialog', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(
+      <GeolocateDialog.WrappedComponent
+        street={{}}
+        addressInformation={{}}
+      />
+    )
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/dialogs/__tests__/GeolocateDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeolocateDialog.test.js
@@ -16,4 +16,11 @@ describe('GeolocateDialog', () => {
     )
     expect(wrapper.exists()).toEqual(true)
   })
+
+  it('does not allow a location to be confirmed when geocoded data does not have street data')
+  it('allows a location to be confirmed when the current signed-in user is the street owner')
+  it('allows a location to be confirmed when the current anonymous user started this street')
+  it('does not allow a location to be confirmed when the current signed-in user is not the street owner')
+  it('does not allow a location to be confirmed when the current anonymous user is not the street owner and there is already an existing location attached')
+  it('allows a location to be confirmed when the current anonymous user is not the street owner but there is no existing location attached')
 })

--- a/assets/scripts/dialogs/__tests__/SaveAsImageDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/SaveAsImageDialog.test.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+import React from 'react'
+import SaveAsImageDialog from '../SaveAsImageDialog'
+import { shallow } from 'enzyme'
+
+// Mock dependencies that could break tests
+jest.mock('../../streets/image', () => {
+  return {
+    getStreetImage: () => {}
+  }
+})
+jest.mock('../../users/settings', () => {})
+
+describe('SaveAsImageDialog', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(
+      <SaveAsImageDialog.WrappedComponent
+        transparentSky={false}
+        segmentNames={false}
+        streetName={false}
+        street={{}}
+      />
+    )
+    expect(wrapper.exists()).toEqual(true)
+  })
+})


### PR DESCRIPTION
With React 16's implementation of [error boundaries](https://reactjs.org/docs/error-boundaries.html), it would be really helpful to set an error boundary on the `Dialog` component so that if the contents of the Dialog throws an error, it will crash the dialog rather than crashing the entire app. However, this was not possible because error boundaries can only catch errors in components below them in the tree, which means `<Dialog>` must be a parent component of each dialog, rather than a child component.

This PR refactors the dialog system such that `<Dialog>` is a parent component for each dialog, which makes error boundaries work.

Additionally, individual dialog components should no longer call `clearDialogs()` because this made each dialog box aware of the dialog box system. Instead, each dialog is now passed a prop `.closeDialog()`, provided by the parent `<Dialog>` component, that a dialog can call to close itself.