### PR TITLE
Update translation file plural syntax

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -235,6 +235,7 @@
     "decrease-width": "Decrease width (hold Shift for more precision)",
     "add-floor": "Add floor",
     "remove-floor": "Remove floor",
+    "floors-count": "{count, plural, one {# floor} other {# floors}}",
     "number-floor": "{number} floor",
     "number-floors": "{number} floors",
     "number-floors-large": "{number} floors"
@@ -262,9 +263,7 @@
     "all": "All streets",
     "twitter-link": "Twitter profile",
     "delete-street-tooltip": "Delete street",
-    "street-count-none": "No streets yet",
     "street-count": "{count, plural, =0 {No streets yet} one {# street} other {# streets}}",
-    "street-count_plural": "{count} streets",
     "sign-in": "Sign in with Twitter for your personal street gallery"
   },
   "users": {


### PR DESCRIPTION
Remove extraneous “street-count-none” and “street-count-plural” strings. Add a new “floors-count” string that is in line with the new format.js plural standards we are using.

In order to save the “number of floors” related strings, I will move these over in Transifex and create a follow up PR afterwards.