### PR TITLE
Remove extraneous geolocate key

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -120,16 +120,6 @@
       "error-unavailable": "Saving to image is not available on this browser.",
       "preview-image-alt": "Preview"
     },
-    "geolocate": {
-      "search": "Search for a location",
-      "clear-search": "Clear search",
-      "zoom-in": "Zoom in",
-      "zoom-out": "Zoom out",
-      "add-location": "Add location",
-      "confirm-location": "Confirm location",
-      "clear-location": "Clear location",
-      "unknown-location": "Unknown location"
-    },
     "geotag": {
       "search": "Search for a location",
       "clear-search": "Clear search",


### PR DESCRIPTION
All translation strings were automatically saved under the new geotag key by [Transifex's TM feature](https://docs.transifex.com/setup/translation-memory). This is now safe to delete since the strings are in Transifex.

On another note, since I'm not sure if there is a Transifex backup I think _it may be smart to backup the non-English localization files to the master repo just in case_. It looks like it's been a few months since this has last been done.