### PR TITLE
Make a humans.txt

### DIFF
--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -23,6 +23,7 @@
 
     <link href="/favicon.ico" rel="shortcut icon">
     <link href="/assets/css/styles.css" rel="stylesheet">
+    <link href="/humans.txt" rel="author">
 
     {{#config.google_analytics_account}}
     {{! Placed in head per Google's instructions }} 

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,0 +1,114 @@
+# humanstxt.org/
+# The humans responsible & technology colophon
+
+# TEAM
+
+    Lou Huang, project lead
+    @saikofish
+    Brooklyn, NY, USA
+
+    Marcin Wichary, UI engineer, project manager
+    @mwichary
+    San Francisco, CA, USA
+
+    Katie Lewis, illustrator, art director
+    @klizlewis
+    San Francisco, CA, USA
+
+    Shaunak Kashyap, backend engineer
+    @ycombinator
+    San Jose, CA, USA
+
+    Ezra Spier, engineer, spokesperson
+    @ahhrrr
+    Oakland, CA, USA
+
+    Marc Hébert, anthropologist
+    San Francisco, CA, USA
+
+    Anselm Bradford, frontend engineer, media production
+    San Francisco, CA, USA
+
+    Drew Dara-Abrams, engineer
+    San Francisco, CA, USA
+
+    Tomasz Magulski, engineer
+    Poland
+
+    Ryder Ross, engineer
+    California, USA
+
+    Trey Hahn, translation coordinator
+    New York City, NY, USA
+
+    Shemar Dacosta, engineer
+    New York City, NY, USA
+
+    Mandy Kong, engineer
+    New York City, NY, USA
+
+
+# THANKS
+
+    Jen Pahlka, for believing in us
+    Mike Migurski, for keeping things warm
+    Billy Riggs and Michael Boswell, for taking the next step
+    Andrew Hyder, domain expertise
+    SaraT Mayer, vision zero
+    Patrick McDonnell, styleguide
+    Pia Mancini, donations
+    Dave Guarino, database admin
+    Matt Hampel and Brandon Liu, engineering mentors
+    Amir Reavis-Bey, database migration
+    Debs Schrimmer, flex zones
+    Nick Doiron, right-to-left localization
+
+
+    Advisors
+
+    Adrian Mak
+    Molly King
+
+
+    Translators
+
+    Diana M. Alhaj, Arabic
+    Wen Jing Jiang, Chinese (Traditional)
+    Aleksi Kinnunen, Finnish
+    Denis Devillé, French
+    Philippe Provost, French
+    "iltarus", German
+    Honorata Grzesikowska, Polish
+    Tomasz Magulski, Polish
+    Weronika Grzejszczak, Polish
+    Carlos Jimenez, Portuguese (Brazil)
+    Stephan Garcia, Portuguese (Brazil)
+    Paco Marquez, Spanish (Mexico)
+    Jakob Fahlstedt, Swedish
+
+
+    Additional illustrations
+
+    Doneliza Joaquin
+    Peter Welte
+    Jon Reese
+
+
+    Additional code
+
+    Cody Moss
+    Maciej Kus
+    Alex Ellis
+    Radosław Miernik
+    Don McCurdy
+    Tommi Vainikainen
+    Kieran Farr
+    Oluwaseun Omoyajowo
+    Ayush Rawal
+
+
+    Incubators
+
+    Code for America
+    NEW INC
+    Civic Hall


### PR DESCRIPTION
This is a way to address the issues in #754 without committing to (a) design / layout (b) code (c) translations. [humans.txt](http://humanstxt.org/) is a common (though not standardized) method for people working on sites to record a list of the people who have contributed to a project. Here, we adopt their structure of "TEAM" and "THANKS" -- in our case, TEAM is anyone who has made significant and ongoing material contributions to the project, and THANKS is everyone else. Translators are currently under "THANKS" but we could always move it if we want. The beauty of the text file is that we can make edits to it without needing to involve an entire team of people.