### PR TITLE
Replace Creative Commons url with placeholder

### DIFF
--- a/assets/css/_dialogs.scss
+++ b/assets/css/_dialogs.scss
@@ -127,7 +127,6 @@
 }
 
 // Content of Save as Image dialog box
-// TODO: Less nesting
 .save-as-image-dialog {
   width: 700px;
 

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -115,7 +115,7 @@
       "option-sky": "Transparent sky",
       "loading": "Loading…",
       "save-button": "Save to your computer…",
-      "license": "This Streetmix-created image may be reused anywhere, for any purpose, under the <br><a href='http://creativecommons.org/licenses/by-sa/4.0/'>Creative Commons Attribution-ShareAlike 4.0 International License</a>.",
+      "license": "This Streetmix-created image may be reused anywhere, for any purpose, under the <br><a href='{url}'>Creative Commons Attribution-ShareAlike 4.0 International License</a>.",
       "error-preview": "There was an error displaying a preview image.",
       "error-unavailable": "Saving to image is not available on this browser.",
       "preview-image-alt": "Preview"


### PR DESCRIPTION
This updates the translation string for the Creative Commons license link so that the URL is replaced with a placeholder, allowing the URL to be determined in the code (so that [the link is based on the user's locale](https://github.com/streetmix/streetmix/blob/master/assets/scripts/dialogs/SaveAsImageDialog.jsx#L140-L180)).

This may affect the existing translations, so @treyhahn please approve and merge when you're ready to address this.