### PR TITLE
StreetMetaData: remove deprecated <u> element

### DIFF
--- a/assets/css/_street-metadata.scss
+++ b/assets/css/_street-metadata.scss
@@ -70,3 +70,7 @@ body.read-only .street-metadata-author a {
   color: darken($ui-colour, 40%);
   margin: 0 4px;
 }
+
+.street-metadata-map a {
+  text-decoration: underline;
+}

--- a/assets/scripts/streets/StreetMetaData.jsx
+++ b/assets/scripts/streets/StreetMetaData.jsx
@@ -116,9 +116,9 @@ class StreetMetaData extends React.Component {
     }
 
     const geolocation = (this.props.enableLocation) ? (
-      <span>
-        <a className="street-metadata-map" onClick={this.onClickGeolocate}>
-          <u>{geolocationText}</u>
+      <span className="street-metadata-map">
+        <a onClick={this.onClickGeolocate}>
+          {geolocationText}
         </a>
       </span>
     ) : null


### PR DESCRIPTION
Small tweak to the location link to remove the `<u>` element which has [technically been deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u). Instead we follow the newer HTML5 guidance for underlining (e.g. links):

> To apply an underlined appearance without any semantic meaning, use the text-decoration property's value "underline".