### PR TITLE
Adopt single brackets in translation string placeholders

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -105,7 +105,7 @@
       "heading": "About Streetmix.",
       "description": "Design, remix, and share your street. Add bike paths, widen sidewalks or traffic lanes, learn how all of this can impact your community.",
       "thanks": "Many thanks to the staff and 2013 CfA fellows for their support and patience, the Blockee team for paving the way, and all of our testers for their time and feedback!",
-      "credits": "A side project by {{cfaLink}} 2013 fellows:",
+      "credits": "A side project by {cfaLink} 2013 fellows:",
       "team-heading": "Project team and maintainers",
       "view-source": "View source code",
       "sponsored-by": "Streetmix is generously sponsored by:",
@@ -144,8 +144,8 @@
   },
   "prompt": {
     "new-street": "New street name:",
-    "delete-street": "Are you sure you want to permanently delete {{streetName}}? This cannot be undone.",
-    "new-width": "New street width (from {{minWidth}} to {{maxWidth}}):"
+    "delete-street": "Are you sure you want to permanently delete {streetName}? This cannot be undone.",
+    "new-width": "New street width (from {minWidth} to {maxWidth}):"
   },
   "toast": {
     "segment-deleted": "The segment has been removed.",
@@ -161,9 +161,9 @@
     "remove": "Drag here to remove"
   },
   "width": {
-    "label": "{{width}} width",
-    "under": "({{width}} room)",
-    "over": "({{width}} over)",
+    "label": "{width} width",
+    "under": "({width} room)",
+    "over": "({width} over)",
     "occupied": "Occupied width:",
     "building": "Building-to-building width:",
     "different": "Different width…",
@@ -173,8 +173,8 @@
   "datetime": {
     "minutes-ago": "A few minutes ago",
     "seconds-ago": "A few seconds ago",
-    "yesterday": "Yesterday at {{time}}",
-    "today": "Today at {{time}}",
+    "yesterday": "Yesterday at {time}",
+    "today": "Today at {time}",
     "format-date-no-year": "MMM D",
     "format-date-with-year": "MMM D, YYYY",
     "format-time": "HH:MM"
@@ -218,12 +218,12 @@
     "twitter-link": "Twitter profile",
     "delete-street-tooltip": "Delete street",
     "street-count-none": "No streets yet",
-    "street-count": "{{count}} street",
-    "street-count_plural": "{{count}} streets"
+    "street-count": "{count} street",
+    "street-count_plural": "{count} streets"
   },
   "users": {
     "anonymous": "Anonymous",
-    "byline": "by {{user}}"
+    "byline": "by {user}"
   },
   "sign-in": {
     "link": "Sign in with Twitter",

--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -61,11 +61,15 @@ function doTheI18n (locale) {
     returnEmptyString: false,
     load: 'all',
     backend: {
-      loadPath: API_URL + 'v1/translate/{{lng}}/{{ns}}'
+      loadPath: API_URL + 'v1/translate/{lng}/{ns}'
     },
-    // Do not escape characters automatically. React already escapes strings,
-    // so we want to avoid double-escaping output.
-    interpolation: { escapeValue: false }
+    interpolation: {
+      prefix: '{',
+      suffix: '}',
+      // Do not escape characters automatically. React already escapes strings,
+      // so we want to avoid double-escaping output.
+      escapeValue: false
+    }
   }
 
   const callback = function (err, t) {

--- a/assets/scripts/gallery/Gallery.jsx
+++ b/assets/scripts/gallery/Gallery.jsx
@@ -23,7 +23,7 @@ function getStreetCountText (count) {
   if (!count) {
     text = t('gallery.street-count-none', 'No streets yet')
   } else {
-    text = t('gallery.street-count', '{{count}} streets', { count })
+    text = t('gallery.street-count', '{count} streets', { count })
   }
   return text
 }

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -58,7 +58,7 @@ class GalleryStreetItem extends React.Component {
     const street = this.props.street
 
     // TODO escape name
-    const message = t('prompt.delete-street', 'Are you sure you want to permanently delete {{streetName}}? This cannot be undone.', { streetName: street.name })
+    const message = t('prompt.delete-street', 'Are you sure you want to permanently delete {streetName}? This cannot be undone.', { streetName: street.name })
 
     if (window.confirm(message)) {
       this.props.handleDelete(street.id)

--- a/assets/scripts/streets/StreetMetaData.jsx
+++ b/assets/scripts/streets/StreetMetaData.jsx
@@ -101,7 +101,7 @@ class StreetMetaData extends React.Component {
     if (creatorId && (!this.props.signedIn || (creatorId !== this.props.userId))) {
       author = this.renderByline(creatorId)
     } else if (!creatorId && (this.props.signedIn || getRemixOnFirstEdit())) {
-      author = t('users.byline', 'by {{user}}', { user: t('users.anonymous', 'Anonymous') })
+      author = t('users.byline', 'by {user}', { user: t('users.anonymous', 'Anonymous') })
     }
 
     const geolocation = (this.props.enableLocation) ? this.renderGeotag(this.props.street, this.props.readOnly) : null

--- a/assets/scripts/streets/StreetWidth.jsx
+++ b/assets/scripts/streets/StreetWidth.jsx
@@ -38,10 +38,10 @@ class StreetWidth extends React.Component {
 
     if (this.props.street.remainingWidth > 0) {
       differenceClass = 'street-width-under'
-      differenceString = t('width.room', '({{width}} room)', { width })
+      differenceString = t('width.room', '({width} room)', { width })
     } else if (this.props.street.remainingWidth < 0) {
       differenceClass = 'street-width-over'
-      differenceString = t('width.over', '({{width}} over)', { width })
+      differenceString = t('width.over', '({width} over)', { width })
     }
 
     return { class: differenceClass, width: differenceString }
@@ -156,7 +156,7 @@ class StreetWidth extends React.Component {
         minWidth: prettifyWidth(MIN_CUSTOM_STREET_WIDTH, this.props.street.units),
         maxWidth: prettifyWidth(MAX_CUSTOM_STREET_WIDTH, this.props.street.units)
       }
-      const promptString = t('prompt.new-width', 'New street width (from {{minWidth}} to {{maxWidth}}):', replacements)
+      const promptString = t('prompt.new-width', 'New street width (from {minWidth} to {maxWidth}):', replacements)
       let width = window.prompt(promptString, prettifyWidth(promptValue, this.props.street.units))
 
       if (width) {
@@ -191,7 +191,7 @@ class StreetWidth extends React.Component {
   render () {
     // TODO work on this so that we can use markup
     const width = prettifyWidth(this.props.street.width, this.props.street.units, { markup: false })
-    const widthString = t('width.label', '{{width}} width', { width })
+    const widthString = t('width.label', '{width} width', { width })
     const difference = this.displayStreetWidthRemaining()
     const differenceClass = `street-width-read-difference ${difference.class}`
 

--- a/assets/scripts/util/date_format.js
+++ b/assets/scripts/util/date_format.js
@@ -29,11 +29,11 @@ export function formatDate (dateString) {
   const timeFormat = t('datetime.format-time', TIME_FORMAT)
 
   if (now.isSame(date, 'day')) {
-    return t('datetime.today', 'Today at {{time}}', { time: date.format(timeFormat) })
+    return t('datetime.today', 'Today at {time}', { time: date.format(timeFormat) })
   }
 
   if (now.clone().subtract(1, 'day').isSame(date, 'day')) {
-    return t('datetime.yesterday', 'Yesterday at {{time}}', { time: date.format(timeFormat) })
+    return t('datetime.yesterday', 'Yesterday at {time}', { time: date.format(timeFormat) })
   }
 
   if (now.isSame(date, 'year')) {


### PR DESCRIPTION
This PR makes a change to use single bracket delimiters for placeholders in translation strings, e.g. `click this {link}`, instead of double bracket delimiters `like {{this}}`. We are making this change because we are shifting toward using `react-intl` as the primary i18n framework, which uses single brackets by default, versus `i18next`, which uses double brackets by default. To continue to support `i18next` where we still need it, it is now configured to use single bracket delimiters for placeholders.

This change also allows us to handle delimiters consistently in Transifex.

This makes some changes to translation strings, which may or may not be handled by Transifex. @treyhahn please let me know when you are ready to address any potential changes to strings in Transifex.