### PR TITLE
Use react-intl library for some translations

### DIFF
--- a/assets/css/_menu-bar.scss
+++ b/assets/css/_menu-bar.scss
@@ -75,8 +75,7 @@ $top-menu-active-text: darken($ui-colour, 40%);
     @include tap-highlight-color(transparent);
 
     border: 0;
-    padding: 10px;
-    margin: -10px;
+    padding: 0;
     font-size: inherit;
     font-weight: inherit;
     text-rendering: optimizeLegibility;

--- a/assets/css/_menu-bar.scss
+++ b/assets/css/_menu-bar.scss
@@ -40,19 +40,14 @@ $top-menu-active-text: darken($ui-colour, 40%);
   li {
     display: inline-block;
     white-space: nowrap;
+  }
 
-    // Dot separator between menu items
-    &::after {
+  // Dot separator between menu items
+  li + li {
+    &::before {
       content: '·';
       margin-left: 0.5em;
       margin-right: 0.5em;
-    }
-
-    // No dot separator on the last menu item
-    &:last-child::after {
-      content: '';
-      margin-left: 0;
-      margin-right: 0;
     }
   }
 

--- a/assets/css/_no-internet.scss
+++ b/assets/css/_no-internet.scss
@@ -24,10 +24,6 @@ body.no-internet {
     display: none;
   }
 
-  .hide-for-no-internet {
-    display: none;
-  }
-
   // Share menu
   .share-sign-in-promo,
   .share-via-link-container,

--- a/assets/css/_no-internet.scss
+++ b/assets/css/_no-internet.scss
@@ -28,11 +28,6 @@ body.no-internet {
     display: none;
   }
 
-  // Hiding menu items that should not exist
-  #help-menu-item::after {
-    content: '' !important;
-  }
-
   // Share menu
   .share-sign-in-promo,
   .share-via-link-container,

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -1,4 +1,7 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { IntlProvider } from 'react-intl'
 import MessageBar from './MessageBar'
 import MenusContainer from '../menus/MenusContainer'
 import StreetNameCanvas from '../streets/StreetNameCanvas'
@@ -17,7 +20,11 @@ import StreetView from './StreetView'
 import DebugHoverPolygon from '../info_bubble/DebugHoverPolygon'
 import PrintContainer from './PrintContainer'
 
-export default class App extends React.PureComponent {
+class App extends React.PureComponent {
+  static propTypes = {
+    locale: PropTypes.object
+  }
+
   render () {
     return (
       <React.Fragment>
@@ -31,7 +38,15 @@ export default class App extends React.PureComponent {
           <InfoBubble />
           <DebugHoverPolygon />
           <WelcomePanel />
-          <Palette />
+
+          <IntlProvider
+            locale={this.props.locale.locale}
+            key={this.props.locale.locale}
+            messages={this.props.locale.messages}
+          >
+            <Palette />
+          </IntlProvider>
+
           <DialogRoot />
           <StreetView />
           <StatusMessage />
@@ -45,3 +60,11 @@ export default class App extends React.PureComponent {
     )
   }
 }
+
+function mapStateToProps (state) {
+  return {
+    locale: state.locale
+  }
+}
+
+export default connect(mapStateToProps)(App)

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -33,7 +33,15 @@ class App extends React.PureComponent {
         <MessageBar />
         <div className="main-screen">
           <GalleryShield />
-          <MenusContainer />
+
+          <IntlProvider
+            locale={this.props.locale.locale}
+            key={`locale_${this.props.locale.locale}`}
+            messages={this.props.locale.messages}
+          >
+            <MenusContainer />
+          </IntlProvider>
+
           <StreetNameCanvas />
           <InfoBubble />
           <DebugHoverPolygon />

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -52,10 +52,12 @@ class App extends React.PureComponent {
             key={this.props.locale.locale}
             messages={this.props.locale.messages}
           >
-            <Palette />
+            <React.Fragment>
+              <Palette />
+              <DialogRoot />
+            </React.Fragment>
           </IntlProvider>
 
-          <DialogRoot />
           <StreetView />
           <StatusMessage />
           <NoConnectionMessage />

--- a/assets/scripts/app/Palette.jsx
+++ b/assets/scripts/app/Palette.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 import Scrollable from '../ui/Scrollable'
 import { connect } from 'react-redux'
-import { t } from '../app/locale'
 import { generateRandSeed } from '../util/random'
 import { getAllSegmentInfo } from '../segments/info'
 import { TILE_SIZE, getVariantInfoDimensions } from '../segments/view'
@@ -19,15 +19,10 @@ class Palette extends React.Component {
   }
 
   componentDidMount () {
-    // We have to run this after this event in order to give images time to load.
-    window.addEventListener('stmx:everything_loaded', (event) => {
-      this.adjustPaletteLayout()
-      window.addEventListener('stmx:language_changed', this.onLocaleChange)
-    })
+    this.adjustPaletteLayout()
   }
 
-  onLocaleChange = () => {
-    this.forceUpdate() // Forces translated text to re-render
+  componentDidUpdate () {
     this.adjustPaletteLayout()
   }
 
@@ -106,7 +101,7 @@ class Palette extends React.Component {
     return (
       <div className="palette-container">
         <div className="palette-trashcan">
-          {t('palette.remove', 'Drag here to remove')}
+          <FormattedMessage id="palette.remove" defaultMessage="Drag here to remove" />
         </div>
         <div className="palette-commands" ref={(ref) => { this.commandsEl = ref }}>
           <UndoRedo />

--- a/assets/scripts/app/UndoRedo.jsx
+++ b/assets/scripts/app/UndoRedo.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { IntlProvider, FormattedMessage } from 'react-intl'
 import { undo, redo, isUndoAvailable, isRedoAvailable } from '../streets/undo_stack'
-import { t } from '../app/locale'
 
 export class UndoRedo extends React.Component {
   static propTypes = {
-    undo: PropTypes.object
+    undo: PropTypes.object,
+    locale: PropTypes.object
   }
 
   constructor (props) {
@@ -30,17 +31,27 @@ export class UndoRedo extends React.Component {
 
   render () {
     return (
-      <React.Fragment>
-        <button onClick={undo} disabled={!this.state.undoAvailable}>{t('btn.undo', 'Undo')}</button>
-        <button onClick={redo} disabled={!this.state.redoAvailable}>{t('btn.redo', 'Redo')}</button>
-      </React.Fragment>
+      <IntlProvider
+        locale={this.props.locale.locale}
+        messages={this.props.locale.messages}
+      >
+        <React.Fragment>
+          <button onClick={undo} disabled={!this.state.undoAvailable}>
+            <FormattedMessage id="btn.undo" defaultMessage="Undo" />
+          </button>
+          <button onClick={redo} disabled={!this.state.redoAvailable}>
+            <FormattedMessage id="btn.redo" defaultMessage="Redo" />
+          </button>
+        </React.Fragment>
+      </IntlProvider>
     )
   }
 }
 
 function mapStateToProps (state) {
   return {
-    undo: state.undo
+    undo: state.undo,
+    locale: state.locale
   }
 }
 

--- a/assets/scripts/app/UndoRedo.jsx
+++ b/assets/scripts/app/UndoRedo.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { IntlProvider, FormattedMessage } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import { undo, redo, isUndoAvailable, isRedoAvailable } from '../streets/undo_stack'
 
 export class UndoRedo extends React.Component {
   static propTypes = {
-    undo: PropTypes.object,
-    locale: PropTypes.object
+    undo: PropTypes.object
   }
 
   constructor (props) {
@@ -31,27 +30,21 @@ export class UndoRedo extends React.Component {
 
   render () {
     return (
-      <IntlProvider
-        locale={this.props.locale.locale}
-        messages={this.props.locale.messages}
-      >
-        <React.Fragment>
-          <button onClick={undo} disabled={!this.state.undoAvailable}>
-            <FormattedMessage id="btn.undo" defaultMessage="Undo" />
-          </button>
-          <button onClick={redo} disabled={!this.state.redoAvailable}>
-            <FormattedMessage id="btn.redo" defaultMessage="Redo" />
-          </button>
-        </React.Fragment>
-      </IntlProvider>
+      <React.Fragment>
+        <button onClick={undo} disabled={!this.state.undoAvailable}>
+          <FormattedMessage id="btn.undo" defaultMessage="Undo" />
+        </button>
+        <button onClick={redo} disabled={!this.state.redoAvailable}>
+          <FormattedMessage id="btn.redo" defaultMessage="Redo" />
+        </button>
+      </React.Fragment>
     )
   }
 }
 
 function mapStateToProps (state) {
   return {
-    undo: state.undo,
-    locale: state.locale
+    undo: state.undo
   }
 }
 

--- a/assets/scripts/app/__tests__/UndoRedo.test.js
+++ b/assets/scripts/app/__tests__/UndoRedo.test.js
@@ -8,7 +8,7 @@ jest.mock('../../streets/undo_stack')
 
 describe('UndoRedo', () => {
   it('renders two buttons', () => {
-    const wrapper = shallow(<UndoRedo />)
+    const wrapper = shallow(<UndoRedo locale={{}} />)
     expect(wrapper.find('button').length).toEqual(2)
   })
 

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -23,6 +23,7 @@ import { resizeStreetWidth } from '../streets/width'
 import { loadSignIn } from '../users/authentication'
 import { updateSettingsFromCountryCode } from '../users/localization'
 import { detectGeolocation } from '../users/geolocation'
+import { initPersistedSettingsStoreObserver } from '../users/settings'
 import { addEventListeners } from './event_listeners'
 import { trackEvent } from './event_tracking'
 import { getMode, setMode, MODES, processMode } from './mode'
@@ -140,6 +141,7 @@ function onEverythingLoaded () {
   setLastStreet(trimStreetData(getStreet()))
   initStreetReduxTransitionSubscriber()
   initializeFlagSubscribers()
+  initPersistedSettingsStoreObserver()
 
   updatePageUrl()
   addEventListeners()

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -15,12 +15,13 @@ import { setLocale as storeLocale } from '../store/actions/locale'
 import es from 'react-intl/locale-data/es'
 import de from 'react-intl/locale-data/de'
 import fi from 'react-intl/locale-data/fi'
+import fr from 'react-intl/locale-data/fr'
 import pl from 'react-intl/locale-data/pl'
 import pt from 'react-intl/locale-data/pt'
 import zh from 'react-intl/locale-data/zh'
 
 // Add react-intl locale data
-addLocaleData([...es, ...de, ...fi, ...pl, ...pt, ...zh])
+addLocaleData([...es, ...de, ...fi, ...fr, ...pl, ...pt, ...zh])
 
 // Default language is set by browser, or is English if undetermined
 const defaultLocale = navigator.language || 'en'
@@ -87,9 +88,6 @@ function doTheI18n (locale) {
 
     // Set the thing in Redux
     store.dispatch(storeLocale(locale, i18next.getResourceBundle(locale, 'main')))
-
-    // Some parts of the UI need to know language has changed
-    window.dispatchEvent(new window.CustomEvent('stmx:language_changed'))
   }
 
   i18next

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -7,6 +7,8 @@ import i18next from 'i18next'
 import i18nextXhr from 'i18next-xhr-backend'
 import { supplant } from '../util/helpers'
 import { API_URL } from './config'
+import store from '../store'
+import { setLocale as storeLocale } from '../store/actions/locale'
 
 // Default language is set by browser, or is English if undetermined
 const defaultLocale = navigator.language || 'en'
@@ -70,6 +72,9 @@ function doTheI18n (locale) {
       }
       els[i].textContent = translation
     }
+
+    // Set the thing in Redux
+    store.dispatch(storeLocale(locale, i18next.getResourceBundle(locale, 'main')))
 
     // Some parts of the UI need to know language has changed
     window.dispatchEvent(new window.CustomEvent('stmx:language_changed'))

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -3,12 +3,24 @@
  * handles internationalization (i18n)
  *
  */
+import { addLocaleData } from 'react-intl'
 import i18next from 'i18next'
 import i18nextXhr from 'i18next-xhr-backend'
 import { supplant } from '../util/helpers'
 import { API_URL } from './config'
 import store from '../store'
 import { setLocale as storeLocale } from '../store/actions/locale'
+
+// Add react-intl files for all the languages we support (added manually for now)
+import es from 'react-intl/locale-data/es'
+import de from 'react-intl/locale-data/de'
+import fi from 'react-intl/locale-data/fi'
+import pl from 'react-intl/locale-data/pl'
+import pt from 'react-intl/locale-data/pt'
+import zh from 'react-intl/locale-data/zh'
+
+// Add react-intl locale data
+addLocaleData([...es, ...de, ...fi, ...pl, ...pt, ...zh])
 
 // Default language is set by browser, or is English if undetermined
 const defaultLocale = navigator.language || 'en'

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -18,10 +18,11 @@ import fi from 'react-intl/locale-data/fi'
 import fr from 'react-intl/locale-data/fr'
 import pl from 'react-intl/locale-data/pl'
 import pt from 'react-intl/locale-data/pt'
+import sv from 'react-intl/locale-data/sv'
 import zh from 'react-intl/locale-data/zh'
 
 // Add react-intl locale data
-addLocaleData([...es, ...de, ...fi, ...fr, ...pl, ...pt, ...zh])
+addLocaleData([...es, ...de, ...fi, ...fr, ...pl, ...pt, ...sv, ...zh])
 
 // Default language is set by browser, or is English if undetermined
 const defaultLocale = navigator.language || 'en'

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -44,7 +44,11 @@ export function onNewLocaleSelected (event) {
 }
 
 export function getLocale () {
-  return window.localStorage.getItem('locale') || defaultLocale
+  try {
+    return JSON.parse(window.localStorage.getItem('locale')) || defaultLocale
+  } catch (err) {
+    return defaultLocale
+  }
 }
 
 function doTheI18n (locale) {
@@ -66,6 +70,7 @@ function doTheI18n (locale) {
   const callback = function (err, t) {
     if (err) {
       console.log(err)
+      return
     }
     const els = document.querySelectorAll('[data-i18n]')
     for (let i = 0, j = els.length; i < j; i++) {

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -24,14 +24,19 @@ import zh from 'react-intl/locale-data/zh'
 // Add react-intl locale data
 addLocaleData([...es, ...de, ...fi, ...fr, ...pl, ...pt, ...sv, ...zh])
 
-// Default language is set by browser, or is English if undetermined
-const defaultLocale = navigator.language || 'en'
-
 export function initLocale (experimental) {
   // Current language is the one set by Streetmix or is the browser default, if unset
   let locale
+
   if (experimental) {
-    locale = getLocale()
+    // Default language is set by browser, or is English if undetermined
+    const defaultLocale = navigator.language || 'en'
+
+    try {
+      locale = JSON.parse(window.localStorage.getItem('locale')) || defaultLocale
+    } catch (err) {
+      locale = defaultLocale
+    }
   } else {
     locale = 'en'
   }
@@ -44,11 +49,7 @@ export function onNewLocaleSelected (event) {
 }
 
 export function getLocale () {
-  try {
-    return JSON.parse(window.localStorage.getItem('locale')) || defaultLocale
-  } catch (err) {
-    return defaultLocale
-  }
+  return store.getState().locale.locale
 }
 
 function doTheI18n (locale) {

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -9,7 +9,7 @@ import i18nextXhr from 'i18next-xhr-backend'
 import { supplant } from '../util/helpers'
 import { API_URL } from './config'
 import store from '../store'
-import { setLocale as storeLocale } from '../store/actions/locale'
+import { setLocale } from '../store/actions/locale'
 
 // Add react-intl files for all the languages we support (added manually for now)
 import es from 'react-intl/locale-data/es'
@@ -40,21 +40,11 @@ export function initLocale (experimental) {
 }
 
 export function onNewLocaleSelected (event) {
-  setLocale(event.target.value)
+  doTheI18n(event.target.value)
 }
 
 export function getLocale () {
   return window.localStorage.getItem('locale') || defaultLocale
-}
-
-export function setLocale (locale) {
-  window.localStorage.setItem('locale', locale)
-  doTheI18n(locale)
-}
-
-export function clearLocale () {
-  window.localStorage.removeItem('locale')
-// TODO: clear language cache here if it's activated
 }
 
 function doTheI18n (locale) {
@@ -88,7 +78,7 @@ function doTheI18n (locale) {
     }
 
     // Set the thing in Redux
-    store.dispatch(storeLocale(locale, i18next.getResourceBundle(locale, 'main')))
+    store.dispatch(setLocale(locale, i18next.getResourceBundle(locale, 'main')))
   }
 
   i18next

--- a/assets/scripts/dialogs/AboutDialog.jsx
+++ b/assets/scripts/dialogs/AboutDialog.jsx
@@ -5,9 +5,9 @@
  *
  */
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import Avatar from '../users/Avatar'
 import { trackEvent } from '../app/event_tracking'
-import { t } from '../app/locale'
 
 export default class AboutDialog extends React.PureComponent {
   componentDidMount () {
@@ -17,13 +17,13 @@ export default class AboutDialog extends React.PureComponent {
   render () {
     return (
       <div className="about-dialog">
-        <h1>{t('dialogs.about.heading', 'About Streetmix.')}</h1>
+        <h1><FormattedMessage id="dialogs.about.heading" defaultMessage="About Streetmix." /></h1>
         <div className="about-dialog-left">
           <p className="about-dialog-description">
-            {t('dialogs.about.description', 'Design, remix, and share your street. Add bike paths, widen sidewalks or traffic lanes, learn how all of this can impact your community.')}
+            <FormattedMessage id="dialogs.about.description" defaultMessage="Design, remix, and share your street. Add bike paths, widen sidewalks or traffic lanes, learn how all of this can impact your community." />
           </p>
           <p className="about-dialog-description">
-            {t('dialogs.about.sponsored-by', 'Streetmix is generously sponsored by:')}
+            <FormattedMessage id="dialogs.about.sponsored-by" defaultMessage="Streetmix is generously sponsored by:" />
           </p>
           <ul className="about-dialog-sponsors">
             <li>
@@ -38,11 +38,13 @@ export default class AboutDialog extends React.PureComponent {
             </li>
           </ul>
           <p>
-            <a href="https://opencollective.com/streetmix/" target="_blank">{t('dialogs.about.donate-link', 'Support us financially')}</a>
+            <a href="https://opencollective.com/streetmix/" target="_blank">
+              <FormattedMessage id="dialogs.about.donate-link" defaultMessage="Support us financially" />
+            </a>
           </p>
         </div>
         <div className="about-dialog-right">
-          <h3>{t('dialogs.about.team-heading', 'Project team and maintainers')}</h3>
+          <h3><FormattedMessage id="dialogs.about.team-heading" defaultMessage="Project team and maintainers" /></h3>
           <ul className="about-dialog-team">
             <li>
               <a target="_blank" href="https://twitter.com/anselmbradford"><Avatar userId="anselmbradford" />Anselm Bradford</a> · media production
@@ -68,7 +70,9 @@ export default class AboutDialog extends React.PureComponent {
           </ul>
 
           <p>
-            <a href="https://github.com/streetmix/streetmix/blob/master/CONTRIBUTING.md" target="_blank">{t('dialogs.about.github-link', 'Contribute to open source')}</a>
+            <a href="https://github.com/streetmix/streetmix/blob/master/CONTRIBUTING.md" target="_blank">
+              <FormattedMessage id="dialogs.about.github-link" defaultMessage="Contribute to open source" />
+            </a>
           </p>
         </div>
       </div>

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -6,11 +6,12 @@
  */
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage, FormattedHTMLMessage, injectIntl, intlShape } from 'react-intl'
 import { registerKeypress, deregisterKeypress } from '../app/keypress'
-import { t } from '../app/locale'
 
-export default class Dialog extends React.PureComponent {
+export class Dialog extends React.PureComponent {
   static propTypes = {
+    intl: intlShape.isRequired,
     closeDialog: PropTypes.func.isRequired,
     children: PropTypes.node.isRequired,
     disableShieldExit: PropTypes.bool
@@ -55,18 +56,20 @@ export default class Dialog extends React.PureComponent {
       shieldClassName += ' dialog-box-shield-unclickable'
     }
 
+    const closeLabel = this.props.intl.formatMessage({ id: 'btn.close', defaultMessage: 'Close' })
+
     return (
       <div className="dialog-box-container" ref={(ref) => { this.dialogEl = ref }}>
         <div className={shieldClassName} onClick={this.onClickShield} />
         {this.state.error ? (
           <div className="dialog-box dialog-error">
-            <h1>{t('dialogs.error.heading', 'Oops!')}</h1>
+            <h1><FormattedMessage id="dialogs.error.heading" defaultMessage="Oops!" /></h1>
             <p>
-              {t('dialogs.error.text', 'Something unexpected happened 😢, please try again.')}
+              <FormattedHTMLMessage id="dialogs.error.text" defaultMessage="Something unexpected happened 😢, please try again." />
             </p>
             <p style={{ textAlign: 'center' }}>
-              <button onClick={this.props.closeDialog} title={t('btn.close', 'Close')}>
-                {t('btn.close', 'Close')}
+              <button onClick={this.props.closeDialog} title={closeLabel}>
+                <FormattedMessage id="btn.close" defaultMessage="Close" />
               </button>
             </p>
           </div>
@@ -75,7 +78,7 @@ export default class Dialog extends React.PureComponent {
             <button
               className="close"
               onClick={this.props.closeDialog}
-              title={t('btn.close', 'Close')}
+              title={closeLabel}
             >
               ×
             </button>
@@ -86,3 +89,5 @@ export default class Dialog extends React.PureComponent {
     )
   }
 }
+
+export default injectIntl(Dialog)

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -7,18 +7,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FormattedMessage, FormattedHTMLMessage, injectIntl, intlShape } from 'react-intl'
 import { isEqual } from 'lodash'
 import { trackEvent } from '../app/event_tracking'
 import { getStreetImage } from '../streets/image'
 import { setSettings } from '../store/actions/settings'
 import { normalizeSlug } from '../util/helpers'
-import { t } from '../app/locale'
 
 // Require save-as polyfills
 import { saveAs } from 'file-saver'
 
-class SaveAsImageDialog extends React.Component {
+export class SaveAsImageDialog extends React.Component {
   static propTypes = {
+    intl: intlShape,
     transparentSky: PropTypes.bool.isRequired,
     segmentNames: PropTypes.bool.isRequired,
     streetName: PropTypes.bool.isRequired,
@@ -81,7 +82,10 @@ class SaveAsImageDialog extends React.Component {
   onPreviewError = () => {
     this.setState({
       isLoading: false,
-      errorMessage: t('dialogs.save.error-preview', 'There was an error displaying a preview image.')
+      errorMessage: this.props.intl.formatMessage({
+        id: 'dialogs.save.error-preview',
+        defaultMessage: 'There was an error displaying a preview image.'
+      })
     })
   }
 
@@ -114,7 +118,10 @@ class SaveAsImageDialog extends React.Component {
       })
     } catch (e) {
       this.setState({
-        errorMessage: t('dialogs.save.error-unavailable', 'Saving to image is not available on this browser.')
+        errorMessage: this.props.intl.formatMessage({
+          id: 'dialogs.save.error-unavailable',
+          defaultMessage: 'Saving to image is not available on this browser.'
+        })
       })
     }
   }
@@ -132,7 +139,7 @@ class SaveAsImageDialog extends React.Component {
   render () {
     return (
       <div className="save-as-image-dialog">
-        <h1>{t('dialogs.save.heading', 'Save as image')}</h1>
+        <h1><FormattedMessage id="dialogs.save.heading" defaultMessage="Save as image" /></h1>
         <p>
           <input
             type="checkbox"
@@ -141,7 +148,7 @@ class SaveAsImageDialog extends React.Component {
             id="save-as-image-segment-names"
           />
           <label htmlFor="save-as-image-segment-names">
-            {t('dialogs.save.option-labels', 'Segment names and widths')}
+            <FormattedMessage id="dialogs.save.option-labels" defaultMessage="Segment names and widths" />
           </label>
 
           <input
@@ -151,7 +158,7 @@ class SaveAsImageDialog extends React.Component {
             id="save-as-image-street-name"
           />
           <label htmlFor="save-as-image-street-name">
-            {t('dialogs.save.option-name', 'Street name')}
+            <FormattedMessage id="dialogs.save.option-name" defaultMessage="Street name" />
           </label>
 
           <input
@@ -161,7 +168,7 @@ class SaveAsImageDialog extends React.Component {
             id="save-as-image-transparent-sky"
           />
           <label htmlFor="save-as-image-transparent-sky">
-            {t('dialogs.save.option-sky', 'Transparent sky')}
+            <FormattedMessage id="dialogs.save.option-sky" defaultMessage="Transparent sky" />
           </label>
         </p>
         {(() => {
@@ -177,14 +184,17 @@ class SaveAsImageDialog extends React.Component {
             return (
               <div className="save-as-image-preview">
                 <div className="save-as-image-preview-loading" style={{display: this.state.isLoading ? 'block' : 'none'}}>
-                  {t('dialogs.save.loading', 'Loading…')}
+                  <FormattedMessage id="dialogs.save.loading" defaultMessage="Loading…" />
                 </div>
                 <div className="save-as-image-preview-image" style={{display: this.state.isLoading ? 'none' : 'block'}}>
                   <img
                     src={this.state.download.dataUrl}
                     onLoad={this.onPreviewLoaded}
                     onError={this.onPreviewError}
-                    alt={t('dialogs.save.preview-image-alt', 'Preview')}
+                    alt={this.props.intl.formatMessage({
+                      id: 'dialogs.save.preview-image-alt',
+                      defaultMessage: 'Preview'
+                    })}
                   />
                 </div>
               </div>
@@ -199,11 +209,21 @@ class SaveAsImageDialog extends React.Component {
             // Note that this property is not supported in Safari/iOS
             download={this.state.download.filename}
             // Link should refer to data URL, even though onClickDownloadImage() is used for direct download
-            href={this.state.download.dataUrl}>
-            {t('dialogs.save.save-button', 'Save to your computer…')}
+            href={this.state.download.dataUrl}
+          >
+            <FormattedMessage id="dialogs.save.save-button" defaultMessage="Save to your computer…" />
           </a>
         </p>
-        <footer dangerouslySetInnerHTML={{ __html: t('dialogs.save.license', 'This Streetmix-created image may be reused anywhere, for any purpose, under the<br /><a href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.') }} />
+        <footer>
+          <FormattedHTMLMessage
+            id="dialogs.save.license"
+            defaultMessage="This Streetmix-created image may be reused anywhere, for any purpose, under the<br /><a href='{url}'>Creative Commons Attribution-ShareAlike 4.0 International License</a>."
+            values={{
+              // TODO: locale-specific license text, e.g. https://creativecommons.org/licenses/by-sa/4.0/deed.zh
+              url: 'https://creativecommons.org/licenses/by-sa/4.0/'
+            }}
+          />
+        </footer>
       </div>
     )
   }
@@ -225,4 +245,4 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SaveAsImageDialog)
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(SaveAsImageDialog))

--- a/assets/scripts/dialogs/__tests__/Dialog.test.js
+++ b/assets/scripts/dialogs/__tests__/Dialog.test.js
@@ -1,13 +1,14 @@
 /* eslint-env jest */
 import React from 'react'
-import Dialog from '../Dialog'
+import { Dialog } from '../Dialog'
 import { shallow } from 'enzyme'
+import { mockIntl } from '../../../../test/__mocks__/react-intl'
 
 describe('Dialog', () => {
   it('renders without crashing', () => {
     const Contents = 'foo'
     const wrapper = shallow(
-      <Dialog closeDialog={jest.fn()}><Contents /></Dialog>
+      <Dialog closeDialog={jest.fn()} intl={mockIntl}><Contents /></Dialog>
     )
     expect(wrapper.exists()).toEqual(true)
   })

--- a/assets/scripts/dialogs/__tests__/SaveAsImageDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/SaveAsImageDialog.test.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 import React from 'react'
-import SaveAsImageDialog from '../SaveAsImageDialog'
+import { SaveAsImageDialog } from '../SaveAsImageDialog'
 import { shallow } from 'enzyme'
+import { mockIntl } from '../../../../test/__mocks__/react-intl'
 
 // Mock dependencies that could break tests
 jest.mock('../../streets/image', () => {
@@ -14,11 +15,12 @@ jest.mock('../../users/settings', () => {})
 describe('SaveAsImageDialog', () => {
   it('renders without crashing', () => {
     const wrapper = shallow(
-      <SaveAsImageDialog.WrappedComponent
+      <SaveAsImageDialog
         transparentSky={false}
         segmentNames={false}
         streetName={false}
         street={{}}
+        intl={mockIntl}
       />
     )
     expect(wrapper.exists()).toEqual(true)

--- a/assets/scripts/menus/ContactMenu.jsx
+++ b/assets/scripts/menus/ContactMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import Menu from './Menu'
-import { t } from '../app/locale'
 
 export default class ContactMenu extends React.PureComponent {
   render () {
@@ -10,22 +10,22 @@ export default class ContactMenu extends React.PureComponent {
           <svg className="icon">
             <use xlinkHref="#icon-forums" />
           </svg>
-          <span>{t('menu.contact.forums', 'Discuss on the forums')}</span>
+          <FormattedMessage id="menu.contact.forums" defaultMessage="Discuss on the forums" />
         </a>
         <a href="https://twitter.com/intent/tweet?text=@streetmix" target="_blank">
           <svg className="icon">
             <use xlinkHref="#icon-twitter" />
           </svg>
-          <span>{t('menu.contact.twitter', 'Send a tweet to @streetmix')}</span>
+          <FormattedMessage id="menu.contact.twitter" defaultMessage="Send a tweet to @streetmix" />
         </a>
         <a href="http://streetmix-slack.herokuapp.com/" target="_blank">
           <svg className="icon">
             <use xlinkHref="#icon-slack" />
           </svg>
-          <span>{t('menu.contact.slack', 'Join Slack chat')}</span>
+          <FormattedMessage id="menu.contact.slack" defaultMessage="Join Slack chat" />
         </a>
         <a href="http://blog.streetmix.net" target="_blank">
-          <span>{t('menu.contact.blog', 'Visit Streetmix blog')}</span>
+          <FormattedMessage id="menu.contact.blog" defaultMessage="Visit Streetmix blog" />
         </a>
       </Menu>
     )

--- a/assets/scripts/menus/ContributeMenu.jsx
+++ b/assets/scripts/menus/ContributeMenu.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import Menu from './Menu'
 import { trackEvent } from '../app/event_tracking'
-import { t } from '../app/locale'
 
 export default class ContributeMenu extends React.PureComponent {
   onClickGitHub () {
@@ -23,14 +23,14 @@ export default class ContributeMenu extends React.PureComponent {
           <svg className="icon">
             <use xlinkHref="#icon-github" />
           </svg>
-          <span>{t('menu.contribute.opensource', 'Contribute to open source')}</span>
+          <FormattedMessage id="menu.contribute.opensource" defaultMessage="Contribute to open source" />
         </a>
         <a href="https://opencollective.com/streetmix/" target="_blank" onClick={this.onClickDonate}>
-          <span>{t('menu.contribute.donate', 'Donate')}</span>
+          <FormattedMessage id="menu.contribute.donate" defaultMessage="Donate" />
         </a>
         {/* Sticker link is broken
         <a href="https://www.stickermule.com/user/1069909781/stickers" target="_blank" onClick={this.onClickStickers}>
-          <span>{t('menu.contribute.stickers', 'Buy a sticker sheet!')}</span>
+          <FormattedMessage id="menu.contribute.stickers" defaultMessage="Buy a sticker sheet!" />
         </a> */}
       </Menu>
     )

--- a/assets/scripts/menus/EnvironmentBadge.jsx
+++ b/assets/scripts/menus/EnvironmentBadge.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { ENV } from '../app/config'
 
-class EnvironmentBadge extends React.PureComponent {
+export class EnvironmentBadge extends React.PureComponent {
   static propTypes = {
     label: PropTypes.string,
     noInternet: PropTypes.bool

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -1,28 +1,24 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl'
 import Menu from './Menu'
 import { registerKeypress } from '../app/keypress'
 import { trackEvent } from '../app/event_tracking'
-import { t } from '../app/locale'
 import { showDialog } from '../store/actions/dialogs'
 
-class HelpMenu extends React.PureComponent {
+export class HelpMenu extends React.PureComponent {
   static propTypes = {
     showDialog: PropTypes.func.isRequired
   }
 
   componentDidMount () {
-    // TODO: This does not really need to be here?
-    registerKeypress('?', { shiftKey: 'optional' }, this.onClickAbout)
+    // Set up keyboard shortcuts
+    registerKeypress('?', { shiftKey: 'optional' }, this.props.showDialog)
   }
 
   onShow () {
     trackEvent('Interaction', 'Open help menu', null, null, false)
-  }
-
-  onClickAbout = () => {
-    this.props.showDialog()
   }
 
   render () {
@@ -30,38 +26,51 @@ class HelpMenu extends React.PureComponent {
       <Menu onShow={this.onShow} {...this.props}>
         <a
           href="#"
-          onClick={this.onClickAbout}
+          onClick={this.props.showDialog}
         >
-          {t('menu.item.about', 'About Streetmix…')}
+          <FormattedMessage id="menu.item.about" defaultMessage="About Streetmix…" />
         </a>
 
         <div className="form non-touch-only help-menu-shortcuts">
           <p>
-            <span>
-              {t('menu.help.keyboard-label', 'Keyboard shortcuts:')}
-            </span>
+            <FormattedMessage id="menu.help.keyboard-label" defaultMessage="Keyboard shortcuts:" />
           </p>
           <table>
             <tbody>
               <tr>
                 <td>
-                  <kbd className="key">{t('key.backspace', 'Backspace')}</kbd>
+                  <kbd className="key"><FormattedMessage id="key.backspace" defaultMessage="Backspace" /></kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.remove', 'Remove a segment you’re pointing at<br />(hold <kbd class="key">Shift</kbd> to remove all)') }} />
+                <td>
+                  <FormattedHTMLMessage
+                    id="menu.help.remove"
+                    defaultMessage="Remove a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> to remove all)"
+                  />
+                </td>
               </tr>
               <tr>
                 <td>
                   <kbd className="key">-</kbd>
                   <kbd className="key">+</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.change', 'Move around the street<br />(hold <kbd class="key">Shift</kbd> to jump to edges)') }} />
+                <td>
+                  <FormattedHTMLMessage
+                    id="menu.help.change"
+                    defaultMessage="Move around the street<br />(hold <kbd class='key'>Shift</kbd> to jump to edges)"
+                  />
+                </td>
               </tr>
               <tr>
                 <td>
                   <kbd className="key">&larr;</kbd>
                   <kbd className="key">&rarr;</kbd>
                 </td>
-                <td dangerouslySetInnerHTML={{ __html: t('menu.help.move', 'Change width of a segment you’re pointing at<br />(hold <kbd class="key">Shift</kbd> for more precision)') }} />
+                <td>
+                  <FormattedHTMLMessage
+                    id="menu.help.move"
+                    defaultMessage="Change width of a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> for more precision)"
+                  />
+                </td>
               </tr>
             </tbody>
           </table>

--- a/assets/scripts/menus/IdentityMenu.jsx
+++ b/assets/scripts/menus/IdentityMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import Menu from './Menu'
-import { t } from '../app/locale'
 import { onSignOutClick } from '../users/authentication'
 
 export default class IdentityMenu extends React.PureComponent {
@@ -8,7 +8,7 @@ export default class IdentityMenu extends React.PureComponent {
     return (
       <Menu {...this.props}>
         <a href="#" onClick={onSignOutClick}>
-          {t('menu.item.sign-out', 'Sign out')}
+          <FormattedMessage id="menu.item.sign-out" defaultMessage="Sign out" />
         </a>
       </Menu>
     )

--- a/assets/scripts/menus/LocaleDropdown.jsx
+++ b/assets/scripts/menus/LocaleDropdown.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { t, getLocale, onNewLocaleSelected } from '../app/locale'
+import { t, onNewLocaleSelected } from '../app/locale'
 import { trackEvent } from '../app/event_tracking'
 
 /**
@@ -82,6 +82,7 @@ const LOCALES = [
 
 export class LocaleDropdown extends React.Component {
   static propTypes = {
+    locale: PropTypes.string,
     /* eslint-disable react/no-unused-prop-types */
     // These props _are_ used but linter can't tell
     level1: PropTypes.bool.isRequired,
@@ -107,7 +108,7 @@ export class LocaleDropdown extends React.Component {
   componentDidMount () {
     // Set the dropdown to the current language.
     // If current language is not in the list, fallback to US English.
-    this.localeSelect.value = getLocale()
+    this.localeSelect.value = this.props.locale.replace('-', '_')
     if (!this.localeSelect.value) {
       this.localeSelect.value = 'en'
     }
@@ -152,6 +153,7 @@ export class LocaleDropdown extends React.Component {
 
 function mapStateToProps (state) {
   return {
+    locale: state.locale.locale,
     level1: state.flags.LOCALES_LEVEL_1.value,
     level2: state.flags.LOCALES_LEVEL_2.value,
     level3: state.flags.LOCALES_LEVEL_3.value

--- a/assets/scripts/menus/LocaleDropdown.jsx
+++ b/assets/scripts/menus/LocaleDropdown.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { t, onNewLocaleSelected } from '../app/locale'
+import { injectIntl, intlShape } from 'react-intl'
+import { onNewLocaleSelected } from '../app/locale'
 import { trackEvent } from '../app/event_tracking'
 
 /**
@@ -82,6 +83,7 @@ const LOCALES = [
 
 export class LocaleDropdown extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     locale: PropTypes.string,
     /* eslint-disable react/no-unused-prop-types */
     // These props _are_ used but linter can't tell
@@ -132,12 +134,11 @@ export class LocaleDropdown extends React.Component {
 
   renderLocaleOptions = () => {
     return LOCALES.filter((item) => item.level >= this.state.level).map(locale =>
-      <option
-        value={locale.value}
-        key={locale.value}
-        data-i18n={locale.key}
-      >
-        {t(locale.key, `[${locale.label}]`)}
+      <option value={locale.value} key={locale.value}>
+        {this.props.intl.formatMessage({
+          id: locale.key,
+          defaultMessage: `[${locale.label}]`
+        })}
       </option>
     )
   }
@@ -160,4 +161,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(LocaleDropdown)
+export default injectIntl(connect(mapStateToProps)(LocaleDropdown))

--- a/assets/scripts/menus/LocaleDropdown.jsx
+++ b/assets/scripts/menus/LocaleDropdown.jsx
@@ -133,14 +133,24 @@ export class LocaleDropdown extends React.Component {
   }
 
   renderLocaleOptions = () => {
-    return LOCALES.filter((item) => item.level >= this.state.level).map(locale =>
-      <option value={locale.value} key={locale.value}>
-        {this.props.intl.formatMessage({
+    return LOCALES
+      .filter((item) => item.level >= this.state.level)
+      // Replace each locale with the translated label
+      .map((locale) => ({
+        ...locale,
+        label: this.props.intl.formatMessage({
           id: locale.key,
           defaultMessage: `[${locale.label}]`
-        })}
-      </option>
-    )
+        })
+      }))
+      // Sort the list of languages alphabetically
+      .sort((a, b) => {
+        if (a.label < b.label) return -1
+        if (a.label > b.label) return 1
+        return 0
+      })
+      // Render each option
+      .map((locale) => <option value={locale.value} key={locale.value}>{locale.label}</option>)
   }
 
   render () {

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -2,9 +2,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
 import EnvironmentBadge from './EnvironmentBadge'
-
-// import { t } from '../app/locale'
 import { URL_SIGN_IN_REDIRECT } from '../app/routing'
 import { showGallery } from '../gallery/view'
 import { getElAbsolutePos } from '../util/helpers'
@@ -106,10 +105,9 @@ class MenuBar extends React.PureComponent {
         <a
           href={`/${URL_SIGN_IN_REDIRECT}`}
           className="command"
-          data-i18n="menu.item.sign-in"
           id="sign-in-link"
         >
-          Sign in
+          <FormattedMessage id="menu.item.sign-in" defaultMessage="Sign in" />
         </a>
       </li>)
 
@@ -117,21 +115,16 @@ class MenuBar extends React.PureComponent {
       ? (<li id="settings-menu-item">
         <button
           data-name="settings"
-          data-i18n="menu.item.settings"
           className="menu-attached"
           disabled={false}
           onClick={this.onClickMenuButton}
         >
-          Settings
+          <FormattedMessage id="menu.item.settings" defaultMessage="Settings" />
         </button>
       </li>) : null
 
     // Buttons have `disabled={false}` because
     // Firefox sometimes disables some buttons… unsure why
-    // --
-    // Note on translations - the {t()} method doesn't re-render when the
-    // language changes, so this still uses the `data-i18n` method to pick up
-    // on text content changes. Individual menus will re-render with {t()}.
     return (
       <nav className="menu-bar">
         <ul className="menu-bar-left">
@@ -142,59 +135,55 @@ class MenuBar extends React.PureComponent {
           <li id="help-menu-item">
             <button
               data-name="help"
-              data-i18n="menu.item.help"
               className="menu-attached"
               disabled={false}
               onClick={this.onClickMenuButton}
             >
-              Help
+              <FormattedMessage id="menu.item.help" defaultMessage="Help" />
             </button>
           </li>
           <li className="hide-for-no-internet">
             <button
               data-name="contact"
-              data-i18n="menu.item.contact"
               className="menu-attached"
               disabled={false}
               onClick={this.onClickMenuButton}
             >
-              Contact
+              <FormattedMessage id="menu.item.contact" defaultMessage="Contact" />
             </button>
           </li>
           <li className="hide-for-no-internet">
             <button
               data-name="contribute"
-              data-i18n="menu.item.contribute"
               className="menu-attached"
               disabled={false}
               onClick={this.onClickMenuButton}
             >
-              Contribute
+              <FormattedMessage id="menu.item.contribute" defaultMessage="Contribute" />
             </button>
           </li>
         </ul>
         <ul ref={(ref) => { this.menuBarRight = ref }} className="menu-bar-right">
           {UserAvatar}
           <li>
-            <a href="/new" target="_blank" data-i18n="menu.item.new-street">
-              New street
+            <a href="/new" target="_blank">
+              <FormattedMessage id="menu.item.new-street" defaultMessage="New street" />
             </a>
           </li>
           <li className="hide-for-no-internet">
-            <a href={myStreetsLink} data-i18n="menu.item.my-streets" onClick={this.onClickMyStreets}>
-              My streets
+            <a href={myStreetsLink} onClick={this.onClickMyStreets}>
+              <FormattedMessage id="menu.item.my-streets" defaultMessage="My streets" />
             </a>
           </li>
           {SettingsButton}
           <li>
             <button
               data-name="share"
-              data-i18n="menu.item.share"
               className="menu-attached"
               disabled={false}
               onClick={this.onClickMenuButton}
             >
-              Share
+              <FormattedMessage id="menu.item.share" defaultMessage="Share" />
             </button>
           </li>
         </ul>

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -7,6 +7,7 @@ import EnvironmentBadge from './EnvironmentBadge'
 import { URL_SIGN_IN_REDIRECT } from '../app/routing'
 import { showGallery } from '../gallery/view'
 import { getElAbsolutePos } from '../util/helpers'
+import MenuBarItem from './MenuBarItem'
 import Avatar from '../users/Avatar'
 
 class MenuBar extends React.PureComponent {
@@ -113,23 +114,6 @@ class MenuBar extends React.PureComponent {
       </li>)
   }
 
-  renderMenuButton = (name, translation, label, requireInternet = false) => {
-    if (requireInternet && this.props.noInternet) return null
-
-    return (
-      <li>
-        <button
-          data-name={name}
-          className="menu-attached"
-          disabled={false}
-          onClick={this.onClickMenuButton}
-        >
-          <FormattedMessage id={translation} defaultMessage={label} />
-        </button>
-      </li>
-    )
-  }
-
   render () {
     const userId = this.props.userId
     const myStreetsLink = userId ? `/${userId}` : ''
@@ -143,10 +127,9 @@ class MenuBar extends React.PureComponent {
       </li>
     )
     const SettingsButton = (this.props.enableLocaleSettings)
-      ? this.renderMenuButton('settings', 'menu.item.settings', 'Settings') : null
+      ? <MenuBarItem name="settings" translation="menu.item.settings" label="Settings" handleClick={this.onClickMenuButton} />
+      : null
 
-    // Buttons have `disabled={false}` because
-    // Firefox sometimes disables some buttons… unsure why
     return (
       <nav className="menu-bar">
         <ul className="menu-bar-left">
@@ -154,9 +137,9 @@ class MenuBar extends React.PureComponent {
             <div className="streetmix-logo" />
             <h1>Streetmix</h1>
           </li>
-          {this.renderMenuButton('help', 'menu.item.help', 'Help')}
-          {this.renderMenuButton('contact', 'menu.item.contact', 'Contact', true)}
-          {this.renderMenuButton('contribute', 'menu.item.contribute', 'Contribute', true)}
+          <MenuBarItem name="help" translation="menu.item.help" label="Help" handleClick={this.onClickMenuButton} />
+          <MenuBarItem name="contact" translation="menu.item.contact" label="Contact" handleClick={this.onClickMenuButton} requireInternet />
+          <MenuBarItem name="contribute" translation="menu.item.contribute" label="Contribute" handleClick={this.onClickMenuButton} requireInternet />
         </ul>
         <ul ref={(ref) => { this.menuBarRight = ref }} className="menu-bar-right">
           {UserAvatar}
@@ -167,7 +150,7 @@ class MenuBar extends React.PureComponent {
           </li>
           {MyStreetsButton}
           {SettingsButton}
-          {this.renderMenuButton('share', 'menu.item.share', 'Share')}
+          <MenuBarItem name="share" translation="menu.item.share" label="Share" handleClick={this.onClickMenuButton} />
         </ul>
         <EnvironmentBadge />
       </nav>

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -112,7 +112,7 @@ class MenuBar extends React.PureComponent {
       </li>)
 
     const SettingsButton = (this.props.enableLocaleSettings)
-      ? (<li id="settings-menu-item">
+      ? (<li>
         <button
           data-name="settings"
           className="menu-attached"
@@ -132,7 +132,7 @@ class MenuBar extends React.PureComponent {
             <div className="streetmix-logo" />
             <h1>Streetmix</h1>
           </li>
-          <li id="help-menu-item">
+          <li>
             <button
               data-name="help"
               className="menu-attached"

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -13,12 +13,14 @@ class MenuBar extends React.PureComponent {
   static propTypes = {
     onMenuDropdownClick: PropTypes.func,
     userId: PropTypes.string,
-    enableLocaleSettings: PropTypes.bool
+    enableLocaleSettings: PropTypes.bool,
+    noInternet: PropTypes.bool
   }
 
   static defaultProps = {
     userId: '',
-    enableLocaleSettings: false
+    enableLocaleSettings: false,
+    noInternet: false
   }
 
   constructor (props) {
@@ -86,12 +88,11 @@ class MenuBar extends React.PureComponent {
     }}))
   }
 
-  render () {
-    const userId = this.props.userId
-    const myStreetsLink = userId ? `/${userId}` : ''
+  renderUserAvatar = (userId) => {
+    if (this.props.noInternet) return null
 
-    const UserAvatar = (userId)
-      ? (<li className="hide-for-no-internet">
+    return (userId)
+      ? (<li>
         <button
           data-name="identity"
           className="menu-attached"
@@ -101,7 +102,7 @@ class MenuBar extends React.PureComponent {
           <Avatar userId={userId} />
           <span className="user-id">{userId}</span>
         </button>
-      </li>) : (<li className="hide-for-no-internet">
+      </li>) : (<li>
         <a
           href={`/${URL_SIGN_IN_REDIRECT}`}
           className="command"
@@ -110,18 +111,39 @@ class MenuBar extends React.PureComponent {
           <FormattedMessage id="menu.item.sign-in" defaultMessage="Sign in" />
         </a>
       </li>)
+  }
 
-    const SettingsButton = (this.props.enableLocaleSettings)
-      ? (<li>
+  renderMenuButton = (name, translation, label, requireInternet = false) => {
+    if (requireInternet && this.props.noInternet) return null
+
+    return (
+      <li>
         <button
-          data-name="settings"
+          data-name={name}
           className="menu-attached"
           disabled={false}
           onClick={this.onClickMenuButton}
         >
-          <FormattedMessage id="menu.item.settings" defaultMessage="Settings" />
+          <FormattedMessage id={translation} defaultMessage={label} />
         </button>
-      </li>) : null
+      </li>
+    )
+  }
+
+  render () {
+    const userId = this.props.userId
+    const myStreetsLink = userId ? `/${userId}` : ''
+
+    const UserAvatar = this.renderUserAvatar(userId)
+    const MyStreetsButton = (this.props.noInternet) ? null : (
+      <li>
+        <a href={myStreetsLink} onClick={this.onClickMyStreets}>
+          <FormattedMessage id="menu.item.my-streets" defaultMessage="My streets" />
+        </a>
+      </li>
+    )
+    const SettingsButton = (this.props.enableLocaleSettings)
+      ? this.renderMenuButton('settings', 'menu.item.settings', 'Settings') : null
 
     // Buttons have `disabled={false}` because
     // Firefox sometimes disables some buttons… unsure why
@@ -132,36 +154,9 @@ class MenuBar extends React.PureComponent {
             <div className="streetmix-logo" />
             <h1>Streetmix</h1>
           </li>
-          <li>
-            <button
-              data-name="help"
-              className="menu-attached"
-              disabled={false}
-              onClick={this.onClickMenuButton}
-            >
-              <FormattedMessage id="menu.item.help" defaultMessage="Help" />
-            </button>
-          </li>
-          <li className="hide-for-no-internet">
-            <button
-              data-name="contact"
-              className="menu-attached"
-              disabled={false}
-              onClick={this.onClickMenuButton}
-            >
-              <FormattedMessage id="menu.item.contact" defaultMessage="Contact" />
-            </button>
-          </li>
-          <li className="hide-for-no-internet">
-            <button
-              data-name="contribute"
-              className="menu-attached"
-              disabled={false}
-              onClick={this.onClickMenuButton}
-            >
-              <FormattedMessage id="menu.item.contribute" defaultMessage="Contribute" />
-            </button>
-          </li>
+          {this.renderMenuButton('help', 'menu.item.help', 'Help')}
+          {this.renderMenuButton('contact', 'menu.item.contact', 'Contact', true)}
+          {this.renderMenuButton('contribute', 'menu.item.contribute', 'Contribute', true)}
         </ul>
         <ul ref={(ref) => { this.menuBarRight = ref }} className="menu-bar-right">
           {UserAvatar}
@@ -170,22 +165,9 @@ class MenuBar extends React.PureComponent {
               <FormattedMessage id="menu.item.new-street" defaultMessage="New street" />
             </a>
           </li>
-          <li className="hide-for-no-internet">
-            <a href={myStreetsLink} onClick={this.onClickMyStreets}>
-              <FormattedMessage id="menu.item.my-streets" defaultMessage="My streets" />
-            </a>
-          </li>
+          {MyStreetsButton}
           {SettingsButton}
-          <li>
-            <button
-              data-name="share"
-              className="menu-attached"
-              disabled={false}
-              onClick={this.onClickMenuButton}
-            >
-              <FormattedMessage id="menu.item.share" defaultMessage="Share" />
-            </button>
-          </li>
+          {this.renderMenuButton('share', 'menu.item.share', 'Share')}
         </ul>
         <EnvironmentBadge />
       </nav>
@@ -196,7 +178,8 @@ class MenuBar extends React.PureComponent {
 function mapStateToProps (state) {
   return {
     userId: state.user.signInData && state.user.signInData.userId,
-    enableLocaleSettings: state.flags.LOCALES_LEVEL_1.value || state.flags.LOCALES_LEVEL_2.value || state.flags.LOCALES_LEVEL_3.value
+    enableLocaleSettings: state.flags.LOCALES_LEVEL_1.value || state.flags.LOCALES_LEVEL_2.value || state.flags.LOCALES_LEVEL_3.value,
+    noInternet: state.system.noInternet
   }
 }
 

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { FormattedMessage } from 'react-intl'
 import EnvironmentBadge from './EnvironmentBadge'
 import { URL_SIGN_IN_REDIRECT } from '../app/routing'
 import { showGallery } from '../gallery/view'
@@ -14,8 +13,7 @@ class MenuBar extends React.PureComponent {
   static propTypes = {
     onMenuDropdownClick: PropTypes.func,
     userId: PropTypes.string,
-    enableLocaleSettings: PropTypes.bool,
-    noInternet: PropTypes.bool
+    enableLocaleSettings: PropTypes.bool
   }
 
   static defaultProps = {
@@ -90,45 +88,35 @@ class MenuBar extends React.PureComponent {
   }
 
   renderUserAvatar = (userId) => {
-    if (this.props.noInternet) return null
-
     return (userId)
-      ? (<li>
-        <button
-          data-name="identity"
-          className="menu-attached"
-          disabled={false}
-          onClick={this.onClickMenuButton}
-        >
+      ? (
+        <MenuBarItem name="identity" handleClick={this.onClickMenuButton} requireInternet>
           <Avatar userId={userId} />
           <span className="user-id">{userId}</span>
-        </button>
-      </li>) : (<li>
-        <a
-          href={`/${URL_SIGN_IN_REDIRECT}`}
+        </MenuBarItem>
+      ) : (
+        <MenuBarItem
+          url={`/${URL_SIGN_IN_REDIRECT}`}
+          translation="menu.item.sign-in"
+          label="Sign in"
+          requireInternet
           className="command"
           id="sign-in-link"
-        >
-          <FormattedMessage id="menu.item.sign-in" defaultMessage="Sign in" />
-        </a>
-      </li>)
+        />
+      )
   }
 
   render () {
     const userId = this.props.userId
     const myStreetsLink = userId ? `/${userId}` : ''
 
-    const UserAvatar = this.renderUserAvatar(userId)
-    const MyStreetsButton = (this.props.noInternet) ? null : (
-      <li>
-        <a href={myStreetsLink} onClick={this.onClickMyStreets}>
-          <FormattedMessage id="menu.item.my-streets" defaultMessage="My streets" />
-        </a>
-      </li>
-    )
-    const SettingsButton = (this.props.enableLocaleSettings)
-      ? <MenuBarItem name="settings" translation="menu.item.settings" label="Settings" handleClick={this.onClickMenuButton} />
-      : null
+    const SettingsButton = this.props.enableLocaleSettings &&
+      <MenuBarItem
+        name="settings"
+        translation="menu.item.settings"
+        label="Settings"
+        handleClick={this.onClickMenuButton}
+      />
 
     return (
       <nav className="menu-bar">
@@ -141,14 +129,21 @@ class MenuBar extends React.PureComponent {
           <MenuBarItem name="contact" translation="menu.item.contact" label="Contact" handleClick={this.onClickMenuButton} requireInternet />
           <MenuBarItem name="contribute" translation="menu.item.contribute" label="Contribute" handleClick={this.onClickMenuButton} requireInternet />
         </ul>
-        <ul ref={(ref) => { this.menuBarRight = ref }} className="menu-bar-right">
-          {UserAvatar}
-          <li>
-            <a href="/new" target="_blank">
-              <FormattedMessage id="menu.item.new-street" defaultMessage="New street" />
-            </a>
-          </li>
-          {MyStreetsButton}
+        <ul className="menu-bar-right" ref={(ref) => { this.menuBarRight = ref }}>
+          {this.renderUserAvatar(userId)}
+          <MenuBarItem
+            url="/new"
+            translation="menu.item.new-street"
+            label="New street"
+            target="_blank"
+          />
+          <MenuBarItem
+            url={myStreetsLink}
+            translation="menu.item.my-streets"
+            label="My streets"
+            handleClick={this.onClickMyStreets}
+            requireInternet
+          />
           {SettingsButton}
           <MenuBarItem name="share" translation="menu.item.share" label="Share" handleClick={this.onClickMenuButton} />
         </ul>
@@ -161,8 +156,7 @@ class MenuBar extends React.PureComponent {
 function mapStateToProps (state) {
   return {
     userId: state.user.signInData && state.user.signInData.userId,
-    enableLocaleSettings: state.flags.LOCALES_LEVEL_1.value || state.flags.LOCALES_LEVEL_2.value || state.flags.LOCALES_LEVEL_3.value,
-    noInternet: state.system.noInternet
+    enableLocaleSettings: state.flags.LOCALES_LEVEL_1.value || state.flags.LOCALES_LEVEL_2.value || state.flags.LOCALES_LEVEL_3.value
   }
 }
 

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -57,16 +57,15 @@ class MenuBar extends React.PureComponent {
 
   /**
    * Handles clicks on <button> elements which result in a dropdown menu.
+   * Pass in the name of this menu, and it returns (curries) a function
+   * that handles the event.
    */
-  onClickMenuButton = (event) => {
-    // We need to send to the parent component (which handles menus) information
-    // about what button was clicked and its position, so that the specified
-    // menu can open in the correct place. The clicked button stores `data-name`
-    // on its attributes, and position is based on its parent `li` element.
-    const buttonEl = event.target.closest('button')
-    const name = buttonEl.dataset.name
-    const position = getElAbsolutePos(buttonEl.parentNode)
-    this.props.onMenuDropdownClick({ name, position })
+  onClickMenuButton = (menu) => {
+    return (event) => {
+      const buttonEl = event.target.closest('button')
+      const position = getElAbsolutePos(buttonEl)
+      this.props.onMenuDropdownClick(menu, position)
+    }
   }
 
   onClickMyStreets = (event) => {
@@ -92,7 +91,7 @@ class MenuBar extends React.PureComponent {
   renderUserAvatar = (userId) => {
     return (userId)
       ? (
-        <MenuBarItem name="identity" handleClick={this.onClickMenuButton} requireInternet>
+        <MenuBarItem handleClick={this.onClickMenuButton('identity')} requireInternet>
           <Avatar userId={userId} />
           <span className="user-id">{userId}</span>
         </MenuBarItem>
@@ -114,10 +113,9 @@ class MenuBar extends React.PureComponent {
 
     const SettingsButton = this.props.enableLocaleSettings &&
       <MenuBarItem
-        name="settings"
-        translation="menu.item.settings"
         label="Settings"
-        handleClick={this.onClickMenuButton}
+        translation="menu.item.settings"
+        handleClick={this.onClickMenuButton('settings')}
       />
 
     return (
@@ -127,27 +125,27 @@ class MenuBar extends React.PureComponent {
             <div className="streetmix-logo" />
             <h1>Streetmix</h1>
           </li>
-          <MenuBarItem name="help" translation="menu.item.help" label="Help" handleClick={this.onClickMenuButton} />
-          <MenuBarItem name="contact" translation="menu.item.contact" label="Contact" handleClick={this.onClickMenuButton} requireInternet />
-          <MenuBarItem name="contribute" translation="menu.item.contribute" label="Contribute" handleClick={this.onClickMenuButton} requireInternet />
+          <MenuBarItem label="Help" translation="menu.item.help" handleClick={this.onClickMenuButton('help')} />
+          <MenuBarItem label="Contact" translation="menu.item.contact" handleClick={this.onClickMenuButton('contact')} requireInternet />
+          <MenuBarItem label="Contribute" translation="menu.item.contribute" handleClick={this.onClickMenuButton('contribute')} requireInternet />
         </ul>
         <ul className="menu-bar-right" ref={(ref) => { this.menuBarRight = ref }}>
           {this.renderUserAvatar(userId)}
           <MenuBarItem
-            url="/new"
-            translation="menu.item.new-street"
             label="New street"
+            translation="menu.item.new-street"
+            url="/new"
             target="_blank"
           />
           <MenuBarItem
-            url={myStreetsLink}
-            translation="menu.item.my-streets"
             label="My streets"
+            translation="menu.item.my-streets"
+            url={myStreetsLink}
             handleClick={this.onClickMyStreets}
             requireInternet
           />
           {SettingsButton}
-          <MenuBarItem name="share" translation="menu.item.share" label="Share" handleClick={this.onClickMenuButton} />
+          <MenuBarItem label="Share" translation="menu.item.share" handleClick={this.onClickMenuButton('share')} />
         </ul>
         <EnvironmentBadge />
       </nav>

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -22,8 +22,8 @@ class MenuBar extends React.PureComponent {
     noInternet: false
   }
 
-  constructor (props) {
-    super(props)
+  componentDidMount () {
+    this.attachSignInTracking()
 
     window.addEventListener('resize', this.onResize)
 
@@ -31,14 +31,16 @@ class MenuBar extends React.PureComponent {
     window.addEventListener('stmx:streetnamecanvas_mounted', this.onResize)
   }
 
-  componentDidMount () {
-    this.attachSignInTracking()
-  }
-
   componentDidUpdate (prevProps) {
     if (this.props.userId && !prevProps.userId) {
       this.attachSignInTracking()
     }
+  }
+
+  componentWillUnmount () {
+    // Clean up event listeners
+    window.removeEventListener('resize', this.onResize)
+    window.removeEventListener('stmx:streetnamecanvas_mounted', this.onResize)
   }
 
   /**

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -91,7 +91,7 @@ class MenuBar extends React.PureComponent {
   renderUserAvatar = (userId) => {
     return (userId)
       ? (
-        <MenuBarItem handleClick={this.onClickMenuButton('identity')} requireInternet>
+        <MenuBarItem onClick={this.onClickMenuButton('identity')} requireInternet>
           <Avatar userId={userId} />
           <span className="user-id">{userId}</span>
         </MenuBarItem>
@@ -115,7 +115,7 @@ class MenuBar extends React.PureComponent {
       <MenuBarItem
         label="Settings"
         translation="menu.item.settings"
-        handleClick={this.onClickMenuButton('settings')}
+        onClick={this.onClickMenuButton('settings')}
       />
 
     return (
@@ -125,9 +125,9 @@ class MenuBar extends React.PureComponent {
             <div className="streetmix-logo" />
             <h1>Streetmix</h1>
           </li>
-          <MenuBarItem label="Help" translation="menu.item.help" handleClick={this.onClickMenuButton('help')} />
-          <MenuBarItem label="Contact" translation="menu.item.contact" handleClick={this.onClickMenuButton('contact')} requireInternet />
-          <MenuBarItem label="Contribute" translation="menu.item.contribute" handleClick={this.onClickMenuButton('contribute')} requireInternet />
+          <MenuBarItem label="Help" translation="menu.item.help" onClick={this.onClickMenuButton('help')} />
+          <MenuBarItem label="Contact" translation="menu.item.contact" onClick={this.onClickMenuButton('contact')} requireInternet />
+          <MenuBarItem label="Contribute" translation="menu.item.contribute" onClick={this.onClickMenuButton('contribute')} requireInternet />
         </ul>
         <ul className="menu-bar-right" ref={(ref) => { this.menuBarRight = ref }}>
           {this.renderUserAvatar(userId)}
@@ -141,11 +141,11 @@ class MenuBar extends React.PureComponent {
             label="My streets"
             translation="menu.item.my-streets"
             url={myStreetsLink}
-            handleClick={this.onClickMyStreets}
+            onClick={this.onClickMyStreets}
             requireInternet
           />
           {SettingsButton}
-          <MenuBarItem label="Share" translation="menu.item.share" handleClick={this.onClickMenuButton('share')} />
+          <MenuBarItem label="Share" translation="menu.item.share" onClick={this.onClickMenuButton('share')} />
         </ul>
         <EnvironmentBadge />
       </nav>

--- a/assets/scripts/menus/MenuBarItem.jsx
+++ b/assets/scripts/menus/MenuBarItem.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
+
+export class MenuBarItem extends React.Component {
+  static propTypes = {
+    children: PropTypes.any,
+    name: PropTypes.string,
+    translation: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    handleClick: PropTypes.func,
+    requireInternet: PropTypes.bool,
+    noInternet: PropTypes.bool
+  }
+
+  static defaultProps = {
+    requireInternet: false
+  }
+
+  render () {
+    const { name, translation, label, requireInternet } = this.props
+
+    if (requireInternet && this.props.noInternet) return null
+
+    // Buttons have `disabled={false}` because Firefox
+    // sometimes disables some buttons… unsure why
+    return (
+      <li>
+        <button
+          data-name={name}
+          className="menu-attached"
+          disabled={false}
+          onClick={this.props.handleClick}
+        >
+          {this.props.children || <FormattedMessage id={translation} defaultMessage={label} />}
+        </button>
+      </li>
+    )
+  }
+}
+
+function mapStateToProps (state) {
+  return {
+    noInternet: state.system.noInternet
+  }
+}
+
+export default connect(mapStateToProps)(MenuBarItem)

--- a/assets/scripts/menus/MenuBarItem.jsx
+++ b/assets/scripts/menus/MenuBarItem.jsx
@@ -16,7 +16,7 @@ export class MenuBarItem extends React.PureComponent {
     url: PropTypes.string,
 
     // Event handlers
-    handleClick: PropTypes.func,
+    onClick: PropTypes.func,
 
     // Won't display if there's no internet detected
     requireInternet: PropTypes.bool,
@@ -28,13 +28,13 @@ export class MenuBarItem extends React.PureComponent {
 
   static defaultProps = {
     requireInternet: false,
-    handleClick: () => {},
+    onClick: () => {},
     translation: '',
     label: ''
   }
 
   render () {
-    const { translation, label, requireInternet, url, handleClick, noInternet, dispatch, ...restProps } = this.props
+    const { translation, label, requireInternet, url, onClick, noInternet, dispatch, ...restProps } = this.props
 
     if (requireInternet && noInternet) return null
 
@@ -44,7 +44,7 @@ export class MenuBarItem extends React.PureComponent {
     if (url) {
       return (
         <li>
-          <a href={url} onClick={handleClick} {...restProps}>
+          <a href={url} onClick={onClick} {...restProps}>
             {children}
           </a>
         </li>
@@ -57,7 +57,7 @@ export class MenuBarItem extends React.PureComponent {
           <button
             className="menu-attached"
             disabled={false}
-            onClick={handleClick}
+            onClick={onClick}
             {...restProps}
           >
             {children}

--- a/assets/scripts/menus/MenuBarItem.jsx
+++ b/assets/scripts/menus/MenuBarItem.jsx
@@ -9,9 +9,8 @@ export class MenuBarItem extends React.PureComponent {
     children: PropTypes.any,
 
     // Otherwise, uses a <FormattedMessage /> component to render menu label
-    name: PropTypes.string,
-    translation: PropTypes.string,
     label: PropTypes.string,
+    translation: PropTypes.string,
 
     // If provided, renders using anchor tags intead of buttons
     url: PropTypes.string,
@@ -35,7 +34,7 @@ export class MenuBarItem extends React.PureComponent {
   }
 
   render () {
-    const { name, translation, label, requireInternet, url, handleClick, noInternet, dispatch, ...restProps } = this.props
+    const { translation, label, requireInternet, url, handleClick, noInternet, dispatch, ...restProps } = this.props
 
     if (requireInternet && noInternet) return null
 
@@ -56,7 +55,6 @@ export class MenuBarItem extends React.PureComponent {
       return (
         <li>
           <button
-            data-name={name}
             className="menu-attached"
             disabled={false}
             onClick={handleClick}

--- a/assets/scripts/menus/MenuBarItem.jsx
+++ b/assets/scripts/menus/MenuBarItem.jsx
@@ -29,7 +29,9 @@ export class MenuBarItem extends React.PureComponent {
 
   static defaultProps = {
     requireInternet: false,
-    handleClick: () => {}
+    handleClick: () => {},
+    translation: '',
+    label: ''
   }
 
   render () {

--- a/assets/scripts/menus/MenuBarItem.jsx
+++ b/assets/scripts/menus/MenuBarItem.jsx
@@ -3,40 +3,68 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 
-export class MenuBarItem extends React.Component {
+export class MenuBarItem extends React.PureComponent {
   static propTypes = {
+    // Accepts children
     children: PropTypes.any,
+
+    // Otherwise, uses a <FormattedMessage /> component to render menu label
     name: PropTypes.string,
-    translation: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired,
+    translation: PropTypes.string,
+    label: PropTypes.string,
+
+    // If provided, renders using anchor tags intead of buttons
+    url: PropTypes.string,
+
+    // Event handlers
     handleClick: PropTypes.func,
+
+    // Won't display if there's no internet detected
     requireInternet: PropTypes.bool,
+
+    // Props from store
+    dispatch: PropTypes.func,
     noInternet: PropTypes.bool
   }
 
   static defaultProps = {
-    requireInternet: false
+    requireInternet: false,
+    handleClick: () => {}
   }
 
   render () {
-    const { name, translation, label, requireInternet } = this.props
+    const { name, translation, label, requireInternet, url, handleClick, noInternet, dispatch, ...restProps } = this.props
 
-    if (requireInternet && this.props.noInternet) return null
+    if (requireInternet && noInternet) return null
 
-    // Buttons have `disabled={false}` because Firefox
-    // sometimes disables some buttons… unsure why
-    return (
-      <li>
-        <button
-          data-name={name}
-          className="menu-attached"
-          disabled={false}
-          onClick={this.props.handleClick}
-        >
-          {this.props.children || <FormattedMessage id={translation} defaultMessage={label} />}
-        </button>
-      </li>
-    )
+    const children = this.props.children ||
+      <FormattedMessage id={translation} defaultMessage={label} />
+
+    if (url) {
+      return (
+        <li>
+          <a href={url} onClick={handleClick} {...restProps}>
+            {children}
+          </a>
+        </li>
+      )
+    } else {
+      // Buttons have `disabled={false}` because Firefox
+      // sometimes disables some buttons… unsure why
+      return (
+        <li>
+          <button
+            data-name={name}
+            className="menu-attached"
+            disabled={false}
+            onClick={handleClick}
+            {...restProps}
+          >
+            {children}
+          </button>
+        </li>
+      )
+    }
   }
 }
 

--- a/assets/scripts/menus/MenusContainer.jsx
+++ b/assets/scripts/menus/MenusContainer.jsx
@@ -57,12 +57,15 @@ class MenusContainer extends React.PureComponent {
    * Clicked buttons that have a menu component will report back to this component
    * what was clicked and where it should be placed, which is then passed to
    * individual menus.
+   *
+   * @param {string} menu - name of the menu that was clicked
+   * @param {Array} position - [x, y] position to place the menu at
    */
-  onMenuDropdownClick = (clickedItem) => {
+  onMenuDropdownClick = (menu, position) => {
     // If the clicked menu is already active, it's toggled off.
-    const activeMenu = (this.props.activeMenu === clickedItem.name) ? null : clickedItem.name
+    const activeMenu = (this.props.activeMenu === menu) ? null : menu
     this.setState({
-      activeMenuPos: activeMenu ? clickedItem.position : [0, 0]
+      activeMenuPos: activeMenu ? position : [0, 0]
     })
     this.props.showMenu(activeMenu)
   }

--- a/assets/scripts/menus/MenusContainer.jsx
+++ b/assets/scripts/menus/MenusContainer.jsx
@@ -52,6 +52,10 @@ class MenusContainer extends React.PureComponent {
     }
   }
 
+  componentDidCatch (error) {
+    console.log(error)
+  }
+
   /**
    * Callback function passed to the MenuBar component.
    * Clicked buttons that have a menu component will report back to this component

--- a/assets/scripts/menus/SettingsMenu.jsx
+++ b/assets/scripts/menus/SettingsMenu.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { FormattedMessage } from 'react-intl'
 import Menu from './Menu'
 import LocaleDropdown from './LocaleDropdown'
 
@@ -7,7 +8,7 @@ export default class SettingsMenu extends React.PureComponent {
     return (
       <Menu alignment="right" onShow={this.onShow} {...this.props}>
         <div className="form">
-          <p><span data-i18n="menu.language.heading">Language</span></p>
+          <p><FormattedMessage id="menu.language.heading" defaultMessage="Language" /></p>
           <LocaleDropdown />
         </div>
       </Menu>

--- a/assets/scripts/menus/ShareMenu.jsx
+++ b/assets/scripts/menus/ShareMenu.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
+import { FormattedMessage, FormattedHTMLMessage } from 'react-intl'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Menu from './Menu'
 
-import { t } from '../app/locale'
 import { FACEBOOK_APP_ID } from '../app/config'
 import { trackEvent } from '../app/event_tracking'
 import { getPageTitle } from '../app/page_title'
@@ -11,7 +11,7 @@ import { printImage } from '../app/print'
 import { getSharingUrl } from '../util/share_url'
 import { showDialog } from '../store/actions/dialogs'
 
-class ShareMenu extends React.Component {
+export class ShareMenu extends React.Component {
   static propTypes = {
     showDialog: PropTypes.func.isRequired,
     signedIn: PropTypes.bool.isRequired,
@@ -96,18 +96,20 @@ class ShareMenu extends React.Component {
       '&description=' + encodeURIComponent(shareText)
 
     const signInPromo = (!this.props.signedIn)
-      ? (<div
-        className="share-sign-in-promo"
-        dangerouslySetInnerHTML={{ __html: t('menu.share.sign-in', '<a href="/twitter-sign-in?redirectUri=/just-signed-in">Sign in with Twitter</a> for nicer links to your streets and your personal street gallery') }}
-      />) : null
+      ? (
+        <div className="share-sign-in-promo">
+          <FormattedHTMLMessage
+            id="menu.share.sign-in"
+            defaultMessage="<a href='/twitter-sign-in?redirectUri=/just-signed-in'>Sign in with Twitter</a> for nicer links to your streets and your personal street gallery"
+          />
+        </div>
+      ) : null
 
     return (
       <Menu alignment="right" onShow={this.onShow} className="share-menu" {...this.props}>
         {signInPromo}
         <div className="share-via-link-container">
-          <span>
-            {t('menu.share.link', 'Copy and paste this link to share:')}
-          </span>
+          <FormattedMessage id="menu.share.link" defaultMessage="Copy and paste this link to share:" />
           <input
             className="share-via-link"
             type="text"
@@ -125,7 +127,7 @@ class ShareMenu extends React.Component {
           <svg className="icon">
             <use xlinkHref="#icon-twitter" />
           </svg>
-          <span>{t('menu.share.twitter', 'Share using Twitter')}</span>
+          <FormattedMessage id="menu.share.twitter" defaultMessage="Share using Twitter" />
         </a>
         <a
           className="share-via-facebook"
@@ -136,15 +138,15 @@ class ShareMenu extends React.Component {
           <svg className="icon">
             <use xlinkHref="#icon-facebook" />
           </svg>
-          <span>{t('menu.share.facebook', 'Share using Facebook')}</span>
+          <FormattedMessage id="menu.share.facebook" defaultMessage="Share using Facebook" />
         </a>
         <a href="#" onClick={printImage}>
-          <span>{t('menu.share.print', 'Print…')}</span>
+          <FormattedMessage id="menu.share.print" defaultMessage="Print…" />
         </a>
         <a id="save-as-image" href="#" onClick={this.onClickSaveAsImage}>
-          <span>{t('menu.share.save', 'Save as image…')}</span>
+          <FormattedMessage id="menu.share.save" defaultMessage="Save as image…" />
           <span className="menu-item-subtext">
-            {t('menu.share.save-byline', 'For including in a report, blog, etc.')}
+            <FormattedMessage id="menu.share.save-byline" defaultMessage="For including in a report, blog, etc." />
           </span>
         </a>
       </Menu>

--- a/assets/scripts/menus/__tests__/ContactMenu.test.js
+++ b/assets/scripts/menus/__tests__/ContactMenu.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import ContactMenu from '../ContactMenu'
+
+describe('ContactMenu', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<ContactMenu />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/menus/__tests__/ContributeMenu.test.js
+++ b/assets/scripts/menus/__tests__/ContributeMenu.test.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import ContributeMenu from '../ContributeMenu'
+
+describe('ContributeMenu', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<ContributeMenu />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/menus/__tests__/EnvironmentBadge.test.js
+++ b/assets/scripts/menus/__tests__/EnvironmentBadge.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import { EnvironmentBadge } from '../EnvironmentBadge'
+
+describe('EnvironmentBadge', () => {
+  it('renders nothing in standard conditions', () => {
+    const wrapper = shallow(<EnvironmentBadge />)
+    expect(wrapper.text()).toEqual('')
+  })
+
+  it('displays a specific label if given', () => {
+    const wrapper = shallow(<EnvironmentBadge label="foo" />)
+    expect(wrapper.text()).toEqual('foo')
+  })
+
+  it('displays correctly without Internet', () => {
+    const wrapper = shallow(<EnvironmentBadge noInternet />)
+    expect(wrapper.text()).toEqual('Demo')
+    expect(wrapper.find('.environment-label-demo').length).toEqual(1)
+  })
+
+  it.skip('displays correctly in development environment', () => {
+    // This doesn't work
+    jest.mock('../../app/config', () => ({
+      ENV: 'development'
+    }))
+
+    const wrapper = shallow(<EnvironmentBadge />)
+    expect(wrapper.text()).toEqual('Dev')
+    expect(wrapper.find('.environment-label-development').length).toEqual(1)
+  })
+
+  it.skip('displays correctly in staging environment', () => {
+    // This doesn't work
+    jest.mock('../../app/config', () => ({
+      ENV: 'staging'
+    }))
+
+    const wrapper = shallow(<EnvironmentBadge />)
+    expect(wrapper.text()).toEqual('Staging')
+    expect(wrapper.find('.environment-label-staging').length).toEqual(1)
+  })
+
+  it.skip('displays correctly in sandbox environment', () => {
+    // This doesn't work
+    jest.mock('../../app/config', () => ({
+      ENV: 'sandbox'
+    }))
+
+    const wrapper = shallow(<EnvironmentBadge />)
+    expect(wrapper.text()).toEqual('Sandbox')
+    expect(wrapper.find('.environment-label-sandbox').length).toEqual(1)
+  })
+})

--- a/assets/scripts/menus/__tests__/HelpMenu.test.js
+++ b/assets/scripts/menus/__tests__/HelpMenu.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+import React from 'react'
+import { HelpMenu } from '../HelpMenu'
+import { shallow } from 'enzyme'
+
+describe('HelpMenu', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<HelpMenu showDialog={jest.fn()} />)
+    expect(wrapper.find('div').length).toEqual(1)
+  })
+
+  it('shows the About dialog when its link is clicked', () => {
+    const showDialog = jest.fn()
+    const wrapper = shallow(<HelpMenu showDialog={showDialog} />)
+    wrapper.find('a').simulate('click')
+    expect(showDialog).toBeCalled()
+  })
+
+  // To implement this test, we need to test that the `keydown`
+  // event is listened to on the window. It's possible this is out
+  // of scope for a unit test and should be captured in the
+  // end-to-end acceptance testing instead.
+  it('shows the About dialog when keyboard shortcut is pressed')
+})

--- a/assets/scripts/menus/__tests__/HelpMenu.test.js
+++ b/assets/scripts/menus/__tests__/HelpMenu.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import { HelpMenu } from '../HelpMenu'
 import { shallow } from 'enzyme'
+import { HelpMenu } from '../HelpMenu'
 
 describe('HelpMenu', () => {
   it('renders without crashing', () => {

--- a/assets/scripts/menus/__tests__/IdentityMenu.test.js
+++ b/assets/scripts/menus/__tests__/IdentityMenu.test.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import IdentityMenu from '../IdentityMenu'
+
+jest.mock('../../users/authentication', () => {
+  return {
+    onSignOutClick: () => {}
+  }
+})
+
+describe('IdentityMenu', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<IdentityMenu />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/menus/__tests__/MenuBarItem.test.js
+++ b/assets/scripts/menus/__tests__/MenuBarItem.test.js
@@ -9,7 +9,7 @@ function FormattedMessage () {
 
 describe('MenuBarItem', () => {
   it('renders without crashing', () => {
-    const wrapper = shallow(<MenuBarItem translation="foo" label="foo" />)
+    const wrapper = shallow(<MenuBarItem label="foo" translation="foo" />)
     expect(wrapper.children().length).toEqual(1)
   })
 

--- a/assets/scripts/menus/__tests__/MenuBarItem.test.js
+++ b/assets/scripts/menus/__tests__/MenuBarItem.test.js
@@ -10,8 +10,7 @@ function FormattedMessage () {
 describe('MenuBarItem', () => {
   it('renders without crashing', () => {
     const wrapper = shallow(<MenuBarItem translation="foo" label="foo" />)
-    // expect(wrapper.find(FormattedMessage).exists()).toEqual(true)
-    expect(wrapper.find('div').length).toEqual(1)
+    expect(wrapper.children().length).toEqual(1)
   })
 
   it('handles the click', () => {
@@ -19,11 +18,6 @@ describe('MenuBarItem', () => {
     const wrapper = shallow(<MenuBarItem handleClick={showDialog} />)
     wrapper.find('button').simulate('click')
     expect(showDialog).toBeCalled()
-  })
-
-  it('does not render if it requires Internet access, and there is no Internet', () => {
-    const wrapper = shallow(<MenuBarItem requireInternet />)
-    expect(wrapper.find('div').length).toEqual(1)
   })
 
   it('renders children instead of default label if provided', () => {
@@ -41,5 +35,22 @@ describe('MenuBarItem', () => {
   it('passes unhandled props to child elements', () => {
     const wrapper = shallow(<MenuBarItem className="foo" />)
     expect(wrapper.find('.foo').exists()).toEqual(true)
+  })
+
+  describe('internet connectivity behavior', () => {
+    it('does not render if it requires Internet access, and there is no Internet', () => {
+      const wrapper = shallow(<MenuBarItem requireInternet noInternet />)
+      expect(wrapper.children().length).toEqual(0)
+    })
+
+    it('renders if it requires Internet access, and there is Internet', () => {
+      const wrapper = shallow(<MenuBarItem requireInternet noInternet={false} />)
+      expect(wrapper.children().length).toEqual(1)
+    })
+
+    it('renders if it does not require Internet access, and there is no Internet', () => {
+      const wrapper = shallow(<MenuBarItem noInternet />)
+      expect(wrapper.children().length).toEqual(1)
+    })
   })
 })

--- a/assets/scripts/menus/__tests__/MenuBarItem.test.js
+++ b/assets/scripts/menus/__tests__/MenuBarItem.test.js
@@ -3,9 +3,14 @@ import React from 'react'
 import { MenuBarItem } from '../MenuBarItem'
 import { shallow } from 'enzyme'
 
+function FormattedMessage () {
+  return <span />
+}
+
 describe('MenuBarItem', () => {
   it('renders without crashing', () => {
-    const wrapper = shallow(<MenuBarItem />)
+    const wrapper = shallow(<MenuBarItem translation="foo" label="foo" />)
+    // expect(wrapper.find(FormattedMessage).exists()).toEqual(true)
     expect(wrapper.find('div').length).toEqual(1)
   })
 
@@ -19,5 +24,22 @@ describe('MenuBarItem', () => {
   it('does not render if it requires Internet access, and there is no Internet', () => {
     const wrapper = shallow(<MenuBarItem requireInternet />)
     expect(wrapper.find('div').length).toEqual(1)
+  })
+
+  it('renders children instead of default label if provided', () => {
+    const wrapper = shallow(<MenuBarItem><span className="foo">bar</span></MenuBarItem>)
+    expect(wrapper.find(FormattedMessage).exists()).toEqual(false)
+    expect(wrapper.find('.foo').exists()).toEqual(true)
+    expect(wrapper.text()).toEqual('bar')
+  })
+
+  it('renders anchor tag instead of button if url is provided', () => {
+    const wrapper = shallow(<MenuBarItem url="#" />)
+    expect(wrapper.find('a').exists()).toEqual(true)
+  })
+
+  it('passes unhandled props to child elements', () => {
+    const wrapper = shallow(<MenuBarItem className="foo" />)
+    expect(wrapper.find('.foo').exists()).toEqual(true)
   })
 })

--- a/assets/scripts/menus/__tests__/MenuBarItem.test.js
+++ b/assets/scripts/menus/__tests__/MenuBarItem.test.js
@@ -14,10 +14,10 @@ describe('MenuBarItem', () => {
   })
 
   it('handles the click', () => {
-    const showDialog = jest.fn()
-    const wrapper = shallow(<MenuBarItem handleClick={showDialog} />)
+    const handleClick = jest.fn()
+    const wrapper = shallow(<MenuBarItem onClick={handleClick} />)
     wrapper.find('button').simulate('click')
-    expect(showDialog).toBeCalled()
+    expect(handleClick).toBeCalled()
   })
 
   it('renders children instead of default label if provided', () => {

--- a/assets/scripts/menus/__tests__/MenuBarItem.test.js
+++ b/assets/scripts/menus/__tests__/MenuBarItem.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import { MenuBarItem } from '../MenuBarItem'
 import { shallow } from 'enzyme'
+import { MenuBarItem } from '../MenuBarItem'
 
 function FormattedMessage () {
   return <span />

--- a/assets/scripts/menus/__tests__/MenuBarItem.test.js
+++ b/assets/scripts/menus/__tests__/MenuBarItem.test.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+import React from 'react'
+import { MenuBarItem } from '../MenuBarItem'
+import { shallow } from 'enzyme'
+
+describe('MenuBarItem', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<MenuBarItem />)
+    expect(wrapper.find('div').length).toEqual(1)
+  })
+
+  it('handles the click', () => {
+    const showDialog = jest.fn()
+    const wrapper = shallow(<MenuBarItem handleClick={showDialog} />)
+    wrapper.find('button').simulate('click')
+    expect(showDialog).toBeCalled()
+  })
+
+  it('does not render if it requires Internet access, and there is no Internet', () => {
+    const wrapper = shallow(<MenuBarItem requireInternet />)
+    expect(wrapper.find('div').length).toEqual(1)
+  })
+})

--- a/assets/scripts/menus/__tests__/SettingsMenu.test.js
+++ b/assets/scripts/menus/__tests__/SettingsMenu.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import SettingsMenu from '../SettingsMenu'
 import { shallow } from 'enzyme'
+import SettingsMenu from '../SettingsMenu'
 
 describe('SettingsMenu', () => {
   it('renders without crashing', () => {

--- a/assets/scripts/menus/__tests__/ShareMenu.test.js
+++ b/assets/scripts/menus/__tests__/ShareMenu.test.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import { ShareMenu } from '../ShareMenu'
+
+jest.mock('../../app/page_title', () => {
+  return {
+    getPageTitle: () => {}
+  }
+})
+
+describe('ShareMenu', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<ShareMenu showDialog={jest.fn()} signedIn street={{}} />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+
+  describe('sign-in promo', () => {
+    it('shows the sign-in promo if user is not signed in', () => {
+      const wrapper = shallow(<ShareMenu showDialog={jest.fn()} signedIn={false} street={{}} />)
+      expect(wrapper.find('.share-sign-in-promo').length).toEqual(1)
+    })
+
+    it('does not show the sign-in promo if user is signed in', () => {
+      const wrapper = shallow(<ShareMenu showDialog={jest.fn()} signedIn street={{}} />)
+      expect(wrapper.find('.share-sign-in-promo').length).toEqual(0)
+    })
+  })
+})

--- a/assets/scripts/store/actions/__tests__/locale.test.js
+++ b/assets/scripts/store/actions/__tests__/locale.test.js
@@ -11,7 +11,7 @@ describe('locale action creators', () => {
       },
       qux: {
         baz: {
-          bar: 'foo'
+          bar: 'foo {{boop}}'
         }
       }
     }
@@ -22,7 +22,7 @@ describe('locale action creators', () => {
       messages: {
         'foo.bar': 'baz',
         'foo.qux': 'bar',
-        'qux.baz.bar': 'foo'
+        'qux.baz.bar': 'foo {boop}'
       }
     }
 

--- a/assets/scripts/store/actions/__tests__/locale.test.js
+++ b/assets/scripts/store/actions/__tests__/locale.test.js
@@ -18,7 +18,7 @@ describe('locale action creators', () => {
 
     const expectedAction = {
       type: types.SET_LOCALE,
-      locale: 'en',
+      locale: 'pt-BR',
       messages: {
         'foo.bar': 'baz',
         'foo.qux': 'bar',
@@ -26,6 +26,6 @@ describe('locale action creators', () => {
       }
     }
 
-    expect(actions.setLocale('en', translation)).toEqual(expectedAction)
+    expect(actions.setLocale('pt_BR', translation)).toEqual(expectedAction)
   })
 })

--- a/assets/scripts/store/actions/__tests__/locale.test.js
+++ b/assets/scripts/store/actions/__tests__/locale.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+import * as actions from '../locale'
+import * as types from '../index'
+
+describe('locale action creators', () => {
+  it('should create an action to save translation in react-intl message format', () => {
+    const translation = {
+      foo: {
+        bar: 'baz',
+        qux: 'bar'
+      },
+      qux: {
+        baz: {
+          bar: 'foo'
+        }
+      }
+    }
+
+    const expectedAction = {
+      type: types.SET_LOCALE,
+      locale: 'en',
+      messages: {
+        'foo.bar': 'baz',
+        'foo.qux': 'bar',
+        'qux.baz.bar': 'foo'
+      }
+    }
+
+    expect(actions.setLocale('en', translation)).toEqual(expectedAction)
+  })
+})

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -62,6 +62,9 @@ export const SET_SEGMENT_DATA_NO = 'SET_SEGMENT_DATA_NO'
 export const UPDATE_HOVER_POLYGON = 'UPDATE_HOVER_POLYGON'
 export const SET_INFO_BUBBLE_MOUSE_INSIDE = 'SET_INFO_BUBBLE_MOUSE_INSIDE'
 
+/* locale */
+export const SET_LOCALE = 'SET_LOCALE'
+
 /* map */
 export const SET_MAP_STATE = 'SET_MAP_STATE'
 

--- a/assets/scripts/store/actions/locale.js
+++ b/assets/scripts/store/actions/locale.js
@@ -22,11 +22,19 @@ function flattenObject (obj) {
   return toReturn
 }
 
+// Replace double bracket {{placeholders}} with {single} for react-intl
+function replacePlaceholders (messages) {
+  return Object.entries(messages).reduce((accumulator, entry) => {
+    accumulator[entry[0]] = entry[1].replace('{{', '{').replace('}}', '}')
+    return accumulator
+  }, {})
+}
+
 export function setLocale (locale, messages) {
   return {
     type: SET_LOCALE,
     // Converts "es_MX" to "en-MX" (and similar) for react-intl
     locale: locale.replace('_', '-'),
-    messages: flattenObject(messages)
+    messages: replacePlaceholders(flattenObject(messages))
   }
 }

--- a/assets/scripts/store/actions/locale.js
+++ b/assets/scripts/store/actions/locale.js
@@ -1,9 +1,31 @@
 import { SET_LOCALE } from './index'
 
+// Flattens a nested object from translation response, e.g.
+// { key1: { key2: "string" }} => { "key1.key2": "string" }
+// This is because react-intl expects to look up translations this way.
+// ES6-ported function from https://gist.github.com/penguinboy/762197
+// This is quite simple; it does not address arrays or null values, since
+// the responses from the server will not be containing those.
+function flattenObject (obj) {
+  const toReturn = {}
+  let flatObject
+  Object.keys(obj).forEach(i => {
+    if (typeof obj[i] === 'object') {
+      flatObject = flattenObject(obj[i])
+      Object.keys(flatObject).forEach(x => {
+        toReturn[i + '.' + x] = flatObject[x]
+      })
+    } else {
+      toReturn[i] = obj[i]
+    }
+  })
+  return toReturn
+}
+
 export function setLocale (locale, messages) {
   return {
     type: SET_LOCALE,
     locale,
-    messages
+    messages: flattenObject(messages)
   }
 }

--- a/assets/scripts/store/actions/locale.js
+++ b/assets/scripts/store/actions/locale.js
@@ -1,0 +1,9 @@
+import { SET_LOCALE } from './index'
+
+export function setLocale (locale, messages) {
+  return {
+    type: SET_LOCALE,
+    locale,
+    messages
+  }
+}

--- a/assets/scripts/store/actions/locale.js
+++ b/assets/scripts/store/actions/locale.js
@@ -25,7 +25,8 @@ function flattenObject (obj) {
 export function setLocale (locale, messages) {
   return {
     type: SET_LOCALE,
-    locale,
+    // Converts "es_MX" to "en-MX" (and similar) for react-intl
+    locale: locale.replace('_', '-'),
     messages: flattenObject(messages)
   }
 }

--- a/assets/scripts/store/actions/persistSettings.js
+++ b/assets/scripts/store/actions/persistSettings.js
@@ -3,6 +3,6 @@ import { SET_USER_UNITS } from './index'
 export function setUserUnits (units) {
   return {
     type: SET_USER_UNITS,
-    units
+    units: Number.parseInt(units, 10)
   }
 }

--- a/assets/scripts/store/reducers/__tests__/persistSettings.test.js
+++ b/assets/scripts/store/reducers/__tests__/persistSettings.test.js
@@ -16,4 +16,12 @@ describe('persistSettings reducer', () => {
       units: 2
     })
   })
+
+  it('should parse string arguments as integers', () => {
+    expect(
+      reducer(undefined, actions.setUserUnits('2'))
+    ).toEqual({
+      units: 2
+    })
+  })
 })

--- a/assets/scripts/store/reducers/__tests__/persistSettings.test.js
+++ b/assets/scripts/store/reducers/__tests__/persistSettings.test.js
@@ -5,23 +5,18 @@ import * as actions from '../../actions/persistSettings'
 describe('persistSettings reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({
-      units: 1
+      units: 1,
+      locale: null
     })
   })
 
   it('should update units from initial state', () => {
-    expect(
-      reducer(undefined, actions.setUserUnits(2))
-    ).toEqual({
-      units: 2
-    })
+    const state = reducer(undefined, actions.setUserUnits(2))
+    expect(state.units).toEqual(2)
   })
 
   it('should parse string arguments as integers', () => {
-    expect(
-      reducer(undefined, actions.setUserUnits('2'))
-    ).toEqual({
-      units: 2
-    })
+    const state = reducer(undefined, actions.setUserUnits('2'))
+    expect(state.units).toEqual(2)
   })
 })

--- a/assets/scripts/store/reducers/index.js
+++ b/assets/scripts/store/reducers/index.js
@@ -6,6 +6,7 @@ import errors from './errors'
 import flags from './flags'
 import gallery from './gallery'
 import infoBubble from './infoBubble'
+import locale from './locale'
 import map from './map'
 import menus from './menus'
 import settings from './settings'
@@ -25,6 +26,7 @@ const reducers = combineReducers({
   flags,
   gallery,
   infoBubble,
+  locale,
   map,
   menus,
   settings,

--- a/assets/scripts/store/reducers/locale.js
+++ b/assets/scripts/store/reducers/locale.js
@@ -1,0 +1,21 @@
+import { SET_LOCALE } from '../actions'
+
+const initialState = {
+  locale: 'en',
+  messages: {}
+}
+
+const locale = (state = initialState, action) => {
+  switch (action.type) {
+    case SET_LOCALE:
+      return {
+        ...state,
+        locale: action.locale,
+        messages: action.messages
+      }
+    default:
+      return state
+  }
+}
+
+export default locale

--- a/assets/scripts/store/reducers/locale.js
+++ b/assets/scripts/store/reducers/locale.js
@@ -1,7 +1,8 @@
 import { SET_LOCALE } from '../actions'
 
 const initialState = {
-  locale: 'en',
+  // Default language is set by browser, or is English if undetermined
+  locale: navigator.language || 'en',
   messages: {}
 }
 

--- a/assets/scripts/store/reducers/persistSettings.js
+++ b/assets/scripts/store/reducers/persistSettings.js
@@ -1,7 +1,8 @@
-import { SET_USER_UNITS } from '../actions'
+import { SET_USER_UNITS, SET_LOCALE } from '../actions'
 
 const initialState = {
-  units: 1
+  units: 1,
+  locale: null
 }
 
 const persistSettings = (state = initialState, action) => {
@@ -10,6 +11,11 @@ const persistSettings = (state = initialState, action) => {
       return {
         ...state,
         units: action.units
+      }
+    case SET_LOCALE:
+      return {
+        ...state,
+        locale: action.locale
       }
     default:
       return state

--- a/assets/scripts/streets/__tests__/StreetMetaData.test.js
+++ b/assets/scripts/streets/__tests__/StreetMetaData.test.js
@@ -21,6 +21,7 @@ describe('StreetMetaData', () => {
       <StreetMetaData.WrappedComponent
         street={{}}
         signedIn
+        locale={{}}
       />
     )
     expect(wrapper.exists()).toEqual(true)
@@ -42,6 +43,7 @@ describe('StreetMetaData', () => {
         readOnly
         enableLocation
         signedIn
+        locale={{}}
       />
     )
 
@@ -55,6 +57,7 @@ describe('StreetMetaData', () => {
         readOnly
         enableLocation
         signedIn
+        locale={{}}
       />
     )
 

--- a/assets/scripts/users/localization.js
+++ b/assets/scripts/users/localization.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import { cloneDeep, throttle } from 'lodash'
 
 import { debug } from '../preinit/debug_settings'
 import {
@@ -76,17 +76,20 @@ export function updateSettingsFromCountryCode (countryCode) {
 }
 
 export function updateUnitSettings (countryCode) {
-  let localStorageUnits = window.localStorage[LOCAL_STORAGE_SETTINGS_UNITS_ID]
+  const localStorageUnits = window.localStorage[LOCAL_STORAGE_SETTINGS_UNITS_ID]
+  let unitType
 
   if (localStorageUnits) {
-    store.dispatch(setUserUnits(localStorageUnits))
+    unitType = localStorageUnits
   } else if (debug.forceMetric) {
-    store.dispatch(setUserUnits(SETTINGS_UNITS_METRIC))
+    unitType = SETTINGS_UNITS_METRIC
   } else if (COUNTRIES_IMPERIAL_UNITS.indexOf(countryCode) !== -1) {
-    store.dispatch(setUserUnits(SETTINGS_UNITS_IMPERIAL))
+    unitType = SETTINGS_UNITS_IMPERIAL
   } else {
-    store.dispatch(setUserUnits(SETTINGS_UNITS_METRIC))
+    unitType = SETTINGS_UNITS_METRIC
   }
+
+  store.dispatch(setUserUnits(unitType))
 }
 
 export function updateUnits (newUnits) {
@@ -164,3 +167,20 @@ export function propagateUnits () {
       break
   }
 }
+
+/**
+ * Use subscribe() model to set localstorage (a Redux pattern)
+ * https://egghead.io/lessons/javascript-redux-persisting-the-state-to-the-local-storage
+ * https://twitter.com/dan_abramov/status/703684128416333825
+ *
+ * Benefit: LocalStorage is always reflects the store, no matter how it's updated
+ * Uses a throttle to prevent continuous rewrites
+ */
+store.subscribe(throttle(() => {
+  const unitType = store.getState().persistSettings.units
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_SETTINGS_UNITS_ID, JSON.stringify(unitType))
+  } catch (err) {
+    // Ignore write errors.
+  }
+}, 1000))

--- a/assets/scripts/users/localization.js
+++ b/assets/scripts/users/localization.js
@@ -1,4 +1,4 @@
-import { cloneDeep, throttle } from 'lodash'
+import { cloneDeep } from 'lodash'
 
 import { debug } from '../preinit/debug_settings'
 import {
@@ -167,20 +167,3 @@ export function propagateUnits () {
       break
   }
 }
-
-/**
- * Use subscribe() model to set localstorage (a Redux pattern)
- * https://egghead.io/lessons/javascript-redux-persisting-the-state-to-the-local-storage
- * https://twitter.com/dan_abramov/status/703684128416333825
- *
- * Benefit: LocalStorage is always reflects the store, no matter how it's updated
- * Uses a throttle to prevent continuous rewrites
- */
-store.subscribe(throttle(() => {
-  const unitType = store.getState().persistSettings.units
-  try {
-    window.localStorage.setItem(LOCAL_STORAGE_SETTINGS_UNITS_ID, JSON.stringify(unitType))
-  } catch (err) {
-    // Ignore write errors.
-  }
-}, 1000))

--- a/assets/scripts/users/localization.js
+++ b/assets/scripts/users/localization.js
@@ -79,13 +79,13 @@ export function updateUnitSettings (countryCode) {
   let localStorageUnits = window.localStorage[LOCAL_STORAGE_SETTINGS_UNITS_ID]
 
   if (localStorageUnits) {
-    store.dispatch(setUserUnits(parseInt(localStorageUnits)))
+    store.dispatch(setUserUnits(localStorageUnits))
   } else if (debug.forceMetric) {
-    saveUserUnits(SETTINGS_UNITS_METRIC)
+    store.dispatch(setUserUnits(SETTINGS_UNITS_METRIC))
   } else if (COUNTRIES_IMPERIAL_UNITS.indexOf(countryCode) !== -1) {
-    saveUserUnits(SETTINGS_UNITS_IMPERIAL)
+    store.dispatch(setUserUnits(SETTINGS_UNITS_IMPERIAL))
   } else {
-    saveUserUnits(SETTINGS_UNITS_METRIC)
+    store.dispatch(setUserUnits(SETTINGS_UNITS_METRIC))
   }
 }
 
@@ -96,7 +96,7 @@ export function updateUnits (newUnits) {
     return
   }
 
-  saveUserUnits(newUnits)
+  store.dispatch(setUserUnits(newUnits))
   street.units = newUnits
   setStreetDataInRedux()
 
@@ -163,9 +163,4 @@ export function propagateUnits () {
 
       break
   }
-}
-
-export function saveUserUnits (unitType) {
-  window.localStorage[LOCAL_STORAGE_SETTINGS_UNITS_ID] = unitType
-  store.dispatch(setUserUnits(parseInt(unitType)))
 }

--- a/assets/scripts/users/settings.js
+++ b/assets/scripts/users/settings.js
@@ -156,7 +156,7 @@ export function initPersistedSettingsStoreObserver () {
   const onChange = throttle((settings) => {
     try {
       window.localStorage.setItem(LOCAL_STORAGE_SETTINGS_UNITS_ID, JSON.stringify(settings.units))
-      if (typeof settings.locale !== 'undefined') {
+      if (settings.locale) {
         window.localStorage.setItem('locale', JSON.stringify(settings.locale))
       } else {
         window.localStorage.removeItem('locale')

--- a/assets/scripts/users/settings.js
+++ b/assets/scripts/users/settings.js
@@ -10,7 +10,7 @@ import { MODES, processMode, getMode, setMode } from '../app/mode'
 import { setSaveStreetIncomplete } from '../streets/xhr'
 import { newNonblockingAjaxRequest } from '../util/fetch_nonblocking'
 import { getAuthHeader, getSignInData, isSignedIn } from './authentication'
-import store from '../store'
+import store, { observeStore } from '../store'
 import { setSettings as setSettingsActionCreator } from '../store/actions/settings'
 
 export const LOCAL_STORAGE_SETTINGS_ID = 'settings'
@@ -139,4 +139,20 @@ function scheduleSavingSettingsToServer () {
 
 function clearScheduledSavingSettingsToServer () {
   window.clearTimeout(saveSettingsTimerId)
+}
+
+// Persisted settings
+
+export function initPersistedSettingsStoreObserver () {
+  const select = (state) => state.persistSettings
+  const onChange = (settings) => {
+    window.localStorage.setItem(LOCAL_STORAGE_SETTINGS_UNITS_ID, settings.units)
+    if (typeof settings.locale !== 'undefined') {
+      window.localStorage.setItem('locale', settings.locale)
+    } else {
+      window.localStorage.removeItem('locale')
+    }
+  }
+
+  return observeStore(select, onChange)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3170,7 +3170,8 @@
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "compressible": {
       "version": "2.0.13",
@@ -3345,7 +3346,8 @@
     "cookiejar": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+      "dev": true
     },
     "cookies": {
       "version": "0.7.1",
@@ -5152,7 +5154,8 @@
     "formidable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
-      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ=="
+      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ==",
+      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -7181,6 +7184,32 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
+      }
+    },
+    "intl-format-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.1.0.tgz",
+      "integrity": "sha1-BKNp/sv61tpgBbrh8UMzMy3PkxY="
+    },
+    "intl-messageformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-2.2.0.tgz",
+      "integrity": "sha1-NFvNRt5jC3aDMwwuUhd/9eq0hPw=",
+      "requires": {
+        "intl-messageformat-parser": "1.4.0"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.4.0.tgz",
+      "integrity": "sha1-tD1FqXRoytvkQzHXS7Ho3qRPwHU="
+    },
+    "intl-relativeformat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/intl-relativeformat/-/intl-relativeformat-2.1.0.tgz",
+      "integrity": "sha1-AQ8RBYAiUfQKxH0OPhogE0iiVd8=",
+      "requires": {
+        "intl-messageformat": "2.2.0"
       }
     },
     "invariant": {
@@ -12976,6 +13005,17 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-intl": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.4.0.tgz",
+      "integrity": "sha1-ZsFNyd+ac7L7v71gIXJugKYT6xU=",
+      "requires": {
+        "intl-format-cache": "2.1.0",
+        "intl-messageformat": "2.2.0",
+        "intl-relativeformat": "2.1.0",
+        "invariant": "2.2.2"
+      }
+    },
     "react-leaflet": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-1.8.2.tgz",
@@ -15032,6 +15072,7 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
       "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
@@ -15049,6 +15090,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -15056,7 +15098,8 @@
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         }
       }
     },
@@ -15064,6 +15107,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
+      "dev": true,
       "requires": {
         "methods": "1.1.2",
         "superagent": "3.8.2"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react": "16.2.0",
     "react-autosuggest": "9.3.4",
     "react-dom": "16.2.0",
+    "react-intl": "2.4.0",
     "react-leaflet": "1.8.2",
     "react-redux": "5.0.7",
     "react-transition-group": "2.2.1",

--- a/test/__mocks__/react-intl.js
+++ b/test/__mocks__/react-intl.js
@@ -1,0 +1,11 @@
+/* eslint-env jest */
+export const mockIntl = {
+  formatDate: jest.fn(),
+  formatTime: jest.fn(),
+  formatRelative: jest.fn(),
+  formatNumber: jest.fn(),
+  formatPlural: jest.fn(),
+  formatMessage: jest.fn(),
+  formatHTMLMessage: jest.fn(),
+  now: jest.fn()
+}


### PR DESCRIPTION
For some time, we have been using [`i18next`](http://i18next.com/) for internationalization / localization (or, as we usually refer to this, "translations"). We are reaching some of the limitations that this library provides, and while it has served us very well during this work, I believe we might want to consider using the [`react-intl`](https://github.com/yahoo/react-intl) library moving forward.

This PR demonstrates how this might be beneficial for us.

- `react-intl` relies on the browser-standard [`Intl`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) object under the hood. Standards-based is 👍 
- This means we get certain locale information for "free", like time/date formatting.
- Using React components instead of a `t()` in the render function allows us to update via the React lifecycle. With `t()`, changing locales will not update components automatically; it required something else (e.g. forcing an update from an [event listener](https://github.com/streetmix/streetmix/blob/master/assets/scripts/app/locale.js#L74-L75), or [updating the DOM directly with vanilla JS](https://github.com/streetmix/streetmix/blob/master/assets/scripts/menus/MenuBar.jsx#L132-L134)).
- `react-intl`'s [`<FormattedMessage />`](https://github.com/yahoo/react-intl/wiki/Components#formattedmessage) component allows us to string-replace with other React components, something that we had to hack around with `i18next` (see, for instance, [`renderByline()` in `StreetMetaData.jsx`](https://github.com/streetmix/streetmix/blob/master/assets/scripts/streets/StreetMetaData.jsx#L52-L88). Furthermore this means we can remove our own string supplanting code.
- `react-intl`'s [`<FormattedHTMLMessage />`](https://github.com/yahoo/react-intl/wiki/Components#formattedhtmlmessage) sanitises HTML tags for us, which we were not doing when we were manually using `dangerouslySetInnerHTML`.
- In `i18next`, errors would sometimes cause it to fall back to rendering a key, such as `menus.help.whatever`, which is meaningless in the UI. With `react-intl`, fallback messages are first-class functionality. All errors use the default message text and the reason for the failure will be logged in the console, making the issue easier to debug.

### Things to work on eventually

There are certain things that are obvious "next steps" beyond this exploration.

- Locale information can be fully stored in Redux. A user's selected language, if it doesn't match `navigator.language`, can be stored as a "persisted setting" (where the units setting lives right now).

### Open questions

- How do we retrieve strings outside of a React component? (For instance, to render text inside a `window.prompt()`.) The [`react-intl` API](https://github.com/yahoo/react-intl/wiki/API) seems to provide functions that can be used for this purpose, but I haven't explored how to use them yet.
- The recommended pattern is to put the `<IntlProvider>` wrapper around the entire app, but we're also doing this thing where the app is instantly updated when the setting changes, which requires setting a `key=` prop on the component in order for all the child components to know when to update. This actually causes the entire app to re-mount, which means any internal state (either in the DOM, or in React) is reset, and setup methods are called a second time (this creates problems for any component that is not designed to be unmounted and re-mounted during runtime). This is why, in this exploration, the `<IntlProvider>` only wraps specific components we want to update and not the entire application. One possible solution to this is to not show locale changes until after an app reload, which is not out of the question. Another possible thing to explore is [React's new Context API](https://github.com/reactjs/rfcs/blob/master/text/0002-new-version-of-context.md), which is slated for release in the upcoming version of React (v16.3.0). 