### PR TITLE
Add a "3+" form of {count} streets

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -259,7 +259,8 @@
     "delete-street-tooltip": "Delete street",
     "street-count-none": "No streets yet",
     "street-count": "{count} street",
-    "street-count_plural": "{count} streets"
+    "street-count_plural": "{count} streets",
+    "street-count_plural-large": "{count} streets"
   },
   "users": {
     "anonymous": "Anonymous",


### PR DESCRIPTION
In Arabic, a pair (2) has different grammar than 3 or more. This was taken into account when we created the `floors` string [here](https://github.com/streetmix/streetmix/issues/879#issuecomment-376205921) but we still need to do this for `streets`.