### PR TITLE
Add {} floor and {} floors to translation file

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -229,7 +229,10 @@
     "increase-width": "Increase width (hold Shift for more precision)",
     "decrease-width": "Decrease width (hold Shift for more precision)",
     "add-floor": "Add floor",
-    "remove-floor": "Remove floor"
+    "remove-floor": "Remove floor",
+    "number-floor": "{number} floor",
+    "number-floors": "{number} floors",
+    "number-floors-large": "{number} floors"
   },
   "street": {
     "default-name": "Unnamed St",


### PR DESCRIPTION
This resolves issue #879. _Note to self:_ I will need to add in context to the strings in Transifex to explain the difference between “number-floors” and “number-floors-large”.