### PR TITLE
Refactor Gallery component

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -266,7 +266,7 @@
     "twitter-link": "Twitter profile",
     "delete-street-tooltip": "Delete street",
     "street-count-none": "No streets yet",
-    "street-count": "{count} street",
+    "street-count": "{count, plural, =0 {No streets yet} one {# street} other {# streets}}",
     "street-count_plural": "{count} streets",
     "sign-in": "Sign in with Twitter for your personal street gallery"
   },

--- a/assets/scripts/gallery/Gallery.jsx
+++ b/assets/scripts/gallery/Gallery.jsx
@@ -91,8 +91,7 @@ class Gallery extends React.Component {
         childElements = (
           <div className="gallery-sign-in-promo">
             <a href="/twitter-sign-in?redirectUri=/just-signed-in">
-              <FormattedMessage id="sign-in.link" defaultMessage="Sign in with Twitter" />&nbsp;
-              <FormattedMessage id="sign-in.promo-2" defaultMessage="for your personal street gallery" />
+              <FormattedMessage id="gallery.sign-in" defaultMessage="Sign in with Twitter for your personal street gallery" />
             </a>
           </div>
         )

--- a/assets/scripts/gallery/Gallery.jsx
+++ b/assets/scripts/gallery/Gallery.jsx
@@ -17,16 +17,6 @@ import { sendDeleteStreetToServer } from '../streets/xhr'
 import { showError, ERRORS } from '../app/errors'
 import { setGalleryMode, deleteGalleryStreet } from '../store/actions/gallery'
 
-function getStreetCountText (count) {
-  let text
-  if (!count) {
-    text = <FormattedMessage id="gallery.street-count-none" defaultMessage="No streets yet" />
-  } else {
-    text = <FormattedMessage id="gallery.street-count" defaultMessage="{count} streets" values={{ count }} />
-  }
-  return text
-}
-
 class Gallery extends React.Component {
   static propTypes = {
     setGalleryMode: PropTypes.func,
@@ -200,7 +190,13 @@ class Gallery extends React.Component {
           )
         })
         const streetCount = (this.props.userId) ? (
-          <div className="gallery-street-count">{getStreetCountText(this.props.streets.length)}</div>
+          <div className="gallery-street-count">
+            <FormattedMessage
+              id="gallery.street-count"
+              defaultMessage="{count, plural, =0 {No streets yet} one {# street} other {# streets}}"
+              values={{ count: this.props.streets.length }}
+            />
+          </div>
         ) : null
 
         childElements = (

--- a/assets/scripts/gallery/Gallery.jsx
+++ b/assets/scripts/gallery/Gallery.jsx
@@ -24,14 +24,12 @@ class Gallery extends React.Component {
     userId: PropTypes.string,
     mode: PropTypes.string,
     streets: PropTypes.array.isRequired,
-    signInData: PropTypes.object,
-    isSignedIn: PropTypes.bool,
-    street: PropTypes.object
+    isOwnedByCurrentUser: PropTypes.bool,
+    currentStreetId: PropTypes.string
   }
 
   static defaultProps = {
-    streets: [],
-    signInData: {}
+    streets: []
   }
 
   constructor (props) {
@@ -39,24 +37,12 @@ class Gallery extends React.Component {
 
     this.state = {
       selected: null,
-      preventHide: false,
-      isOwnedByCurrentUser: this.props.isSignedIn && (this.props.userId === this.props.signInData.userId)
+      preventHide: false
     }
   }
 
   componentDidMount () {
     this.scrollSelectedStreetIntoView()
-  }
-
-  static getDerivedStateFromProps (nextProps, prevState) {
-    // If user signs in or signs out, gallery ownership state will change.
-    if (nextProps.isSignedIn && (nextProps.userId === nextProps.signInData.userId)) {
-      return {
-        isOwnedByCurrentUser: true
-      }
-    }
-
-    return null
   }
 
   componentDidUpdate () {
@@ -77,7 +63,7 @@ class Gallery extends React.Component {
 
   deleteStreet = (streetId) => {
     let preventHide = false
-    if (streetId === this.props.street.id) {
+    if (streetId === this.props.currentStreetId) {
       preventHide = true
       showError(ERRORS.NO_STREET, false)
     }
@@ -157,13 +143,13 @@ class Gallery extends React.Component {
         // (which displays all streets) or if the user ID provided is different
         // from a currently signed-in user
         let galleryClassName = 'gallery-streets-container'
-        if (!this.props.userId || !this.state.isOwnedByCurrentUser) {
+        if (!this.props.userId || !this.props.isOwnedByCurrentUser) {
           galleryClassName += ' gallery-streets-container-full'
         }
 
         // Display these buttons for a user viewing their own gallery
         let buttons
-        if (this.state.isOwnedByCurrentUser) {
+        if (this.props.isOwnedByCurrentUser) {
           buttons = (
             <div className="gallery-user-buttons">
               <a className="button-like gallery-new-street" href={`/${URL_NEW_STREET}`} target="_blank">
@@ -185,7 +171,7 @@ class Gallery extends React.Component {
               selected={isSelected}
               handleSelect={this.selectStreet}
               handleDelete={this.deleteStreet}
-              allowDelete={this.state.isOwnedByCurrentUser}
+              allowDelete={this.props.isOwnedByCurrentUser}
             />
           )
         })
@@ -228,9 +214,8 @@ function mapStateToProps (state) {
     userId: state.gallery.userId,
     mode: state.gallery.mode,
     streets: state.gallery.streets,
-    signInData: state.user.signInData,
-    isSignedIn: state.user.signedIn,
-    street: state.street
+    currentStreetId: state.street.id,
+    isOwnedByCurrentUser: state.user.signedIn && (state.gallery.userId === state.user.signInData.userId)
   }
 }
 

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -56,9 +56,8 @@ class GalleryStreetItem extends React.Component {
   onClickDeleteGalleryStreet = (event) => {
     event.preventDefault()
     event.stopPropagation()
-    const street = this.props.street
 
-    // TODO escape name
+    const street = this.props.street
     const message = this.props.intl.formatMessage({
       id: 'prompt.delete-street',
       defaultMessage: 'Are you sure you want to permanently delete {streetName}? This cannot be undone.'

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -6,8 +6,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { injectIntl } from 'react-intl'
 import StreetName from '../streets/StreetName'
-import { t } from '../app/locale'
 import { formatDate } from '../util/date_format'
 import { drawStreetThumbnail } from './thumbnail'
 import { getStreetUrl } from '../streets/data_model'
@@ -24,7 +24,8 @@ class GalleryStreetItem extends React.Component {
     handleSelect: PropTypes.func.isRequired,
     handleDelete: PropTypes.func.isRequired,
     allowDelete: PropTypes.bool,
-    dpi: PropTypes.number
+    dpi: PropTypes.number,
+    intl: PropTypes.object
   }
 
   static defaultProps = {
@@ -58,7 +59,12 @@ class GalleryStreetItem extends React.Component {
     const street = this.props.street
 
     // TODO escape name
-    const message = t('prompt.delete-street', 'Are you sure you want to permanently delete {streetName}? This cannot be undone.', { streetName: street.name })
+    const message = this.props.intl.formatMessage({
+      id: 'prompt.delete-street',
+      defaultMessage: 'Are you sure you want to permanently delete {streetName}? This cannot be undone.'
+    }, {
+      streetName: street.name || this.props.intl.formatMessage({ id: 'street.default-name', defaultMessage: 'Unnamed St' })
+    })
 
     if (window.confirm(message)) {
       this.props.handleDelete(street.id)
@@ -84,29 +90,22 @@ class GalleryStreetItem extends React.Component {
           <StreetName name={this.props.street.name} />
           <span className="date">{formatDate(this.props.street.updatedAt)}</span>
 
-          {(() => {
-            if (!this.props.userId) {
-              return (
-                <span className="creator">{this.street.creatorId || t('users.anonymous', 'Anonymous')}</span>
-              )
-            }
-          })()}
+          {!this.props.userId &&
+            <span className="creator">
+              {this.street.creatorId || this.props.intl.formatMessage({ id: 'users.anonymous', defaultMessage: 'Anonymous' })}
+            </span>
+          }
 
-          {(() => {
-            // Only show delete links if you own the street
-            if (this.props.allowDelete) {
-              return (
-                <button
-                  className="remove"
-                  title={t('gallery.delete-street-tooltip', 'Delete street')}
-                  onClick={this.onClickDeleteGalleryStreet}
-                >
-                  ×
-                </button>
-              )
-            }
-          })()}
-
+          {/* Only show delete links if you own the street */ }
+          {this.props.allowDelete &&
+            <button
+              className="remove"
+              title={this.props.intl.formatMessage({ id: 'gallery.delete-street-tooltip', defaultMessage: 'Delete street' })}
+              onClick={this.onClickDeleteGalleryStreet}
+            >
+              ×
+            </button>
+          }
         </a>
       </div>
     )
@@ -120,4 +119,4 @@ function mapStateToProps (state) {
   }
 }
 
-export default connect(mapStateToProps)(GalleryStreetItem)
+export default injectIntl(connect(mapStateToProps)(GalleryStreetItem))


### PR DESCRIPTION
Update the gallery component to resolve translation issues and refactor the code (streamlining a few things).

Translation related:

- Use the react-intl format for formatting messages with plural items (resolves #888, #906). There will need to be a follow up PR to remove the translation keys for `street-count-none` and `street-count_plural`.
- Update the sign in link text to use the new combined message (follow up from #886, #918, #923).

Refactoring:

- Map dispatch actions to props instead of calling `dispatch` directly from component.
- Simplify props that are passed to Gallery component so that it does not have more information and logic than it needs. By doing prop logic in `mapStateToProps` we remove the need to have the `componentWillReceiveProps` lifecycle function at all.
- In GalleryStreetItem, remove the use of the legacy `t` (i18next) translation function.
- In GalleryStreetItem, simplify the if-then display logic.

Bug fix:

- Fix a bug where loading a user's gallery directly on page load, when the user owns the gallery, the UI is not updated to provide user controls (like delete street, create new street, etc)