### PR TITLE
Fix waffle.io broken image link, resolves #816

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ are similar ones may be closed.
 
 ## Code contributions
 
-[![Waffle.io stories in Ready](https://badge.waffle.io/streetmix/streetmix.png?label=ready&title=Issues ready)](https://waffle.io/streetmix/streetmix)
+[![Waffle.io stories in Ready](https://badge.waffle.io/streetmix/streetmix.png?label=ready&style=flat-square)](https://waffle.io/streetmix/streetmix)
 
 If you have the capacity to write code, and wish to contribute to
 Streetmix, we'd love your help!


### PR DESCRIPTION
This pull request updates the link definition so that it now works as suggested on #816.