### PR TITLE
Support right-to-left languages

### DIFF
--- a/assets/css/_info-bubble.scss
+++ b/assets/css/_info-bubble.scss
@@ -378,3 +378,33 @@
   font-weight: 300;
   line-height: 1.25;
 }
+
+[dir='rtl'] {
+  .info-bubble-remove {
+    margin-left: 0;
+    margin-right: 1em;
+  }
+
+  .variants {
+    text-align: right;
+    margin-left: 20px;
+    margin-right: 0;
+    direction: ltr;
+  }
+
+  .non-variant > input {
+    direction: ltr;
+  }
+
+  .info-bubble-type-building header {
+    margin-left: 90px + 50px;
+    margin-right: 0;
+
+    &::after {
+      left: -37px;
+      right: auto;
+      border-left: 37px solid transparent;
+      border-right: none;
+    }
+  }
+}

--- a/assets/css/_menu-bar.scss
+++ b/assets/css/_menu-bar.scss
@@ -171,3 +171,14 @@ $top-menu-active-text: darken($ui-colour, 40%);
     background-color: rgb(28, 189, 209);
   }
 }
+
+[dir='rtl'] {
+  .menu-bar-right {
+    float: left;
+  }
+
+  .environment-badge {
+    right: 14px;
+    left: auto;
+  }
+}

--- a/assets/css/_menus.scss
+++ b/assets/css/_menus.scss
@@ -149,3 +149,17 @@ body.safari .menu {
   max-width: 400px;
   line-height: 18px;
 }
+
+[dir='rtl'] {
+  .menu {
+    &.align-right {
+      left: $left-right-inset;
+      right: auto;
+    }
+
+    .icon {
+      left: auto;
+      right: 0.75em;
+    }
+  }
+}

--- a/assets/css/_palette.scss
+++ b/assets/css/_palette.scss
@@ -93,3 +93,10 @@ body.read-only .palette-container {
     transform: translateY(0);
   }
 }
+
+[dir='rtl'] {
+  .palette-commands {
+    left: 10px;
+    right: auto;
+  }
+}

--- a/assets/css/_street-name.scss
+++ b/assets/css/_street-name.scss
@@ -40,6 +40,10 @@ body.read-only .street-name-canvas {
   font-size: 40px * $size;
   line-height: 30px * $size;
   letter-spacing: 1px * $size;
+
+  [dir='rtl'] {
+    font-size: 30px * $size;
+  }
 }
 
 @mixin street-name-fallback-mixin($size: $street-name-size) {

--- a/assets/css/_street-section.scss
+++ b/assets/css/_street-section.scss
@@ -142,3 +142,11 @@
 #street-section-left-building-old .hover-bk {
   right: 25px;
 }
+
+[dir='rtl'] {
+  #street-section-canvas,
+  .street-scroll-indicator-left,
+  .street-scroll-indicator-right {
+    direction: ltr;
+  }
+}

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -231,6 +231,7 @@
   },
   "i18n": {
     "lang": {
+      "ar": "Arabic",
       "en": "English",
       "en@pirate": "English (Pirate)",
       "fi": "Finnish",

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -41,6 +41,11 @@ export function initLocale (experimental) {
     locale = 'en'
   }
 
+  // right-to-left languages support
+  if (['ar', 'dv', 'fa', 'he'].indexOf(locale) > -1) {
+    document.body.dir = 'rtl'
+  }
+
   doTheI18n(locale)
 }
 

--- a/assets/scripts/menus/LocaleDropdown.jsx
+++ b/assets/scripts/menus/LocaleDropdown.jsx
@@ -20,6 +20,12 @@ import { trackEvent } from '../app/event_tracking'
  */
 const LOCALES = [
   {
+    label: 'Arabic',
+    value: 'ar',
+    key: 'i18n.lang.ar',
+    level: 1
+  },
+  {
     label: 'Chinese (Traditional)',
     value: 'zh-Hant',
     key: 'i18n.lang.zh-hant',

--- a/assets/scripts/streets/SearchAddress.jsx
+++ b/assets/scripts/streets/SearchAddress.jsx
@@ -219,7 +219,7 @@ export class SearchAddress extends React.Component {
     // Note: `alwaysRenderSuggestions` is required to be true otherwise
     // click events on the item list is swallowed. This is a bug
     return (
-      <form className="geotag-input-form" onSubmit={this.onSubmitInput}>
+      <form className="geotag-input-form" onSubmit={this.onSubmitInput} dir="auto">
         <Autosuggest
           ref={(ref) => { this.autosuggestBar = ref }}
           suggestions={this.state.suggestions}


### PR DESCRIPTION
Closes #834   (expecting Arabic translations to be ready in the next few days)

- Most of the changes are CSS, affecting only inside ```<body dir="rtl"> ... </body>```
- JS sets ```document.body.dir = 'rtl'``` if locale is Arabic or other known RTL languages
- Adds ```dir='auto'``` to the map's search bar (adapts direction to what the user types)
- Adds 'ar' Arabic locale to dropdown (I'm not sure what 'level' number means here)
- Avoids flipping segments of a road, arrows, segment options ( ie, doesn't mess up the order of [left, center, right] turn options to [right center left] )