### PR TITLE
Migrating building code to Building React component

### DIFF
--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -519,7 +519,7 @@ body.segment-move-dragging #editable-street-section > div {
   pointer-events: none;
 }
 
-.switching-away-pre {
+.switching-away-exit {
   position: absolute;
   z-index: $z-10-switch-away;
   pointer-events: none;
@@ -532,18 +532,18 @@ body.segment-move-dragging #editable-street-section > div {
   }
 }
 
-.switching-away-post {
+.switching-away-exit-done {
   z-index: $z-10-switch-away !important;
 }
 
-.switching-away-post canvas {
+.switching-away-exit-active canvas {
   transition: transform $segment-switching-time ease-in, opacity $segment-switching-time ease-in !important;
   transform: rotateX(-60deg);
   transform-origin: 50% 120%;
   opacity: 0;
 }
 
-.switching-in-pre {
+.switching-in-enter {
   z-index: -1 !important;
   perspective: 400px;
 
@@ -554,11 +554,11 @@ body.segment-move-dragging #editable-street-section > div {
   }
 }
 
-.switching-in-post {
+.switching-in-enter-done {
   z-index: -1 !important;
 }
 
-.switching-in-post canvas {
+.switching-in-enter-active canvas {
   opacity: 1;
   transition: transform $segment-switching-time, opacity $segment-switching-time !important;
   transform: none;

--- a/assets/css/_street-section.scss
+++ b/assets/css/_street-section.scss
@@ -123,26 +123,6 @@
   }
 }
 
-#street-section-left-building,
-#street-section-left-building-old {
-  left: 0;
-}
-
-#street-section-right-building,
-#street-section-right-building-old {
-  right: 0;
-}
-
-#street-section-right-building .hover-bk,
-#street-section-right-building-old .hover-bk {
-  left: 25px;
-}
-
-#street-section-left-building .hover-bk,
-#street-section-left-building-old .hover-bk {
-  right: 25px;
-}
-
 [dir='rtl'] {
   #street-section-canvas,
   .street-scroll-indicator-left,

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import SkyBackground from './SkyBackground'
 import ScrollIndicators from './ScrollIndicators'
+import Building from '../segments/Building'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { animate } from '../util/helpers'
 import { MAX_CUSTOM_STREET_WIDTH } from '../streets/width'
@@ -152,12 +153,8 @@ class StreetView extends React.Component {
         >
           <section id="street-section-inner" ref={(ref) => { this.streetSectionInner = ref }}>
             <section id="street-section-canvas">
-              <section id="street-section-left-building" className="street-section-building">
-                <div className="hover-bk" />
-              </section>
-              <section id="street-section-right-building" className="street-section-building">
-                <div className="hover-bk" />
-              </section>
+              <Building position="left" />
+              <Building position="right" />
               <div id="street-section-editable" />
               <div id="street-section-left-empty-space" className="segment empty" />
               <div id="street-section-right-empty-space" className="segment empty" />

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -166,16 +166,10 @@ class StreetView extends React.Component {
   calculateBuildingPerspective = (el) => {
     const pos = getElAbsolutePos(el)
     const perspective = -(pos[0] - this.streetSectionOuter.scrollLeft - (this.props.system.viewportWidth / 2))
-    return perspective
-  }
 
-  calculateOldBuildingStyle = (el) => {
-    const pos = getElAbsolutePos(el)
-    const style = {
-      left: (pos[0] - this.streetSectionOuter.scrollLeft) + 'px',
-      top: pos[1] + 'px'
-    }
-    return style
+    el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
+    el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'
+    el.style.perspectiveOrigin = (perspective / 2) + 'px 50%'
   }
 
   render () {

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -12,7 +12,7 @@ import SkyBackground from './SkyBackground'
 import ScrollIndicators from './ScrollIndicators'
 import Building from '../segments/Building'
 import { infoBubble } from '../info_bubble/info_bubble'
-import { animate } from '../util/helpers'
+import { animate, getElAbsolutePos } from '../util/helpers'
 import { MAX_CUSTOM_STREET_WIDTH } from '../streets/width'
 import { app } from '../preinit/app_settings'
 
@@ -33,8 +33,14 @@ class StreetView extends React.Component {
 
       streetSectionSkyTop: 0,
       scrollTop: 0,
-      skyTop: 0
+      skyTop: 0,
+
+      buildingWidth: 0
     }
+  }
+
+  componentDidMount () {
+    this.getBuildingWidth()
   }
 
   componentDidUpdate (prevProps) {
@@ -143,6 +149,35 @@ class StreetView extends React.Component {
     animate(el, { scrollLeft: newScrollLeft }, 300)
   }
 
+  getBuildingWidth = () => {
+    const el = this.streetSectionEditable
+    const pos = getElAbsolutePos(el)
+
+    let width = pos[0] + 25
+    if (width < 0) {
+      width = 0
+    }
+
+    this.setState({
+      buildingWidth: width
+    })
+  }
+
+  calculateBuildingPerspective = (el) => {
+    const pos = getElAbsolutePos(el)
+    const perspective = -(pos[0] - this.streetSectionOuter.scrollLeft - (this.props.system.viewportWidth / 2))
+    return perspective
+  }
+
+  calculateOldBuildingStyle = (el) => {
+    const pos = getElAbsolutePos(el)
+    const style = {
+      left: (pos[0] - this.streetSectionOuter.scrollLeft) + 'px',
+      top: pos[1] + 'px'
+    }
+    return style
+  }
+
   render () {
     return (
       <React.Fragment>
@@ -153,9 +188,19 @@ class StreetView extends React.Component {
         >
           <section id="street-section-inner" ref={(ref) => { this.streetSectionInner = ref }}>
             <section id="street-section-canvas">
-              <Building position="left" />
-              <Building position="right" />
-              <div id="street-section-editable" />
+              <Building
+                position="left"
+                buildingWidth={this.state.buildingWidth}
+                calculateBuildingPerspective={this.calculateBuildingPerspective}
+                calculateOldBuildingStyle={this.calculateOldBuildingStyle}
+              />
+              <Building
+                position="right"
+                buildingWidth={this.state.buildingWidth}
+                calculateBuildingPerspective={this.calculateBuildingPerspective}
+                calculateOldBuildingStyle={this.calculateOldBuildingStyle}
+              />
+              <div id="street-section-editable" ref={(ref) => { this.streetSectionEditable = ref }} />
               <div id="street-section-left-empty-space" className="segment empty" />
               <div id="street-section-right-empty-space" className="segment empty" />
               <section id="street-section-dirt" />

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -173,6 +173,11 @@ class StreetView extends React.Component {
   }
 
   render () {
+    const dirtStyle = {
+      marginLeft: (-this.state.buildingWidth) + 'px',
+      marginRight: (-this.state.buildingWidth) + 'px'
+    }
+
     return (
       <React.Fragment>
         <section
@@ -186,18 +191,16 @@ class StreetView extends React.Component {
                 position="left"
                 buildingWidth={this.state.buildingWidth}
                 calculateBuildingPerspective={this.calculateBuildingPerspective}
-                calculateOldBuildingStyle={this.calculateOldBuildingStyle}
               />
               <Building
                 position="right"
                 buildingWidth={this.state.buildingWidth}
                 calculateBuildingPerspective={this.calculateBuildingPerspective}
-                calculateOldBuildingStyle={this.calculateOldBuildingStyle}
               />
               <div id="street-section-editable" ref={(ref) => { this.streetSectionEditable = ref }} />
               <div id="street-section-left-empty-space" className="segment empty" />
               <div id="street-section-right-empty-space" className="segment empty" />
-              <section id="street-section-dirt" />
+              <section id="street-section-dirt" style={dirtStyle} />
             </section>
           </section>
         </section>

--- a/assets/scripts/app/event_listeners.js
+++ b/assets/scripts/app/event_listeners.js
@@ -1,8 +1,4 @@
 import {
-  onBuildingMouseEnter,
-  onBuildingMouseLeave
-} from '../segments/buildings'
-import {
   onBodyMouseDown,
   onBodyMouseMove,
   onBodyMouseUp
@@ -12,11 +8,6 @@ import { onGlobalKeyDown } from './keyboard_commands'
 import { onResize } from './window_resize'
 
 export function addEventListeners () {
-  document.querySelector('#street-section-left-building').addEventListener('pointerenter', onBuildingMouseEnter)
-  document.querySelector('#street-section-left-building').addEventListener('pointerleave', onBuildingMouseLeave)
-  document.querySelector('#street-section-right-building').addEventListener('pointerenter', onBuildingMouseEnter)
-  document.querySelector('#street-section-right-building').addEventListener('pointerleave', onBuildingMouseLeave)
-
   window.addEventListener('storage', onStorageChange)
 
   window.addEventListener('resize', onResize)

--- a/assets/scripts/app/keyboard_commands.js
+++ b/assets/scripts/app/keyboard_commands.js
@@ -18,7 +18,6 @@ import { isFocusOnBody } from '../util/focus'
 import { registerKeypress } from './keypress'
 import { showStatusMessage } from './status_message'
 import { t } from './locale'
-import { addBuildingFloor, removeBuildingFloor } from '../store/actions/street'
 import { showDialog } from '../store/actions/dialogs'
 import store from '../store'
 
@@ -77,18 +76,6 @@ function onBodyKeyDown (event) {
       if (hoveredEl) {
         if (hoveredEl.classList.contains('segment')) {
           incrementSegmentWidth(hoveredEl, !negative, event.shiftKey)
-        } else if (hoveredEl.id === 'street-section-left-building') {
-          if (negative) {
-            store.dispatch(removeBuildingFloor('left'))
-          } else {
-            store.dispatch(addBuildingFloor('left'))
-          }
-        } else if (hoveredEl.id === 'street-section-right-building') {
-          if (negative) {
-            store.dispatch(removeBuildingFloor('right'))
-          } else {
-            store.dispatch(addBuildingFloor('right'))
-          }
         }
         event.preventDefault()
 

--- a/assets/scripts/app/window_resize.js
+++ b/assets/scripts/app/window_resize.js
@@ -1,11 +1,7 @@
 import { infoBubble } from '../info_bubble/info_bubble'
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
-import {
-  BUILDING_SPACE,
-  updateBuildingPosition
-  // createBuildings
-} from '../segments/buildings'
+import { BUILDING_SPACE } from '../segments/buildings'
 import { TILE_SIZE } from '../segments/view'
 import store from '../store'
 import { windowResize } from '../store/actions/system'
@@ -70,8 +66,4 @@ export function onResize () {
     (street.width * TILE_SIZE) + 'px'
 
   infoBubble.show(true)
-
-  updateBuildingPosition()
-  // TODO hack
-  // createBuildings()
 }

--- a/assets/scripts/app/window_resize.js
+++ b/assets/scripts/app/window_resize.js
@@ -3,8 +3,8 @@ import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
 import {
   BUILDING_SPACE,
-  updateBuildingPosition,
-  createBuildings
+  updateBuildingPosition
+  // createBuildings
 } from '../segments/buildings'
 import { TILE_SIZE } from '../segments/view'
 import store from '../store'
@@ -73,5 +73,5 @@ export function onResize () {
 
   updateBuildingPosition()
   // TODO hack
-  createBuildings()
+  // createBuildings()
 }

--- a/assets/scripts/info_bubble/BuildingHeightControl.jsx
+++ b/assets/scripts/info_bubble/BuildingHeightControl.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { debounce } from 'lodash'
 import { t } from '../app/locale'
-import { MAX_BUILDING_HEIGHT, BUILDINGS, calculateRealHeightNumber, buildingHeightUpdated } from '../segments/buildings'
+import { MAX_BUILDING_HEIGHT, BUILDINGS, calculateRealHeightNumber } from '../segments/buildings'
 import { addBuildingFloor, removeBuildingFloor, setBuildingFloorValue } from '../store/actions/street'
 import { prettifyWidth } from '../util/width_units'
 import { KEYS } from '../app/keyboard_commands'
@@ -64,12 +64,10 @@ class BuildingHeightControl extends React.Component {
 
   onClickIncrement = () => {
     this.props.addBuildingFloor(this.props.position)
-    buildingHeightUpdated()
   }
 
   onClickDecrement = () => {
     this.props.removeBuildingFloor(this.props.position)
-    buildingHeightUpdated()
   }
 
   onInput = (event) => {
@@ -197,7 +195,6 @@ class BuildingHeightControl extends React.Component {
    */
   updateModel = (value) => {
     this.props.setBuildingFloorValue(this.props.position, value)
-    buildingHeightUpdated()
   }
 
   /**

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -164,6 +164,13 @@ class InfoBubble extends React.Component {
     this.el.style.MozTransformOrigin = '50% ' + height + 'px'
     this.el.style.transformOrigin = '50% ' + height + 'px'
 
+    // When the infoBubble needed to be shown for the right building,the offsetWidth
+    // used to calculate the left style was from the previous rendering of this component.
+    // This meant that if the last time the infoBubble was shown was for a segment, then the
+    // offsetWidth used to calculate the new left style would be smaller than it should be.
+    // The current solution is to manually recalculate the left style and set the style
+    // when hovering over the right building.
+
     if (this.state.type === INFO_BUBBLE_TYPE_RIGHT_BUILDING) {
       const bubbleX = this.props.system.viewportWidth - this.el.offsetWidth - 50
       infoBubble.bubbleX = bubbleX

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -28,10 +28,7 @@ const MIN_TOP_MARGIN_FROM_VIEWPORT = 120
 class InfoBubble extends React.Component {
   static propTypes = {
     visible: PropTypes.bool.isRequired,
-    dataNo: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+    dataNo: PropTypes.string,
     setInfoBubbleMouseInside: PropTypes.func,
     street: PropTypes.object,
     system: PropTypes.object

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -169,13 +169,13 @@ class InfoBubble extends React.Component {
         break
       }
       case INFO_BUBBLE_TYPE_LEFT_BUILDING: {
-        const variantId = this.state.street.leftBuildingVariant
+        const variantId = this.props.street.leftBuildingVariant
         const backupName = BUILDINGS[variantId].label
         name = t(`buildings.${variantId}.name`, backupName, { ns: 'segment-info' })
         break
       }
       case INFO_BUBBLE_TYPE_RIGHT_BUILDING: {
-        const variantId = this.state.street.rightBuildingVariant
+        const variantId = this.props.street.rightBuildingVariant
         const backupName = BUILDINGS[variantId].label
         name = t(`buildings.${variantId}.name`, backupName, { ns: 'segment-info' })
         break

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -123,10 +123,8 @@ class InfoBubble extends React.Component {
     this.setState({ highlightTriangle: !this.state.highlightTriangle })
   }
 
-  updateInfoBubbleForBuildings = (dataNo, street) => {
-    const type = (dataNo === 'left') ? INFO_BUBBLE_TYPE_LEFT_BUILDING
-      : (dataNo === 'right') ? INFO_BUBBLE_TYPE_RIGHT_BUILDING
-        : INFO_BUBBLE_TYPE_SEGMENT
+  updateInfoBubbleForBuildings = (position, street) => {
+    const type = (position === 'left') ? INFO_BUBBLE_TYPE_LEFT_BUILDING : INFO_BUBBLE_TYPE_RIGHT_BUILDING
 
     if (this.state.type !== type) {
       this.setState({

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -26,7 +26,10 @@ const INFO_BUBBLE_TYPE_RIGHT_BUILDING = 3
 class InfoBubble extends React.Component {
   static propTypes = {
     visible: PropTypes.bool.isRequired,
-    dataNo: PropTypes.string,
+    dataNo: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
     setInfoBubbleMouseInside: PropTypes.func,
     street: PropTypes.object,
     system: PropTypes.object
@@ -240,7 +243,7 @@ class InfoBubble extends React.Component {
     let position
     switch (type) {
       case INFO_BUBBLE_TYPE_SEGMENT:
-        position = window.parseInt(this.props.dataNo)
+        position = this.props.dataNo
         break
       case INFO_BUBBLE_TYPE_LEFT_BUILDING:
         position = 'left'

--- a/assets/scripts/info_bubble/Variants.jsx
+++ b/assets/scripts/info_bubble/Variants.jsx
@@ -6,7 +6,7 @@ import { getSegmentInfo } from '../segments/info'
 import { VARIANT_ICONS } from '../segments/variant_icons'
 import { getVariantArray } from '../segments/variant_utils'
 import { changeSegmentVariantLegacy } from '../segments/view'
-// import { infoBubble } from './info_bubble'
+import { infoBubble } from './info_bubble'
 import { setBuildingVariant, changeSegmentVariant } from '../store/actions/street'
 
 // Duped from InfoBubble
@@ -100,7 +100,7 @@ class Variants extends React.Component {
           this.props.setBuildingVariant('left', selection)
 
           // TODO: remove legacy notification
-          // infoBubble.onBuildingVariantButtonClick('left')
+          infoBubble.updateContents()
         }
         break
       case INFO_BUBBLE_TYPE_RIGHT_BUILDING:
@@ -108,7 +108,7 @@ class Variants extends React.Component {
           this.props.setBuildingVariant('right', selection)
 
           // TODO: remove legacy notification
-          // infoBubble.onBuildingVariantButtonClick('right')
+          infoBubble.updateContents()
         }
         break
       default:

--- a/assets/scripts/info_bubble/Variants.jsx
+++ b/assets/scripts/info_bubble/Variants.jsx
@@ -6,7 +6,7 @@ import { getSegmentInfo } from '../segments/info'
 import { VARIANT_ICONS } from '../segments/variant_icons'
 import { getVariantArray } from '../segments/variant_utils'
 import { changeSegmentVariantLegacy } from '../segments/view'
-import { infoBubble } from './info_bubble'
+// import { infoBubble } from './info_bubble'
 import { setBuildingVariant, changeSegmentVariant } from '../store/actions/street'
 
 // Duped from InfoBubble
@@ -100,7 +100,7 @@ class Variants extends React.Component {
           this.props.setBuildingVariant('left', selection)
 
           // TODO: remove legacy notification
-          infoBubble.onBuildingVariantButtonClick('left')
+          // infoBubble.onBuildingVariantButtonClick('left')
         }
         break
       case INFO_BUBBLE_TYPE_RIGHT_BUILDING:
@@ -108,7 +108,7 @@ class Variants extends React.Component {
           this.props.setBuildingVariant('right', selection)
 
           // TODO: remove legacy notification
-          infoBubble.onBuildingVariantButtonClick('right')
+          // infoBubble.onBuildingVariantButtonClick('right')
         }
         break
       default:

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -255,9 +255,6 @@ export const infoBubble = {
     }
 
     if (!isInfoBubbleVisible() || !infoBubble._withinHoverPolygon(infoBubble.considerMouseX, infoBubble.considerMouseY)) {
-      if (type === INFO_BUBBLE_TYPE_RIGHT_BUILDING) {
-        console.log(infoBubble.considerMouseX, infoBubble.considerMouseY)
-      }
       infoBubble.show(false)
     }
   },
@@ -273,10 +270,11 @@ export const infoBubble = {
     // If info bubble changes, wake this back up if it's fading out
     cancelFadeoutControls()
 
-    window.dispatchEvent(new window.CustomEvent('stmx:force_infobubble_update'))
+    // window.dispatchEvent(new window.CustomEvent('stmx:force_infobubble_update'))
 
     switch (infoBubble.type) {
       case INFO_BUBBLE_TYPE_SEGMENT:
+        window.dispatchEvent(new window.CustomEvent('stmx:force_infobubble_update'))
         var segment = street.segments[store.getState().infoBubble.dataNo]
         infoBubble.segment = segment
         break
@@ -335,7 +333,10 @@ export const infoBubble = {
     var bubbleX = pos[0] - document.querySelector('#street-section-outer').scrollLeft
     var bubbleY = pos[1]
 
-    const dataNo = segmentEl.dataNo
+    let dataNo = segmentEl.dataNo
+    if (!dataNo) {
+      dataNo = (type === INFO_BUBBLE_TYPE_LEFT_BUILDING) ? 'left' : 'right'
+    }
     store.dispatch(setInfoBubbleSegmentDataNo(dataNo))
 
     infoBubble.el = document.querySelector('.info-bubble')
@@ -350,7 +351,6 @@ export const infoBubble = {
       bubbleY = MIN_TOP_MARGIN_FROM_VIEWPORT
     }
 
-    console.log('offsetWidth: ', segmentEl.offsetWidth)
     bubbleX += segmentEl.offsetWidth / 2
     bubbleX -= bubbleWidth / 2
 
@@ -362,7 +362,6 @@ export const infoBubble = {
       bubbleX = system.viewportWidth - bubbleWidth - 50
     }
 
-    console.log('bubbleX: ', bubbleX)
     infoBubble.el.style.left = bubbleX + 'px'
     infoBubble.el.style.top = bubbleY + 'px'
 

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -1,20 +1,20 @@
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
 import { hideDescription } from './description'
-import {
-  createBuildings,
-  onBuildingMouseEnter,
-  updateBuildingPosition
-} from '../segments/buildings'
+// import {
+//   createBuildings,
+//   onBuildingMouseEnter,
+//   updateBuildingPosition
+// } from '../segments/buildings'
 import { DRAGGING_TYPE_NONE, draggingType } from '../segments/drag_and_drop'
 import { cancelFadeoutControls } from '../segments/resizing'
 import { getElAbsolutePos } from '../util/helpers'
 import { registerKeypress } from '../app/keypress'
-import {
-  switchSegmentElIn,
-  switchSegmentElAway
-} from '../segments/view'
-import { saveStreetToServerIfNecessary } from '../streets/data_model'
+// import {
+//   switchSegmentElIn,
+//   switchSegmentElAway
+// } from '../segments/view'
+// import { saveStreetToServerIfNecessary } from '../streets/data_model'
 import store from '../store'
 import {
   showInfoBubble,
@@ -275,28 +275,28 @@ export const infoBubble = {
     infoBubble.considerType = null
   },
 
-  onBuildingVariantButtonClick: function (side) {
-    var el = document.querySelector('#street-section-' + side + '-building')
-    el.id = 'street-section-' + side + '-building-old'
+  // onBuildingVariantButtonClick: function (side) {
+  //   var el = document.querySelector('#street-section-' + side + '-building')
+  //   el.id = 'street-section-' + side + '-building-old'
 
-    var newEl = document.createElement('div')
-    newEl.className = 'street-section-building'
-    newEl.id = 'street-section-' + side + '-building'
+  //   var newEl = document.createElement('div')
+  //   newEl.className = 'street-section-building'
+  //   newEl.id = 'street-section-' + side + '-building'
 
-    el.parentNode.appendChild(newEl)
-    updateBuildingPosition()
-    switchSegmentElIn(newEl)
-    switchSegmentElAway(el)
+  //   el.parentNode.appendChild(newEl)
+  //   updateBuildingPosition()
+  //   switchSegmentElIn(newEl)
+  //   switchSegmentElAway(el)
 
-    // TODO repeat
-    newEl.addEventListener('pointerenter', onBuildingMouseEnter)
-    newEl.addEventListener('pointerleave', onBuildingMouseEnter)
+  //   // TODO repeat
+  //   newEl.addEventListener('pointerenter', onBuildingMouseEnter)
+  //   newEl.addEventListener('pointerleave', onBuildingMouseEnter)
 
-    saveStreetToServerIfNecessary()
-    createBuildings()
+  //   saveStreetToServerIfNecessary()
+  //   createBuildings()
 
-    infoBubble.updateContents()
-  },
+  //   infoBubble.updateContents()
+  // },
 
   updateContents: function () {
     const street = store.getState().street

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -1,20 +1,10 @@
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
 import { hideDescription } from './description'
-// import {
-//   createBuildings,
-//   onBuildingMouseEnter,
-//   updateBuildingPosition
-// } from '../segments/buildings'
 import { DRAGGING_TYPE_NONE, draggingType } from '../segments/drag_and_drop'
 import { cancelFadeoutControls } from '../segments/resizing'
 import { getElAbsolutePos } from '../util/helpers'
 import { registerKeypress } from '../app/keypress'
-// import {
-//   switchSegmentElIn,
-//   switchSegmentElAway
-// } from '../segments/view'
-// import { saveStreetToServerIfNecessary } from '../streets/data_model'
 import store from '../store'
 import {
   showInfoBubble,
@@ -274,29 +264,6 @@ export const infoBubble = {
     infoBubble.considerSegmentEl = null
     infoBubble.considerType = null
   },
-
-  // onBuildingVariantButtonClick: function (side) {
-  //   var el = document.querySelector('#street-section-' + side + '-building')
-  //   el.id = 'street-section-' + side + '-building-old'
-
-  //   var newEl = document.createElement('div')
-  //   newEl.className = 'street-section-building'
-  //   newEl.id = 'street-section-' + side + '-building'
-
-  //   el.parentNode.appendChild(newEl)
-  //   updateBuildingPosition()
-  //   switchSegmentElIn(newEl)
-  //   switchSegmentElAway(el)
-
-  //   // TODO repeat
-  //   newEl.addEventListener('pointerenter', onBuildingMouseEnter)
-  //   newEl.addEventListener('pointerleave', onBuildingMouseEnter)
-
-  //   saveStreetToServerIfNecessary()
-  //   createBuildings()
-
-  //   infoBubble.updateContents()
-  // },
 
   updateContents: function () {
     const street = store.getState().street

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -331,6 +331,7 @@ export const infoBubble = {
     infoBubble.startMouseY = mouseY
 
     var pos = getElAbsolutePos(segmentEl)
+
     var bubbleX = pos[0] - document.querySelector('#street-section-outer').scrollLeft
     var bubbleY = pos[1]
 
@@ -349,6 +350,7 @@ export const infoBubble = {
       bubbleY = MIN_TOP_MARGIN_FROM_VIEWPORT
     }
 
+    console.log('offsetWidth: ', segmentEl.offsetWidth)
     bubbleX += segmentEl.offsetWidth / 2
     bubbleX -= bubbleWidth / 2
 

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -1,5 +1,4 @@
 import { app } from '../preinit/app_settings'
-import { system } from '../preinit/system_capabilities'
 import { hideDescription } from './description'
 import { DRAGGING_TYPE_NONE, draggingType } from '../segments/drag_and_drop'
 import { cancelFadeoutControls } from '../segments/resizing'
@@ -256,6 +255,9 @@ export const infoBubble = {
     }
 
     if (!isInfoBubbleVisible() || !infoBubble._withinHoverPolygon(infoBubble.considerMouseX, infoBubble.considerMouseY)) {
+      if (type === INFO_BUBBLE_TYPE_RIGHT_BUILDING) {
+        console.log(infoBubble.considerMouseX, infoBubble.considerMouseY)
+      }
       infoBubble.show(false)
     }
   },
@@ -350,6 +352,7 @@ export const infoBubble = {
     bubbleX += segmentEl.offsetWidth / 2
     bubbleX -= bubbleWidth / 2
 
+    const system = store.getState().system
     // TODO const
     if (bubbleX < 50) {
       bubbleX = 50
@@ -357,6 +360,7 @@ export const infoBubble = {
       bubbleX = system.viewportWidth - bubbleWidth - 50
     }
 
+    console.log('bubbleX: ', bubbleX)
     infoBubble.el.style.left = bubbleX + 'px'
     infoBubble.el.style.top = bubbleY + 'px'
 

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -270,8 +270,6 @@ export const infoBubble = {
     // If info bubble changes, wake this back up if it's fading out
     cancelFadeoutControls()
 
-    // window.dispatchEvent(new window.CustomEvent('stmx:force_infobubble_update'))
-
     switch (infoBubble.type) {
       case INFO_BUBBLE_TYPE_SEGMENT:
         window.dispatchEvent(new window.CustomEvent('stmx:force_infobubble_update'))

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -46,7 +46,7 @@ class Building extends React.Component {
     }
 
     if (prevProps.street[variant] && prevProps.street[variant] !== street[variant]) {
-      this.handleBuildingSwitch()
+      this.switchBuildings()
     }
 
     if (prevState.switchBuildings !== this.state.switchBuildings) {
@@ -96,7 +96,7 @@ class Building extends React.Component {
     event.preventDefault()
   }
 
-  handleChangeInRefs = (ref, isOldBuilding) => {
+  changeRefs = (ref, isOldBuilding) => {
     if (!this.state.switchBuildings && !isOldBuilding) return
 
     if (this.state.switchBuildings && isOldBuilding) {
@@ -106,7 +106,7 @@ class Building extends React.Component {
     }
   }
 
-  handleBuildingSwitch = () => {
+  switchBuildings = () => {
     this.setState({
       switchBuildings: !(this.state.switchBuildings),
       newBuildingEnter: !(this.state.newBuildingEnter),
@@ -132,7 +132,7 @@ class Building extends React.Component {
     return (
       <section
         className="street-section-building"
-        ref={(ref) => { this.handleChangeInRefs(ref, isOldBuilding) }}
+        ref={(ref) => { this.changeRefs(ref, isOldBuilding) }}
         onMouseEnter={this.onBuildingMouseEnter}
         onMouseLeave={this.onBuildingMouseLeave}
         style={style}
@@ -152,7 +152,7 @@ class Building extends React.Component {
           in={newBuildingEnter}
           timeout={250}
           classNames="switching-in"
-          onEntered={this.handleBuildingSwitch}
+          onEntered={this.switchBuildings}
           unmountOnExit
         >
           { this.renderBuilding('new') }

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -18,7 +18,8 @@ class Building extends React.Component {
     addBuildingFloor: PropTypes.func,
     removeBuildingFloor: PropTypes.func,
     street: PropTypes.object,
-    buildingWidth: PropTypes.number
+    buildingWidth: PropTypes.number,
+    calculateBuildingPerspective: PropTypes.func
   }
 
   constructor (props) {
@@ -45,6 +46,8 @@ class Building extends React.Component {
     }
 
     if (prevState.switchBuildings !== this.state.switchBuildings) {
+      this.props.calculateBuildingPerspective(this.oldStreetSectionBuilding)
+      this.props.calculateBuildingPerspective(this.streetSectionBuilding)
       createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
     }
   }
@@ -103,13 +106,12 @@ class Building extends React.Component {
   }
 
   render () {
-    const buildingId = 'street-section-' + this.props.position + '-building'
+    const { newBuildingEnter, oldBuildingEnter } = this.state
     const style = {
       [this.props.position]: (-this.props.buildingWidth + 25) + 'px',
       width: this.props.buildingWidth + 'px'
     }
 
-    const { newBuildingEnter, oldBuildingEnter } = this.state
     return (
       <div>
         <CSSTransition
@@ -136,7 +138,6 @@ class Building extends React.Component {
           classNames="switching-away"
         >
           <section
-            id={buildingId}
             className="street-section-building"
             ref={(ref) => { this.handleChangeInRefs(ref) }}
             onMouseEnter={this.onBuildingMouseEnter}

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -1,15 +1,48 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { createBuilding } from './buildings'
 import {
   INFO_BUBBLE_TYPE_RIGHT_BUILDING,
   INFO_BUBBLE_TYPE_LEFT_BUILDING,
   infoBubble
 } from '../info_bubble/info_bubble'
 import { resumeFadeoutControls } from './resizing'
-
+import { KEYS } from '../app/keyboard_commands'
+import { addBuildingFloor, removeBuildingFloor } from '../store/actions/street'
+import store from '../store'
 class Building extends React.Component {
   static propTypes = {
-    position: PropTypes.string.isRequired
+    position: PropTypes.string.isRequired,
+    addBuildingFloor: PropTypes.func,
+    removeBuildingFloor: PropTypes.func,
+    street: PropTypes.object
+  }
+
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      isHovering: false
+    }
+  }
+
+  componentDidMount () {
+    window.addEventListener('keydown', this.handleKeyDown)
+  }
+
+  shouldComponentUpdate (nextState) {
+    return (this.state.isHovering !== nextState.isHovering)
+  }
+
+  componentDidUpdate (prevProps) {
+    const { position, street } = this.props
+    const height = (position === 'left') ? 'leftBuildingHeight' : 'rightBuildingHeight'
+    const variant = (position === 'left') ? 'leftBuildingVariant' : 'rightBuildingVariant'
+
+    if (prevProps[height] !== street[height]) {
+      createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
+    }
   }
 
   onBuildingMouseEnter = (event) => {
@@ -22,11 +55,41 @@ class Building extends React.Component {
 
     infoBubble.considerShowing(event, this.streetSectionBuilding, type)
     resumeFadeoutControls()
+
+    console.log(store.getState())
+
+    this.setState({
+      isHovering: true
+    })
   }
 
   onBuildingMouseLeave = (event) => {
     if (event.pointerType !== 'mouse') return
     infoBubble.dontConsiderShowing()
+
+    this.setState({
+      isHovering: false
+    })
+  }
+
+  handleKeyDown = (event) => {
+    if (!this.state.isHovering) return
+
+    const negative = (event.keyCode === KEYS.MINUS) ||
+      (event.keyCode === KEYS.MINUS_ALT) ||
+      (event.keyCode === KEYS.MINUS_KEYPAD)
+
+    const positive = (event.keyCode === KEYS.EQUAL) ||
+      (event.keyCode === KEYS.EQUAL_ALT) ||
+      (event.keyCode === KEYS.PLUS_KEYPAD)
+
+    if (negative) {
+      this.props.removeBuildingFloor(this.props.position)
+    } else if (positive) {
+      this.props.addBuildingFloor(this.props.position)
+    }
+
+    event.preventDefault()
   }
 
   render () {
@@ -45,4 +108,16 @@ class Building extends React.Component {
   }
 }
 
-export default Building
+function mapStateToProps (state) {
+  return {
+    street: state.street
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    removeBuildingFloor: (...args) => { dispatch(removeBuildingFloor(...args)) },
+    addBuildingFloor: (...args) => { dispatch(addBuildingFloor(...args)) }
+  }
+}
+export default connect(mapStateToProps, mapDispatchToProps)(Building)

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -112,6 +112,13 @@ class Building extends React.Component {
       width: this.props.buildingWidth + 'px'
     }
 
+    const hoverStyle = {}
+    if (this.props.position === 'left') {
+      hoverStyle.right = '25px'
+    } else {
+      hoverStyle.left = '25px'
+    }
+
     return (
       <section
         className="street-section-building"
@@ -119,7 +126,9 @@ class Building extends React.Component {
         onMouseEnter={this.onBuildingMouseEnter}
         onMouseLeave={this.onBuildingMouseLeave}
         style={style}
-      />
+      >
+        <div className="hover-bk" style={hoverStyle} />
+      </section>
     )
   }
 

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -47,12 +47,12 @@ class Building extends React.Component {
 
     if (prevProps.street[variant] && prevProps.street[variant] !== street[variant]) {
       this.handleBuildingSwitch()
-      infoBubble.updateContents()
     }
 
     if (prevState.switchBuildings !== this.state.switchBuildings) {
       this.props.calculateBuildingPerspective(this.oldStreetSectionBuilding)
       this.props.calculateBuildingPerspective(this.streetSectionBuilding)
+      this.oldStreetSectionBuilding.classList.remove('hover')
       createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
     }
   }
@@ -72,7 +72,7 @@ class Building extends React.Component {
 
   onBuildingMouseLeave = (event) => {
     window.removeEventListener('keydown', this.handleKeyDown)
-    if (event.pointerType !== 'mouse') return
+    // if (event.pointerType !== 'mouse') return
     infoBubble.dontConsiderShowing()
   }
 
@@ -132,7 +132,6 @@ class Building extends React.Component {
 
     return (
       <section
-        id={(isOldBuilding) ? 'old-building' : 'new-building'}
         className="street-section-building"
         ref={(ref) => { this.handleChangeInRefs(ref, isOldBuilding) }}
         onMouseEnter={this.onBuildingMouseEnter}

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
-import { createBuilding } from './buildings'
+import { createBuilding, BUILDINGS } from './buildings'
 import {
   INFO_BUBBLE_TYPE_RIGHT_BUILDING,
   INFO_BUBBLE_TYPE_LEFT_BUILDING,
@@ -80,17 +80,20 @@ class Building extends React.Component {
       (event.keyCode === KEYS.EQUAL_ALT) ||
       (event.keyCode === KEYS.PLUS_KEYPAD)
 
-    if (negative) {
+    const variant = this.props.street[this.state.variant]
+    const hasFloors = BUILDINGS[variant].hasFloors
+
+    if (negative && hasFloors) {
       this.props.removeBuildingFloor(this.props.position)
-    } else if (positive) {
+    } else if (positive && hasFloors) {
       this.props.addBuildingFloor(this.props.position)
     }
 
     event.preventDefault()
   }
 
-  handleChangeInRefs = (ref) => {
-    if (this.state.switchBuildings) {
+  handleChangeInRefs = (ref, isOldBuilding) => {
+    if (this.state.switchBuildings && isOldBuilding) {
       this.oldStreetSectionBuilding = ref
     } else {
       this.streetSectionBuilding = ref
@@ -107,6 +110,7 @@ class Building extends React.Component {
 
   renderBuilding = (building) => {
     const isOldBuilding = (building === 'old')
+
     const style = {
       [this.props.position]: (-this.props.buildingWidth + 25) + 'px',
       width: this.props.buildingWidth + 'px'
@@ -121,8 +125,9 @@ class Building extends React.Component {
 
     return (
       <section
+        id={(isOldBuilding) ? 'old-building' : 'new-building'}
         className="street-section-building"
-        ref={(ref) => { (isOldBuilding) ? this.handleChangeInRefs(ref) : this.streetSectionBuilding = ref }}
+        ref={(ref) => { this.handleChangeInRefs(ref, isOldBuilding) }}
         onMouseEnter={this.onBuildingMouseEnter}
         onMouseLeave={this.onBuildingMouseLeave}
         style={style}
@@ -143,6 +148,7 @@ class Building extends React.Component {
           timeout={250}
           classNames="switching-in"
           onEntered={this.handleBuildingSwitch}
+          unmountOnExit
         >
           { this.renderBuilding('new') }
         </CSSTransition>
@@ -151,6 +157,7 @@ class Building extends React.Component {
           in={oldBuildingEnter}
           timeout={250}
           classNames="switching-away"
+          unmountOnExit
         >
           { this.renderBuilding('old') }
         </CSSTransition>

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -43,6 +43,7 @@ class Building extends React.Component {
 
     if (prevProps.street[variant] && prevProps.street[variant] !== street[variant]) {
       this.handleBuildingSwitch()
+      infoBubble.updateContents()
     }
 
     if (prevState.switchBuildings !== this.state.switchBuildings) {

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -93,6 +93,8 @@ class Building extends React.Component {
   }
 
   handleChangeInRefs = (ref, isOldBuilding) => {
+    if (!this.state.switchBuildings && !isOldBuilding) return
+
     if (this.state.switchBuildings && isOldBuilding) {
       this.oldStreetSectionBuilding = ref
     } else {

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -37,7 +37,11 @@ class Building extends React.Component {
   componentDidUpdate (prevProps, prevState) {
     const { street, position } = this.props
     const { variant, height } = this.state
-    if (prevProps.street[height] !== street[height]) {
+
+    const lastOverflow = (prevProps.street.remainingWidth < 0)
+    const streetOverflow = (street.remainingWidth < 0)
+
+    if (prevProps.street[height] !== street[height] || lastOverflow !== streetOverflow) {
       createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
     }
 

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -72,7 +72,6 @@ class Building extends React.Component {
 
   onBuildingMouseLeave = (event) => {
     window.removeEventListener('keydown', this.handleKeyDown)
-    // if (event.pointerType !== 'mouse') return
     infoBubble.dontConsiderShowing()
   }
 

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -31,7 +31,7 @@ class Building extends React.Component {
   componentDidUpdate (prevProps) {
     const { street, position } = this.props
     const { variant, height } = this.state
-    if (prevProps[height] !== street[height]) {
+    if (prevProps.street[height] !== street[height] || prevProps.street[variant] !== street[variant]) {
       createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
     }
   }
@@ -75,6 +75,7 @@ class Building extends React.Component {
 
   render () {
     const buildingId = 'street-section-' + this.props.position + '-building'
+
     return (
       <section
         id={buildingId}
@@ -101,4 +102,5 @@ function mapDispatchToProps (dispatch) {
     addBuildingFloor: (...args) => { dispatch(addBuildingFloor(...args)) }
   }
 }
+
 export default connect(mapStateToProps, mapDispatchToProps)(Building)

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  INFO_BUBBLE_TYPE_RIGHT_BUILDING,
+  INFO_BUBBLE_TYPE_LEFT_BUILDING,
+  infoBubble
+} from '../info_bubble/info_bubble'
+import { resumeFadeoutControls } from './resizing'
+
+class Building extends React.Component {
+  static propTypes = {
+    position: PropTypes.string.isRequired
+  }
+
+  onBuildingMouseEnter = (event) => {
+    let type
+    if (this.props.position === 'left') {
+      type = INFO_BUBBLE_TYPE_LEFT_BUILDING
+    } else if (this.props.position === 'right') {
+      type = INFO_BUBBLE_TYPE_RIGHT_BUILDING
+    }
+
+    infoBubble.considerShowing(event, this.streetSectionBuilding, type)
+    resumeFadeoutControls()
+  }
+
+  onBuildingMouseLeave = (event) => {
+    if (event.pointerType !== 'mouse') return
+    infoBubble.dontConsiderShowing()
+  }
+
+  render () {
+    const buildingId = 'street-section-' + this.props.position + '-building'
+    return (
+      <section
+        id={buildingId}
+        className="street-section-building"
+        ref={(ref) => { this.streetSectionBuilding = ref }}
+        onMouseEnter={this.onBuildingMouseEnter}
+        onMouseLeave={this.onBuildingMouseLeave}
+      >
+        <div className="hover-bk" />
+      </section>
+    )
+  }
+}
+
+export default Building

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -10,7 +10,7 @@ import {
 import { resumeFadeoutControls } from './resizing'
 import { KEYS } from '../app/keyboard_commands'
 import { addBuildingFloor, removeBuildingFloor } from '../store/actions/street'
-import store from '../store'
+
 class Building extends React.Component {
   static propTypes = {
     position: PropTypes.string.isRequired,
@@ -23,29 +23,21 @@ class Building extends React.Component {
     super(props)
 
     this.state = {
-      isHovering: false
+      variant: (props.position === 'left') ? 'leftBuildingVariant' : 'rightBuildingVariant',
+      height: (props.position === 'left') ? 'leftBuildingHeight' : 'rightBuildingHeight'
     }
   }
 
-  componentDidMount () {
-    window.addEventListener('keydown', this.handleKeyDown)
-  }
-
-  shouldComponentUpdate (nextState) {
-    return (this.state.isHovering !== nextState.isHovering)
-  }
-
   componentDidUpdate (prevProps) {
-    const { position, street } = this.props
-    const height = (position === 'left') ? 'leftBuildingHeight' : 'rightBuildingHeight'
-    const variant = (position === 'left') ? 'leftBuildingVariant' : 'rightBuildingVariant'
-
+    const { street, position } = this.props
+    const { variant, height } = this.state
     if (prevProps[height] !== street[height]) {
       createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
     }
   }
 
   onBuildingMouseEnter = (event) => {
+    window.addEventListener('keydown', this.handleKeyDown)
     let type
     if (this.props.position === 'left') {
       type = INFO_BUBBLE_TYPE_LEFT_BUILDING
@@ -55,26 +47,15 @@ class Building extends React.Component {
 
     infoBubble.considerShowing(event, this.streetSectionBuilding, type)
     resumeFadeoutControls()
-
-    console.log(store.getState())
-
-    this.setState({
-      isHovering: true
-    })
   }
 
   onBuildingMouseLeave = (event) => {
+    window.removeEventListener('keydown', this.handleKeyDown)
     if (event.pointerType !== 'mouse') return
     infoBubble.dontConsiderShowing()
-
-    this.setState({
-      isHovering: false
-    })
   }
 
   handleKeyDown = (event) => {
-    if (!this.state.isHovering) return
-
     const negative = (event.keyCode === KEYS.MINUS) ||
       (event.keyCode === KEYS.MINUS_ALT) ||
       (event.keyCode === KEYS.MINUS_KEYPAD)

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -105,12 +105,26 @@ class Building extends React.Component {
     })
   }
 
-  render () {
-    const { newBuildingEnter, oldBuildingEnter } = this.state
+  renderBuilding = (building) => {
+    const isOldBuilding = (building === 'old')
     const style = {
       [this.props.position]: (-this.props.buildingWidth + 25) + 'px',
       width: this.props.buildingWidth + 'px'
     }
+
+    return (
+      <section
+        className="street-section-building"
+        ref={(ref) => { (isOldBuilding) ? this.handleChangeInRefs(ref) : this.streetSectionBuilding = ref }}
+        onMouseEnter={this.onBuildingMouseEnter}
+        onMouseLeave={this.onBuildingMouseLeave}
+        style={style}
+      />
+    )
+  }
+
+  render () {
+    const { newBuildingEnter, oldBuildingEnter } = this.state
 
     return (
       <div>
@@ -121,15 +135,7 @@ class Building extends React.Component {
           classNames="switching-in"
           onEntered={this.handleBuildingSwitch}
         >
-          <section
-            className="street-section-building"
-            ref={(ref) => { this.streetSectionBuilding = ref }}
-            onMouseEnter={this.onBuildingMouseEnter}
-            onMouseLeave={this.onBuildingMouseLeave}
-            style={style}
-          >
-            <div className="hover-bk" />
-          </section>
+          { this.renderBuilding('new') }
         </CSSTransition>
         <CSSTransition
           key="old-building"
@@ -137,15 +143,7 @@ class Building extends React.Component {
           timeout={250}
           classNames="switching-away"
         >
-          <section
-            className="street-section-building"
-            ref={(ref) => { this.handleChangeInRefs(ref) }}
-            onMouseEnter={this.onBuildingMouseEnter}
-            onMouseLeave={this.onBuildingMouseLeave}
-            style={style}
-          >
-            <div className="hover-bk" />
-          </section>
+          { this.renderBuilding('old') }
         </CSSTransition>
       </div>
     )

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -1,13 +1,8 @@
-import {
-  INFO_BUBBLE_TYPE_RIGHT_BUILDING,
-  INFO_BUBBLE_TYPE_LEFT_BUILDING,
-  infoBubble
-} from '../info_bubble/info_bubble'
 import { saveStreetToServerIfNecessary } from '../streets/data_model'
 import { getElAbsolutePos } from '../util/helpers'
 import { RandomGenerator } from '../util/random'
 import { images } from '../app/load_resources'
-import { resumeFadeoutControls } from './resizing'
+
 import { TILE_SIZE, TILESET_POINT_PER_PIXEL, drawSegmentImage } from './view'
 import store from '../store'
 
@@ -343,24 +338,6 @@ export function createBuildings () {
 
   createBuilding(leftEl, street.leftBuildingVariant, 'left', street.leftBuildingHeight, street)
   createBuilding(rightEl, street.rightBuildingVariant, 'right', street.rightBuildingHeight, street)
-}
-
-export function onBuildingMouseEnter (event) {
-  let type
-  if (this.id === 'street-section-left-building') {
-    type = INFO_BUBBLE_TYPE_LEFT_BUILDING
-  } else {
-    type = INFO_BUBBLE_TYPE_RIGHT_BUILDING
-  }
-
-  infoBubble.considerShowing(event, this, type)
-  resumeFadeoutControls()
-}
-
-export function onBuildingMouseLeave (event) {
-  if (event.pointerType !== 'mouse') return
-
-  infoBubble.dontConsiderShowing()
 }
 
 export function updateBuildingPosition () {

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -1,5 +1,4 @@
 import { saveStreetToServerIfNecessary } from '../streets/data_model'
-import { getElAbsolutePos } from '../util/helpers'
 import { RandomGenerator } from '../util/random'
 import { images } from '../app/load_resources'
 
@@ -338,24 +337,4 @@ export function createBuildings () {
 
   createBuilding(leftEl, street.leftBuildingVariant, 'left', street.leftBuildingHeight, street)
   createBuilding(rightEl, street.rightBuildingVariant, 'right', street.rightBuildingHeight, street)
-}
-
-export function updateBuildingPosition () {
-  var el = document.querySelector('#street-section-editable')
-  var pos = getElAbsolutePos(el)
-
-  var width = pos[0] + 25
-
-  if (width < 0) {
-    width = 0
-  }
-
-  // document.querySelector('#street-section-left-building').style.width = width + 'px'
-  // document.querySelector('#street-section-right-building').style.width = width + 'px'
-
-  // document.querySelector('#street-section-left-building').style.left = (-width + 25) + 'px'
-  // document.querySelector('#street-section-right-building').style.right = (-width + 25) + 'px'
-
-  document.querySelector('#street-section-dirt').style.marginLeft = -width + 'px'
-  document.querySelector('#street-section-dirt').style.marginRight = -width + 'px'
 }

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -1,4 +1,3 @@
-import { saveStreetToServerIfNecessary } from '../streets/data_model'
 import { RandomGenerator } from '../util/random'
 import { images } from '../app/load_resources'
 
@@ -322,11 +321,6 @@ export function createBuilding (el, variant, position, floors, street) {
     position === 'left', totalWidth, height,
     0,
     1.0, dpi)
-}
-
-export function buildingHeightUpdated () {
-  saveStreetToServerIfNecessary()
-  createBuildings()
 }
 
 export function createBuildings () {

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -322,13 +322,3 @@ export function createBuilding (el, variant, position, floors, street) {
     0,
     1.0, dpi)
 }
-
-export function createBuildings () {
-  const leftEl = document.querySelector('#street-section-left-building')
-  const rightEl = document.querySelector('#street-section-right-building')
-
-  const street = store.getState().street
-
-  createBuilding(leftEl, street.leftBuildingVariant, 'left', street.leftBuildingHeight, street)
-  createBuilding(rightEl, street.rightBuildingVariant, 'right', street.rightBuildingHeight, street)
-}

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -350,11 +350,11 @@ export function updateBuildingPosition () {
     width = 0
   }
 
-  document.querySelector('#street-section-left-building').style.width = width + 'px'
-  document.querySelector('#street-section-right-building').style.width = width + 'px'
+  // document.querySelector('#street-section-left-building').style.width = width + 'px'
+  // document.querySelector('#street-section-right-building').style.width = width + 'px'
 
-  document.querySelector('#street-section-left-building').style.left = (-width + 25) + 'px'
-  document.querySelector('#street-section-right-building').style.right = (-width + 25) + 'px'
+  // document.querySelector('#street-section-left-building').style.left = (-width + 25) + 'px'
+  // document.querySelector('#street-section-right-building').style.right = (-width + 25) + 'px'
 
   document.querySelector('#street-section-dirt').style.marginLeft = -width + 'px'
   document.querySelector('#street-section-dirt').style.marginRight = -width + 'px'

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -297,7 +297,7 @@ function shadeInContext (ctx) {
   ctx.restore()
 }
 
-function createBuilding (el, variant, position, floors, street) {
+export function createBuilding (el, variant, position, floors, street) {
   const totalWidth = el.offsetWidth
   const buildingHeight = getBuildingImageHeight(variant, position, floors)
 

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -523,7 +523,7 @@ export function changeSegmentVariantLegacy (dataNo, variantName, variantChoice) 
 }
 
 export function switchSegmentElIn (el) {
-  el.classList.add('switching-in-pre')
+  el.classList.add('switching-in-enter')
 
   window.setTimeout(function () {
     var pos = getElAbsolutePos(el)
@@ -535,12 +535,14 @@ export function switchSegmentElIn (el) {
     el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.perspectiveOrigin = (perspective / 2) + 'px 50%'
 
-    el.classList.add('switching-in-post')
+    el.classList.add('switching-in-enter-active')
+    el.classList.add('switching-in-enter-done')
   }, SEGMENT_SWITCHING_TIME / 2)
 
   window.setTimeout(function () {
-    el.classList.remove('switching-in-pre')
-    el.classList.remove('switching-in-post')
+    el.classList.remove('switching-in-enter')
+    el.classList.remove('switching-in-enter-active')
+    el.classList.remove('switching-in-enter-done')
   }, SEGMENT_SWITCHING_TIME * 1.5)
 }
 
@@ -558,13 +560,14 @@ export function switchSegmentElAway (el) {
 
   el.parentNode.removeChild(el)
   el.classList.remove('hover')
-  el.classList.add('switching-away-pre')
+  el.classList.add('switching-away-exit')
   el.style.left = (pos[0] - document.querySelector('#street-section-outer').scrollLeft) + 'px'
   el.style.top = pos[1] + 'px'
   document.body.appendChild(el)
 
   window.setTimeout(function () {
-    el.classList.add('switching-away-post')
+    el.classList.add('switching-away-exit-active')
+    el.classList.add('switching-away-exit-done')
   }, 0)
 
   window.setTimeout(function () {

--- a/assets/scripts/store/actions/infoBubble.js
+++ b/assets/scripts/store/actions/infoBubble.js
@@ -21,7 +21,7 @@ export function hideInfoBubble () {
 export function setInfoBubbleSegmentDataNo (dataNo) {
   return {
     type: SET_SEGMENT_DATA_NO,
-    dataNo: window.parseInt(dataNo)
+    dataNo: dataNo
   }
 }
 

--- a/assets/scripts/store/actions/infoBubble.js
+++ b/assets/scripts/store/actions/infoBubble.js
@@ -19,9 +19,10 @@ export function hideInfoBubble () {
 }
 
 export function setInfoBubbleSegmentDataNo (dataNo) {
+  const isBuilding = (dataNo === 'left' || dataNo === 'right')
   return {
     type: SET_SEGMENT_DATA_NO,
-    dataNo: dataNo
+    dataNo: (isBuilding) ? dataNo : Number.parseInt(dataNo)
   }
 }
 

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -1,9 +1,9 @@
 import { msg } from '../app/messages'
 import { URL_NO_USER, RESERVED_URLS, URL_RESERVED_PREFIX } from '../app/routing'
-import {
-  // createBuildings,
-  updateBuildingPosition
-} from '../segments/buildings'
+// import {
+//   createBuildings,
+//   updateBuildingPosition
+// } from '../segments/buildings'
 import { DEFAULT_SEGMENTS } from '../segments/default'
 import { getSegmentInfo } from '../segments/info'
 import { normalizeAllSegmentWidths } from '../segments/resizing'
@@ -280,7 +280,7 @@ export function createDomFromData () {
   }
 
   repositionSegments()
-  updateBuildingPosition()
+  // updateBuildingPosition()
   // createBuildings()
 }
 

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -1,9 +1,5 @@
 import { msg } from '../app/messages'
 import { URL_NO_USER, RESERVED_URLS, URL_RESERVED_PREFIX } from '../app/routing'
-// import {
-//   createBuildings,
-//   updateBuildingPosition
-// } from '../segments/buildings'
 import { DEFAULT_SEGMENTS } from '../segments/default'
 import { getSegmentInfo } from '../segments/info'
 import { normalizeAllSegmentWidths } from '../segments/resizing'
@@ -280,8 +276,6 @@ export function createDomFromData () {
   }
 
   repositionSegments()
-  // updateBuildingPosition()
-  // createBuildings()
 }
 
 export function setStreetCreatorId (newId) {

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -1,7 +1,7 @@
 import { msg } from '../app/messages'
 import { URL_NO_USER, RESERVED_URLS, URL_RESERVED_PREFIX } from '../app/routing'
 import {
-  createBuildings,
+  // createBuildings,
   updateBuildingPosition
 } from '../segments/buildings'
 import { DEFAULT_SEGMENTS } from '../segments/default'
@@ -281,7 +281,7 @@ export function createDomFromData () {
 
   repositionSegments()
   updateBuildingPosition()
-  createBuildings()
+  // createBuildings()
 }
 
 export function setStreetCreatorId (newId) {

--- a/assets/scripts/streets/street.js
+++ b/assets/scripts/streets/street.js
@@ -5,13 +5,31 @@ import { updateStreetName } from './name'
 const street = store.getState().street
 let oldStreetName = street.name
 let oldStreetLocation = (street.location) ? street.location.wofId : null
+let oldLeftBuildingHeight = street.leftBuildingHeight
+let oldRightBuildingHeight = street.rightBuildingHeight
 
 export function initStreetReduxTransitionSubscriber () {
   store.subscribe(() => {
     const state = store.getState().street
+    updateIfBuildingsChanged(state)
     updateIfStreetNameChanged(state)
     updateIfLocationChanged(state)
   })
+}
+
+function updateIfBuildingsChanged (state) {
+  let changed = false
+  if (state.leftBuildingHeight !== oldLeftBuildingHeight) {
+    oldLeftBuildingHeight = state.leftBuildingHeight
+    changed = true
+  }
+  if (state.rightBuildingHeight !== oldRightBuildingHeight) {
+    oldRightBuildingHeight = state.rightBuildingHeight
+    changed = true
+  }
+  if (changed) {
+    saveStreetToServerIfNecessary()
+  }
 }
 
 function updateIfStreetNameChanged (state) {

--- a/assets/scripts/streets/street.js
+++ b/assets/scripts/streets/street.js
@@ -7,6 +7,8 @@ let oldStreetName = street.name
 let oldStreetLocation = (street.location) ? street.location.wofId : null
 let oldLeftBuildingHeight = street.leftBuildingHeight
 let oldRightBuildingHeight = street.rightBuildingHeight
+let oldLeftBuildingVariant = street.leftBuildingVariant
+let oldRightBuildingVariant = street.rightBuildingVariant
 
 export function initStreetReduxTransitionSubscriber () {
   store.subscribe(() => {
@@ -19,6 +21,7 @@ export function initStreetReduxTransitionSubscriber () {
 
 function updateIfBuildingsChanged (state) {
   let changed = false
+  // Checking building heights
   if (state.leftBuildingHeight !== oldLeftBuildingHeight) {
     oldLeftBuildingHeight = state.leftBuildingHeight
     changed = true
@@ -27,6 +30,17 @@ function updateIfBuildingsChanged (state) {
     oldRightBuildingHeight = state.rightBuildingHeight
     changed = true
   }
+
+  // Checking building variants
+  if (state.leftBuildingVariant !== oldLeftBuildingVariant) {
+    oldLeftBuildingVariant = state.leftBuildingVariant
+    changed = true
+  }
+  if (state.rightBuildingVariant !== oldRightBuildingVariant) {
+    oldRightBuildingVariant = state.rightBuildingVariant
+    changed = true
+  }
+
   if (changed) {
     saveStreetToServerIfNecessary()
   }

--- a/assets/scripts/streets/width.js
+++ b/assets/scripts/streets/width.js
@@ -1,6 +1,6 @@
 import { onResize } from '../app/window_resize'
 import { system } from '../preinit/system_capabilities'
-import { BUILDING_SPACE, createBuildings } from '../segments/buildings'
+import { BUILDING_SPACE } from '../segments/buildings'
 import { getSegmentVariantInfo } from '../segments/info'
 import { getSegmentWidthResolution } from '../segments/resizing'
 import { TILE_SIZE } from '../segments/view'
@@ -100,15 +100,9 @@ export function recalculateWidth () {
 
   store.dispatch(updateSegments(segments))
 
-  var lastOverflow = document.body.classList.contains('street-overflows')
-
   if (street.remainingWidth >= 0) {
     document.body.classList.remove('street-overflows')
   } else {
     document.body.classList.add('street-overflows')
-  }
-
-  if (lastOverflow !== document.body.classList.contains('street-overflows')) {
-    createBuildings()
   }
 }

--- a/assets/scripts/streets/width.js
+++ b/assets/scripts/streets/width.js
@@ -99,10 +99,4 @@ export function recalculateWidth () {
   }
 
   store.dispatch(updateSegments(segments))
-
-  if (street.remainingWidth >= 0) {
-    document.body.classList.remove('street-overflows')
-  } else {
-    document.body.classList.add('street-overflows')
-  }
 }

--- a/config/test.js
+++ b/config/test.js
@@ -9,7 +9,7 @@ module.exports = {
     baseuri: '/api'
   },
   db: {
-    url: 'mongodb://localhost/streetmix_test'
+    url: 'mongodb://127.0.0.1:27017/streetmix_test'
   },
   email: {
     feedback_recipient: 'nobody@example.com'


### PR DESCRIPTION
Code related to rendering the buildings, switching the buildings, and changing the building's height can now be found within a Building component. 

What is found in this PR:
- In order to display the CSS transition of switching buildings, we used the `react-transition-group` library which required changing the original classnames involved in animating the building switches to match what the library required. Since segments use the same classnames when switching, I changed the classnames added to segments when switching to match those used when switching buildings. 
-  `buildingWidth` is calculated and the perspective is changed by the `StreetView` component and passed to the `Building` component since some of the values used to calculate buildingWidth are in `StreetView` so we can use `refs` instead of query selectors.
- Event listeners that handle when a building is hovered over can now be found within the `Building` component.
- Changing of the building height using the keyboard shortcuts is now handled by the `Building` component itself. If the building height is changed via the `infoBubble`, the `Building` component listens to changes in `street.height` and redraws the building accordingly. 
- If the building variant changes, the buildings are redrawn as well.
- The use of the `id` for the buildings is deprecated.

Thoughts/Concerns:
- There was some trouble rendering the `infoBubble` for the right building correctly. From what I can understand, the `show()` method found in `info_bubble.js` which calculates the `left` style for the infoBubble is called before the `InfoBubble` component is fully rendered. Therefore, when the infoBubble needed to be shown for the right building, the `offsetWidth` used to calculate the `left` style was from the previous rendering of the infoBubble. This meant that if the last time the infoBubble was shown was for a segment then the `offsetWidth` used to calculate the new `left` style would be smaller than it should be. **The current fix is to update the `left` style when hovering over the right building directly in the `InfoBubble` component.**
- In an attempt to fix the above problem, updating state for the infoBubble when hovering over a building was done separately from updating state when hovering over a segment. This was done in `componentWillReceiveProps`, which will soon be deprecated in React Version 17. The current version used by Streetmix is Version 16.2.0. The suggested change for Version 16.3 and above is to use `getDerivedStateFromProps`. **For a future PR, we should probably update to the latest version and change all uses of `componentWillReceiveProps` to `getDerivedStateFromProps`**

closes #884 