### PR TITLE
StreetName/GalleryStreetItem refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ addons:
 services:
   - mongodb
 
+before_install:
+  # Install dependencies for node `canvas` package
+  # https://github.com/Automattic/node-canvas#compiling
+  - sudo apt-get install libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev build-essential g++
+
 before_script:
   # Artificial wait before connecting to MongoDB
   # https://docs.travis-ci.com/user/database-setup/#MongoDB-does-not-immediately-accept-connections

--- a/assets/css/_gallery.scss
+++ b/assets/css/_gallery.scss
@@ -162,40 +162,6 @@ body:not(.safari).gallery-visible .street-section-sky {
     margin-left: 0;
   }
 
-  .creator {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 18px;
-    text-align: center;
-    display: block;
-    font-size: 11px;
-    color: black;
-  }
-
-  .date {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 5px;
-    text-align: center;
-    display: block;
-    font-size: 11px;
-    color: black;
-    font-weight: 300;
-  }
-
-  button.remove {
-    position: absolute;
-    font-size: 16px;
-    padding: 0 10px;
-    line-height: 25px;
-    top: -10px;
-    right: -5px;
-    display: none;
-    user-select: none;
-  }
-
   &:hover {
     background: fade-out($ui-colour, 0.1);
 
@@ -217,6 +183,38 @@ body:not(.safari).gallery-visible .street-section-sky {
       opacity: 1;
     }
   }
+}
+
+.gallery-street-item-creator {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 18px;
+  text-align: center;
+  display: block;
+  font-size: 11px;
+  color: black;
+}
+
+.gallery-street-item-date {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 5px;
+  text-align: center;
+  display: block;
+  font-size: 11px;
+  color: black;
+  font-weight: 300;
+}
+
+.gallery-street-item-delete {
+  position: absolute;
+  padding: 0 10px;
+  line-height: 25px;
+  top: -8px;
+  right: -5px;
+  user-select: none;
 }
 
 .gallery-user-buttons {

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -47,10 +47,12 @@ class App extends React.PureComponent {
             key={`locale_${this.props.locale.locale}`}
             messages={this.props.locale.messages}
           >
-            <MenusContainer />
+            <React.Fragment>
+              <MenusContainer />
+              <StreetNameCanvas />
+            </React.Fragment>
           </IntlProvider>
 
-          <StreetNameCanvas />
           <InfoBubble />
           <DebugHoverPolygon />
 

--- a/assets/scripts/gallery/Gallery.jsx
+++ b/assets/scripts/gallery/Gallery.jsx
@@ -170,6 +170,7 @@ class Gallery extends React.Component {
               selected={isSelected}
               handleSelect={this.selectStreet}
               handleDelete={this.deleteStreet}
+              showStreetOwner={this.props.userId !== item.creatorId}
               allowDelete={this.props.isOwnedByCurrentUser}
             />
           )

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -98,11 +98,14 @@ export class GalleryStreetItem extends React.Component {
           />
 
           <StreetName name={this.props.street.name} />
-          <span className="date">{formatDate(this.props.street.updatedAt)}</span>
+
+          <span className="gallery-street-item-date">
+            {formatDate(this.props.street.updatedAt)}
+          </span>
 
           {/* Show street creator (owner) or 'Anonymous' */ }
           {this.props.showStreetOwner &&
-            <span className="creator">
+            <span className="gallery-street-item-creator">
               {this.props.street.creatorId || this.props.intl.formatMessage({ id: 'users.anonymous', defaultMessage: 'Anonymous' })}
             </span>
           }
@@ -110,7 +113,7 @@ export class GalleryStreetItem extends React.Component {
           {/* Only show delete button if allowed, e.g. if user is owner of the street */ }
           {this.props.allowDelete &&
             <button
-              className="remove"
+              className="gallery-street-item-delete"
               title={this.props.intl.formatMessage({ id: 'gallery.delete-street-tooltip', defaultMessage: 'Delete street' })}
               onClick={this.onClickDeleteGalleryStreet}
             >

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -20,7 +20,7 @@ export class GalleryStreetItem extends React.Component {
   static propTypes = {
     street: PropTypes.object.isRequired,
     intl: PropTypes.object.isRequired,
-    userId: PropTypes.string,
+    showStreetOwner: PropTypes.bool,
     selected: PropTypes.bool,
     allowDelete: PropTypes.bool,
     handleSelect: PropTypes.func,
@@ -29,6 +29,7 @@ export class GalleryStreetItem extends React.Component {
   }
 
   static defaultProps = {
+    showStreetOwner: true,
     selected: false,
     allowDelete: false,
     handleSelect: () => {}, // no-op
@@ -100,7 +101,7 @@ export class GalleryStreetItem extends React.Component {
           <span className="date">{formatDate(this.props.street.updatedAt)}</span>
 
           {/* Show street creator (owner) or 'Anonymous' */ }
-          {!this.props.userId &&
+          {this.props.showStreetOwner &&
             <span className="creator">
               {this.props.street.creatorId || this.props.intl.formatMessage({ id: 'users.anonymous', defaultMessage: 'Anonymous' })}
             </span>
@@ -124,7 +125,6 @@ export class GalleryStreetItem extends React.Component {
 
 function mapStateToProps (state) {
   return {
-    userId: state.gallery.userId,
     dpi: state.system.hiDpi
   }
 }

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -16,33 +16,36 @@ const THUMBNAIL_WIDTH = 180
 const THUMBNAIL_HEIGHT = 110
 const THUMBNAIL_MULTIPLIER = 0.1 * 2
 
-class GalleryStreetItem extends React.Component {
+export class GalleryStreetItem extends React.Component {
   static propTypes = {
-    userId: PropTypes.string,
-    selected: PropTypes.bool.isRequired,
     street: PropTypes.object.isRequired,
-    handleSelect: PropTypes.func.isRequired,
-    handleDelete: PropTypes.func.isRequired,
+    intl: PropTypes.object.isRequired,
+    userId: PropTypes.string,
+    selected: PropTypes.bool,
     allowDelete: PropTypes.bool,
-    dpi: PropTypes.number,
-    intl: PropTypes.object
+    handleSelect: PropTypes.func,
+    handleDelete: PropTypes.func,
+    dpi: PropTypes.number
   }
 
   static defaultProps = {
     selected: false,
+    allowDelete: false,
+    handleSelect: () => {}, // no-op
     handleDelete: () => {}, // no-op
-    allowDelete: false
+    dpi: 1
   }
 
   componentDidMount () {
+    if (!this.props.street.data) return
+
     this.drawCanvas()
   }
 
   drawCanvas = () => {
     const ctx = this.thumbnailEl.getContext('2d')
-    if (!this.props.street.data) {
-      console.log(this.props.street)
-    }
+
+    // TODO: document magic number 2
     drawStreetThumbnail(ctx, this.props.street.data.street,
       THUMBNAIL_WIDTH * 2, THUMBNAIL_HEIGHT * 2, this.props.dpi, THUMBNAIL_MULTIPLIER, true, false, true, false, false)
   }
@@ -73,6 +76,12 @@ class GalleryStreetItem extends React.Component {
   render () {
     const className = (this.props.selected) ? 'selected' : ''
 
+    // TODO: handle data errors better
+    if (!this.props.street.data) {
+      console.error('No street data!', this.props.street)
+      return null
+    }
+
     return (
       <div className="gallery-street-item">
         <a
@@ -80,6 +89,7 @@ class GalleryStreetItem extends React.Component {
           onClick={this.onClickGalleryStreet}
           className={className}
         >
+          {/* TODO: document magic number 2 */}
           <canvas
             width={THUMBNAIL_WIDTH * this.props.dpi * 2}
             height={THUMBNAIL_HEIGHT * this.props.dpi * 2}
@@ -89,13 +99,14 @@ class GalleryStreetItem extends React.Component {
           <StreetName name={this.props.street.name} />
           <span className="date">{formatDate(this.props.street.updatedAt)}</span>
 
+          {/* Show street creator (owner) or 'Anonymous' */ }
           {!this.props.userId &&
             <span className="creator">
-              {this.street.creatorId || this.props.intl.formatMessage({ id: 'users.anonymous', defaultMessage: 'Anonymous' })}
+              {this.props.street.creatorId || this.props.intl.formatMessage({ id: 'users.anonymous', defaultMessage: 'Anonymous' })}
             </span>
           }
 
-          {/* Only show delete links if you own the street */ }
+          {/* Only show delete button if allowed, e.g. if user is owner of the street */ }
           {this.props.allowDelete &&
             <button
               className="remove"

--- a/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
+++ b/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+import React from 'react'
+import { mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
+import { mockIntl } from '../../../../test/__mocks__/react-intl'
+import { GalleryStreetItem } from '../GalleryStreetItem'
+
+// Mock dependencies
+jest.mock('../thumbnail', () => {
+  return {
+    drawStreetThumbnail: jest.fn()
+  }
+})
+jest.mock('../../streets/data_model', () => {
+  return {
+    getStreetUrl: jest.fn()
+  }
+})
+
+const MOCK_STREET_DATA = {
+  data: {},
+  creatorId: 'foo'
+}
+
+describe('GalleryStreetItem', () => {
+  it('renders without crashing', () => {
+    // Mounting is required to test that a canvas element will be rendered correctly
+    // This also uses jsdom + canvas packages under the hood
+    const wrapper = mountWithIntl(
+      <GalleryStreetItem
+        street={MOCK_STREET_DATA}
+        intl={mockIntl}
+      />)
+
+    expect(wrapper.exists()).toEqual(true)
+  })
+})

--- a/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
+++ b/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
@@ -33,4 +33,28 @@ describe('GalleryStreetItem', () => {
 
     expect(wrapper.exists()).toEqual(true)
   })
+
+  it('displays street owner', () => {
+    const wrapper = mountWithIntl(
+      <GalleryStreetItem
+        street={MOCK_STREET_DATA}
+        intl={mockIntl}
+      />)
+
+    expect(wrapper.find('.gallery-street-item-creator').text()).toEqual('foo')
+  })
+
+  it('does not display street owner when specified', () => {
+    const wrapper = mountWithIntl(
+      <GalleryStreetItem
+        street={MOCK_STREET_DATA}
+        intl={mockIntl}
+        showStreetOwner={false}
+      />)
+
+    expect(wrapper.find('.gallery-street-item-creator').length).toEqual(0)
+  })
+
+  it('handles select')
+  it('handles delete')
 })

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -1,25 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 import { needsUnicodeFont } from '../util/unicode'
 import { t } from '../app/locale'
 
 const MAX_STREET_NAME_WIDTH = 50
 
-class StreetName extends React.PureComponent {
+export default class StreetName extends React.PureComponent {
   static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
     childRef: PropTypes.func,
     onClick: PropTypes.func,
-    isStreetReadOnly: PropTypes.bool,
-    isHoverable: PropTypes.bool
+    editable: PropTypes.bool
   }
 
   static defaultProps = {
     name: '',
-    isStreetReadOnly: false,
-    isHoverable: false
+    editable: false
   }
 
   /**
@@ -57,8 +54,7 @@ class StreetName extends React.PureComponent {
   }
 
   renderHoverPrompt = () => {
-    if (this.props.isStreetReadOnly || !this.props.isHoverable) return null
-    if (typeof this.props.onClick === 'function' && this.state.isHovered) {
+    if (this.props.editable && this.state.isHovered) {
       return (
         <div className="street-name-hover-prompt">
           {t('street.rename', 'Click to rename')}
@@ -88,12 +84,3 @@ class StreetName extends React.PureComponent {
     )
   }
 }
-
-function mapStateToProps (state) {
-  return {
-    isStreetReadOnly: state.app.readOnly,
-    isHoverable: !state.system.touch
-  }
-}
-
-export default connect(mapStateToProps)(StreetName)

--- a/assets/scripts/streets/StreetName.jsx
+++ b/assets/scripts/streets/StreetName.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 import { needsUnicodeFont } from '../util/unicode'
-import { t } from '../app/locale'
 
 const MAX_STREET_NAME_WIDTH = 50
 
@@ -57,7 +57,7 @@ export default class StreetName extends React.PureComponent {
     if (this.props.editable && this.state.isHovered) {
       return (
         <div className="street-name-hover-prompt">
-          {t('street.rename', 'Click to rename')}
+          <FormattedMessage id="street.rename" defaultMessage="Click to rename" />
         </div>
       )
     }
@@ -66,8 +66,8 @@ export default class StreetName extends React.PureComponent {
   }
 
   render () {
-    let classString = 'street-name-text ' + (!needsUnicodeFont(this.props.name) ? '' : 'fallback-unicode-font')
-    const streetName = StreetName.normalizeStreetName(this.props.name) || t('street.default-name', 'Unnamed St')
+    const streetNameClass = 'street-name-text ' + (!needsUnicodeFont(this.props.name) ? '' : 'fallback-unicode-font')
+    const displayName = StreetName.normalizeStreetName(this.props.name) || <FormattedMessage id="street.default-name" defaultMessage="Unnamed St" />
 
     return (
       <div
@@ -79,7 +79,7 @@ export default class StreetName extends React.PureComponent {
         id={this.props.id}
       >
         {this.renderHoverPrompt()}
-        <div className={classString}>{streetName}</div>
+        <div className={streetNameClass}>{displayName}</div>
       </div>
     )
   }

--- a/assets/scripts/streets/StreetNameCanvas.jsx
+++ b/assets/scripts/streets/StreetNameCanvas.jsx
@@ -101,6 +101,7 @@ class StreetNameCanvas extends React.Component {
     return (
       <div className={this.determineClassNames().join(' ')}>
         <StreetName
+          editable={this.props.editable}
           id="street-name"
           childRef={(ref) => { this.streetName = ref }}
           name={this.props.street.name}

--- a/assets/scripts/streets/__tests__/StreetName.test.js
+++ b/assets/scripts/streets/__tests__/StreetName.test.js
@@ -1,0 +1,33 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import { mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
+import StreetName from '../StreetName'
+
+describe('StreetName', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallow(<StreetName />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+
+  it('renders a name', () => {
+    const wrapper = shallow(<StreetName name="foo" />)
+    expect(wrapper.text()).toEqual('foo')
+  })
+
+  it('truncates very long names', () => {
+    const wrapper = shallow(<StreetName name="foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar" />)
+    // We don't care what the actual length of string is, just that it's been truncated
+    expect(wrapper.text().endsWith('…')).toEqual(true)
+  })
+
+  it('renders a placeholder if there is no name', () => {
+    // Requires the react-intl test helper to retrieve the correct content of <FormattedMessage />
+    const wrapper = mountWithIntl(<StreetName />)
+    expect(wrapper.text()).toEqual('Unnamed St')
+  })
+
+  it('shows a "Click to edit" message when mouse is hovering over it')
+  it('does not do that if the street name is not editable')
+  it('responds to an onClick handler')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -418,13 +418,13 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.0"
+        "acorn": "5.5.3"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         }
       }
@@ -2400,6 +2400,14 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz",
       "integrity": "sha512-/0Q00Oie9C72P8zQHtFvzmkrMC3oOFUnMWjCy5F2+BE8lzICm91hQPhh0+XIsAFPKOe2Dh3pKgbRmU3EKxfldA=="
     },
+    "canvas": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.6.10.tgz",
+      "integrity": "sha512-wd97ZrUfLYWjQ0qcJGiM44anXB+RviRu3DETpPIS4Sf7JzhP9PawwHdZOlx8sufcsRSeWuQe93qaCtwvK1jWXQ==",
+      "requires": {
+        "nan": "2.6.2"
+      }
+    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3293,12 +3301,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
-      "dev": true
-    },
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
@@ -3671,6 +3673,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
       "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
+    },
+    "data-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+      "integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.1"
+      }
     },
     "date-fns": {
       "version": "1.29.0",
@@ -8142,7 +8155,7 @@
       "requires": {
         "jest-mock": "22.2.0",
         "jest-util": "22.4.1",
-        "jsdom": "11.6.2"
+        "jsdom": "11.9.0"
       }
     },
     "jest-environment-node": {
@@ -8724,24 +8737,23 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.6.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
-      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.9.0.tgz",
+      "integrity": "sha512-sb3omwJTJ+HwAltLZevM/KQBusY+l2Ar5UfnTCWk9oUVBiDnQPBNiG1BaTAKttCnneonYbNo7vi4EFDY2lBfNA==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.5.0",
+        "acorn": "5.5.3",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
-        "browser-process-hrtime": "0.1.2",
-        "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "data-urls": "1.0.0",
         "domexception": "1.0.1",
         "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
-        "left-pad": "1.2.0",
-        "nwmatcher": "1.4.3",
+        "left-pad": "1.3.0",
+        "nwmatcher": "1.4.4",
         "parse5": "4.0.0",
         "pn": "1.1.0",
         "request": "2.83.0",
@@ -8752,15 +8764,16 @@
         "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.4.0",
+        "whatwg-mimetype": "2.1.0",
+        "whatwg-url": "6.4.1",
         "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
-          "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
         },
         "parse5": {
@@ -8993,9 +9006,9 @@
       "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
     },
     "left-pad": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
-      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
       "dev": true
     },
     "leven": {
@@ -10850,9 +10863,9 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true
     },
     "oauth": {
@@ -16522,10 +16535,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
+    "whatwg-mimetype": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+      "integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+      "dev": true
+    },
     "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
+      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
       "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "browserify": "16.1.0",
     "browserify-middleware": "8.0.0",
     "btoa": "1.1.2",
+    "canvas": "1.6.10",
     "compression": "1.7.2",
     "config": "1.30.0",
     "cookie-parser": "1.4.3",


### PR DESCRIPTION
As a continuation of reafactoring and internationalization work in the Gallery (#925), and as preparation for fixing date-time formatting in the gallery, I started to add some basic tests `GalleryStreetItem`. To do testing here properly though, we also had to refactor `StreetName`. This PR contains some of this refactoring work; actual date-time formatting work will happen later.

`StreetName` component:

- This was disconnected from Redux in order to make testing its parent components (e.g. `GalleryStreetItem`) easier without having to pass in a data store.
    - We now ignore whether the component displays in a touch-capable device, relying on mouse event handlers to handle state. This may affect the display on touch-enabled devices, but it should be a minor effect.
    - We now let the parent component decide whether the street name is editable, because only one parent (`StreetNameCanvas`) will actually ever allow this.
- Update `StreetName` to use `react-intl` for translations, now that nearly all of its parent components are within a `<IntlProvider>` tree.  `StreetNameCanvas` was moved into one of these to make it happen. This also sets up `StreetNameCanvas` to be able to use `react-intl` in future.
- Basic tests for the `StreetName` component have been added, since it is now easier without higher-order components wrapping it.

`GalleryStreetItem` component:

- Further refactored so that the parent component decides whether to show the street owner name, which only happens for an "all streets" gallery. This allows us to remove the `userId` prop because an individual street item does not actually need to know whose gallery is being viewed at any given time.
- CSS names for child elements refactored so that it doesn't use non-namespaced names (which are highly susceptible to collisions).
- Additional comments added.
- Handling of streets that have empty data objects (a remnant of an older data bug where some streets would be missing data) moved to the `render()` function.
- Tests have been added. Note that this required installing the npm package `canvas` which renders canvas elements in a non-browser environment like Node.js. Although this is super handy for tests, in the future, we may be able to use this canvas package to port canvas rendering to the back-end. (See https://github.com/streetmix/streetmix/projects/7)
