### PR TITLE
Combine "sign in link" translation strings

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -21,6 +21,7 @@
     },
     "share": {
       "sign-in": "<a href='/twitter-sign-in?redirectUri=/just-signed-in'>Sign in with Twitter</a> for nicer links to your streets and your personal street gallery",
+      "sign-in-2": "<a href='/twitter-sign-in?redirectUri=/just-signed-in'>Sign in with Twitter for your personal street gallery</a>",
       "link": "Copy and paste this link to share:",
       "twitter": "Share using Twitter",
       "facebook": "Share using Facebook",
@@ -267,7 +268,6 @@
   },
   "sign-in": {
     "link": "Sign in with Twitter",
-    "promo-1": "for nicer links to your streets and your personal street gallery",
     "promo-2": "for your personal street gallery"
   },
   "meta": {

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -21,7 +21,6 @@
     },
     "share": {
       "sign-in": "<a href='/twitter-sign-in?redirectUri=/just-signed-in'>Sign in with Twitter</a> for nicer links to your streets and your personal street gallery",
-      "sign-in-2": "<a href='/twitter-sign-in?redirectUri=/just-signed-in'>Sign in with Twitter for your personal street gallery</a>",
       "link": "Copy and paste this link to share:",
       "twitter": "Share using Twitter",
       "facebook": "Share using Facebook",
@@ -260,7 +259,8 @@
     "delete-street-tooltip": "Delete street",
     "street-count-none": "No streets yet",
     "street-count": "{count} street",
-    "street-count_plural": "{count} streets"
+    "street-count_plural": "{count} streets",
+    "sign-in": "Sign in with Twitter for your personal street gallery"
   },
   "users": {
     "anonymous": "Anonymous",


### PR DESCRIPTION
Delete extraneous sign-in.promo-1 (which is already translated in the
share.sign-in string) and add a concatenated share.sign-in-2 string.

Once this is merged, I will bring over the translations form
sing-in.link and sign-in.promo-2 to the new share.sign-in-2. Then I’ll
make a new PR to delete the unused sign-in strings.

This addresses part of issue #886, but not the entire thing. After the 2nd PR is made, the issue will have been addressed.