### PR TITLE
Add Japanese to i18n keys

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -276,14 +276,13 @@
   "i18n": {
     "lang": {
       "ar": "Arabic",
+      "de": "German",
       "en": "English",
-      "en@pirate": "English (Pirate)",
+      "es": "Spanish",
+      "es-mx": "Spanish (Mexico)",
       "fi": "Finnish",
       "fr": "French",
       "ja": "Japanese",
-      "de": "German",
-      "es": "Spanish",
-      "es-mx": "Spanish (Mexico)",
       "pl": "Polish",
       "pt-br": "Portuguese (Brazil)",
       "sv": "Swedish",

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -280,6 +280,7 @@
       "en@pirate": "English (Pirate)",
       "fi": "Finnish",
       "fr": "French",
+      "ja": "Japanese",
       "de": "German",
       "es": "Spanish",
       "es-mx": "Spanish (Mexico)",


### PR DESCRIPTION
Adding the `"ja": "Japanese"` to main.json. Also @louh, I have 2 other question on this section:

1. Should the language names be alphabetically ordered here? These 3 are out of order right now: "de": "German", "es": "Spanish", "es-mx": "Spanish (Mexico)".

2. Did we delete Pirate English before? I'm not sure why it's showing up for me. Hopefully I'm not doing something wrong.