### PR TITLE
Completed tests for GeotagDialog component

### DIFF
--- a/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
@@ -9,26 +9,18 @@ jest.mock('../../streets/remix', () => ({
   getRemixOnFirstEdit: jest.fn()
 }))
 
-function getTestComponent (addressInformation = null, street = null) {
+function getTestComponent (addressInformation, street) {
   const testMarker = { lat: 0, lng: 0 }
-  let testAddressInfo = {
+  const testAddressInfo = addressInformation || {
     street: 'foo',
     id: 'foo'
   }
-  let testStreet = {
+  const testStreet = street || {
     creatorId: 'foo',
     location: {
       label: 'foo',
       wofId: 'foo'
     }
-  }
-
-  if (addressInformation) {
-    testAddressInfo = addressInformation
-  }
-
-  if (street) {
-    testStreet = street
   }
 
   return (

--- a/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
@@ -2,15 +2,12 @@
 import React from 'react'
 import GeotagDialog from '../GeotagDialog'
 import { shallow } from 'enzyme'
+import { getRemixOnFirstEdit } from '../../streets/remix'
 
 // Mock dependencies that could break tests
-jest.mock('../../streets/remix', () => {
-  return {
-    getRemixOnFirstEdit: () => {
-      return false
-    }
-  }
-})
+jest.mock('../../streets/remix', () => ({
+  getRemixOnFirstEdit: jest.fn()
+}))
 
 describe('GeotagDialog', () => {
   it('renders without crashing', () => {
@@ -35,13 +32,9 @@ describe('GeotagDialog', () => {
         markerLocation={testMarker}
       />
     )
-    expect(wrapper.find('button .confirm-button').length).toEqual(0)
+    expect(wrapper.find('button .confirm-button')).toHaveLength(0)
   })
-  // Current signed-in or not signed-in user compared to street owner is based on getRemixOnFirstEdit
-  // which uses store.user.signedInData. Not sure how to replicate that in testing environment.
   it('allows a location to be confirmed when the current signed-in user is the street owner', () => {
-    // getRemixOnFirstEdit returns false - meaning the current signed-in user is the street owner
-    // getRemixOnFirstEdit returns true - current signed-user or not signed in is not the street owner
     const testMarker = { lat: 0, lng: 0 }
     const testAddressInfo = {
       street: 'test street',
@@ -61,6 +54,7 @@ describe('GeotagDialog', () => {
         markerLocation={testMarker}
       />
     )
+    getRemixOnFirstEdit.mockReturnValueOnce(false)
     wrapper.setProps({
       markerLocation: { lat: 10, lng: 10 },
       addressInformation: {
@@ -68,10 +62,123 @@ describe('GeotagDialog', () => {
         id: 'test id 2'
       }
     })
-    expect(wrapper.find('button .confirm-button').length).toEqual(1)
+    expect(wrapper.find('button .confirm-button')).toHaveLength(1)
   })
-  it('allows a location to be confirmed when the current anonymous user started this street')
-  it('does not allow a location to be confirmed when the current signed-in user is not the street owner')
-  it('does not allow a location to be confirmed when the current anonymous user is not the street owner and there is already an existing location attached')
-  it('allows a location to be confirmed when the current anonymous user is not the street owner but there is no existing location attached')
+  it('allows a location to be confirmed when the current anonymous user started this street', () => {
+    const testMarker = { lat: 0, lng: 0 }
+    const testAddressInfo = {
+      street: 'test street',
+      id: 'test id'
+    }
+    const testStreet = {
+      creatorId: null,
+      location: {
+        label: 'test location',
+        wofId: 'test id'
+      }
+    }
+    const wrapper = shallow(
+      <GeotagDialog.WrappedComponent
+        street={testStreet}
+        addressInformation={testAddressInfo}
+        markerLocation={testMarker}
+      />
+    )
+    getRemixOnFirstEdit.mockReturnValueOnce(false)
+    wrapper.setProps({
+      markerLocation: { lat: 10, lng: 10 },
+      addressInformation: {
+        street: 'test street 2',
+        id: 'test id 2'
+      }
+    })
+    expect(wrapper.find('button .confirm-button')).toHaveLength(1)
+  })
+  it('does not allow a location to be confirmed when the current signed-in user is not the street owner', () => {
+    const testMarker = { lat: 0, lng: 0 }
+    const testAddressInfo = {
+      street: 'test street',
+      id: 'test id'
+    }
+    const testStreet = {
+      creatorId: 'test creator',
+      location: {
+        label: 'test location',
+        wofId: 'test id'
+      }
+    }
+    const wrapper = shallow(
+      <GeotagDialog.WrappedComponent
+        street={testStreet}
+        addressInformation={testAddressInfo}
+        markerLocation={testMarker}
+      />
+    )
+    getRemixOnFirstEdit.mockReturnValueOnce(true)
+    wrapper.setProps({
+      markerLocation: { lat: 10, lng: 10 },
+      addressInformation: {
+        street: 'test street 2',
+        id: 'test id 2'
+      }
+    })
+    expect(wrapper.find('button .confirm-button')).toHaveLength(0)
+  })
+  it('does not allow a location to be confirmed when the current anonymous user is not the street owner and there is already an existing location attached', () => {
+    const testMarker = { lat: 0, lng: 0 }
+    const testAddressInfo = {
+      street: 'test street',
+      id: 'test id'
+    }
+    const testStreet = {
+      creatorId: 'test creator',
+      location: {
+        label: 'test location',
+        wofId: 'test id'
+      }
+    }
+    const wrapper = shallow(
+      <GeotagDialog.WrappedComponent
+        street={testStreet}
+        addressInformation={testAddressInfo}
+        markerLocation={testMarker}
+      />
+    )
+    getRemixOnFirstEdit.mockReturnValueOnce(true)
+    wrapper.setProps({
+      markerLocation: { lat: 10, lng: 10 },
+      addressInformation: {
+        street: 'test street 2',
+        id: 'test id 2'
+      }
+    })
+    expect(wrapper.find('button .confirm-button')).toHaveLength(0)
+  })
+  it('allows a location to be confirmed when the current anonymous user is not the street owner but there is no existing location attached', () => {
+    const testMarker = { lat: 0, lng: 0 }
+    const testAddressInfo = {
+      street: 'test street',
+      id: 'test id'
+    }
+    const testStreet = {
+      creatorId: 'test creator',
+      location: null
+    }
+    const wrapper = shallow(
+      <GeotagDialog.WrappedComponent
+        street={testStreet}
+        addressInformation={testAddressInfo}
+        markerLocation={testMarker}
+      />
+    )
+    getRemixOnFirstEdit.mockReturnValueOnce(true)
+    wrapper.setProps({
+      markerLocation: { lat: 10, lng: 10 },
+      addressInformation: {
+        street: 'test street 2',
+        id: 'test id 2'
+      }
+    })
+    expect(wrapper.find('button .confirm-button')).toHaveLength(1)
+  })
 })

--- a/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
@@ -9,6 +9,47 @@ jest.mock('../../streets/remix', () => ({
   getRemixOnFirstEdit: jest.fn()
 }))
 
+function getTestComponent (addressInformation = null, street = null) {
+  const testMarker = { lat: 0, lng: 0 }
+  let testAddressInfo = {
+    street: 'foo',
+    id: 'foo'
+  }
+  let testStreet = {
+    creatorId: 'foo',
+    location: {
+      label: 'foo',
+      wofId: 'foo'
+    }
+  }
+
+  if (addressInformation) {
+    testAddressInfo = addressInformation
+  }
+
+  if (street) {
+    testStreet = street
+  }
+
+  return (
+    <GeotagDialog.WrappedComponent
+      street={testStreet}
+      addressInformation={testAddressInfo}
+      markerLocation={testMarker}
+    />
+  )
+}
+
+function updateProps (wrapper) {
+  wrapper.setProps({
+    markerLocation: { lat: 10, lng: 10 },
+    addressInformation: {
+      street: 'bar',
+      id: 'bar'
+    }
+  })
+}
+
 describe('GeotagDialog', () => {
   it('renders without crashing', () => {
     const wrapper = shallow(
@@ -21,164 +62,49 @@ describe('GeotagDialog', () => {
   })
 
   it('does not allow a location to be confirmed when geocoded data does not have street data', () => {
-    const testMarker = { lat: 0, lng: 0 }
     const testAddressInfo = {
       street: null
     }
-    const wrapper = shallow(
-      <GeotagDialog.WrappedComponent
-        street={{}}
-        addressInformation={testAddressInfo}
-        markerLocation={testMarker}
-      />
-    )
+    const wrapper = shallow(getTestComponent(testAddressInfo, {}))
     expect(wrapper.find('button .confirm-button')).toHaveLength(0)
   })
+
   it('allows a location to be confirmed when the current signed-in user is the street owner', () => {
-    const testMarker = { lat: 0, lng: 0 }
-    const testAddressInfo = {
-      street: 'test street',
-      id: 'test id'
-    }
-    const testStreet = {
-      creatorId: 'test creator',
-      location: {
-        label: 'test location',
-        wofId: 'test id'
-      }
-    }
-    const wrapper = shallow(
-      <GeotagDialog.WrappedComponent
-        street={testStreet}
-        addressInformation={testAddressInfo}
-        markerLocation={testMarker}
-      />
-    )
+    const wrapper = shallow(getTestComponent())
     getRemixOnFirstEdit.mockReturnValueOnce(false)
-    wrapper.setProps({
-      markerLocation: { lat: 10, lng: 10 },
-      addressInformation: {
-        street: 'test street 2',
-        id: 'test id 2'
-      }
-    })
+    updateProps(wrapper)
     expect(wrapper.find('button .confirm-button')).toHaveLength(1)
   })
+
   it('allows a location to be confirmed when the current anonymous user started this street', () => {
-    const testMarker = { lat: 0, lng: 0 }
-    const testAddressInfo = {
-      street: 'test street',
-      id: 'test id'
-    }
-    const testStreet = {
-      creatorId: null,
-      location: {
-        label: 'test location',
-        wofId: 'test id'
-      }
-    }
-    const wrapper = shallow(
-      <GeotagDialog.WrappedComponent
-        street={testStreet}
-        addressInformation={testAddressInfo}
-        markerLocation={testMarker}
-      />
-    )
+    const wrapper = shallow(getTestComponent())
     getRemixOnFirstEdit.mockReturnValueOnce(false)
-    wrapper.setProps({
-      markerLocation: { lat: 10, lng: 10 },
-      addressInformation: {
-        street: 'test street 2',
-        id: 'test id 2'
-      }
-    })
+    updateProps(wrapper)
     expect(wrapper.find('button .confirm-button')).toHaveLength(1)
   })
+
   it('does not allow a location to be confirmed when the current signed-in user is not the street owner', () => {
-    const testMarker = { lat: 0, lng: 0 }
-    const testAddressInfo = {
-      street: 'test street',
-      id: 'test id'
-    }
-    const testStreet = {
-      creatorId: 'test creator',
-      location: {
-        label: 'test location',
-        wofId: 'test id'
-      }
-    }
-    const wrapper = shallow(
-      <GeotagDialog.WrappedComponent
-        street={testStreet}
-        addressInformation={testAddressInfo}
-        markerLocation={testMarker}
-      />
-    )
+    const wrapper = shallow(getTestComponent())
     getRemixOnFirstEdit.mockReturnValueOnce(true)
-    wrapper.setProps({
-      markerLocation: { lat: 10, lng: 10 },
-      addressInformation: {
-        street: 'test street 2',
-        id: 'test id 2'
-      }
-    })
+    updateProps(wrapper)
     expect(wrapper.find('button .confirm-button')).toHaveLength(0)
   })
+
   it('does not allow a location to be confirmed when the current anonymous user is not the street owner and there is already an existing location attached', () => {
-    const testMarker = { lat: 0, lng: 0 }
-    const testAddressInfo = {
-      street: 'test street',
-      id: 'test id'
-    }
-    const testStreet = {
-      creatorId: 'test creator',
-      location: {
-        label: 'test location',
-        wofId: 'test id'
-      }
-    }
-    const wrapper = shallow(
-      <GeotagDialog.WrappedComponent
-        street={testStreet}
-        addressInformation={testAddressInfo}
-        markerLocation={testMarker}
-      />
-    )
+    const wrapper = shallow(getTestComponent())
     getRemixOnFirstEdit.mockReturnValueOnce(true)
-    wrapper.setProps({
-      markerLocation: { lat: 10, lng: 10 },
-      addressInformation: {
-        street: 'test street 2',
-        id: 'test id 2'
-      }
-    })
+    updateProps(wrapper)
     expect(wrapper.find('button .confirm-button')).toHaveLength(0)
   })
+
   it('allows a location to be confirmed when the current anonymous user is not the street owner but there is no existing location attached', () => {
-    const testMarker = { lat: 0, lng: 0 }
-    const testAddressInfo = {
-      street: 'test street',
-      id: 'test id'
-    }
     const testStreet = {
-      creatorId: 'test creator',
+      creatorId: 'foo',
       location: null
     }
-    const wrapper = shallow(
-      <GeotagDialog.WrappedComponent
-        street={testStreet}
-        addressInformation={testAddressInfo}
-        markerLocation={testMarker}
-      />
-    )
+    const wrapper = shallow(getTestComponent(null, testStreet))
     getRemixOnFirstEdit.mockReturnValueOnce(true)
-    wrapper.setProps({
-      markerLocation: { lat: 10, lng: 10 },
-      addressInformation: {
-        street: 'test street 2',
-        id: 'test id 2'
-      }
-    })
+    updateProps(wrapper)
     expect(wrapper.find('button .confirm-button')).toHaveLength(1)
   })
 })

--- a/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
@@ -4,7 +4,13 @@ import GeotagDialog from '../GeotagDialog'
 import { shallow } from 'enzyme'
 
 // Mock dependencies that could break tests
-jest.mock('../../streets/remix', () => {})
+jest.mock('../../streets/remix', () => {
+  return {
+    getRemixOnFirstEdit: () => {
+      return false
+    }
+  }
+})
 
 describe('GeotagDialog', () => {
   it('renders without crashing', () => {
@@ -17,8 +23,53 @@ describe('GeotagDialog', () => {
     expect(wrapper.exists()).toEqual(true)
   })
 
-  it('does not allow a location to be confirmed when geocoded data does not have street data')
-  it('allows a location to be confirmed when the current signed-in user is the street owner')
+  it('does not allow a location to be confirmed when geocoded data does not have street data', () => {
+    const testMarker = { lat: 0, lng: 0 }
+    const testAddressInfo = {
+      street: null
+    }
+    const wrapper = shallow(
+      <GeotagDialog.WrappedComponent
+        street={{}}
+        addressInformation={testAddressInfo}
+        markerLocation={testMarker}
+      />
+    )
+    expect(wrapper.find('button .confirm-button').length).toEqual(0)
+  })
+  // Current signed-in or not signed-in user compared to street owner is based on getRemixOnFirstEdit
+  // which uses store.user.signedInData. Not sure how to replicate that in testing environment.
+  it('allows a location to be confirmed when the current signed-in user is the street owner', () => {
+    // getRemixOnFirstEdit returns false - meaning the current signed-in user is the street owner
+    // getRemixOnFirstEdit returns true - current signed-user or not signed in is not the street owner
+    const testMarker = { lat: 0, lng: 0 }
+    const testAddressInfo = {
+      street: 'test street',
+      id: 'test id'
+    }
+    const testStreet = {
+      creatorId: 'test creator',
+      location: {
+        label: 'test location',
+        wofId: 'test id'
+      }
+    }
+    const wrapper = shallow(
+      <GeotagDialog.WrappedComponent
+        street={testStreet}
+        addressInformation={testAddressInfo}
+        markerLocation={testMarker}
+      />
+    )
+    wrapper.setProps({
+      markerLocation: { lat: 10, lng: 10 },
+      addressInformation: {
+        street: 'test street 2',
+        id: 'test id 2'
+      }
+    })
+    expect(wrapper.find('button .confirm-button').length).toEqual(1)
+  })
   it('allows a location to be confirmed when the current anonymous user started this street')
   it('does not allow a location to be confirmed when the current signed-in user is not the street owner')
   it('does not allow a location to be confirmed when the current anonymous user is not the street owner and there is already an existing location attached')


### PR DESCRIPTION
The `GeotagDialog` component determines whether or not the street owner is the current user using `getRemixOnFirstEdit`. This means that the only difference between the tests for testing street owner is current signed in user or an anonymous user in the street object which does not affect the results. 

`getRemixOnFirstEdit` should also return `false` if the current user is anonymous and the street owner is also anonymous, allowing location to be edited if the previous conditions were met. 
