### PR TITLE
Refactor MessageBar component

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -69,7 +69,8 @@
     "trouble-loading": "We’re having trouble loading Streetmix.",
     "slow-connection-1": "Streetmix wasn’t able to connect to the Internet in awhile now.",
     "slow-connection-2": "You might want to reload the page and try again. Please note you might lose the latest change to the street. Sorry!",
-    "no-connection": "Streetmix is having trouble connecting to the Internet."
+    "no-connection": "Streetmix is having trouble connecting to the Internet.",
+    "more-info": "More info"
   },
   "error": {
     "button": {

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -36,9 +36,9 @@ class App extends React.PureComponent {
           <React.Fragment>
             <BlockingError />
             <Gallery />
+            <MessageBar />
           </React.Fragment>
         </IntlProvider>
-        <MessageBar />
         <div className="main-screen">
           <GalleryShield />
 

--- a/assets/scripts/app/MessageBar.jsx
+++ b/assets/scripts/app/MessageBar.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
-import { injectIntl, intlShape } from 'react-intl'
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 
 const TRANSITION_DURATION = 250
 const TRANSITION_BASE_STYLE = {
@@ -64,7 +64,7 @@ class MessageBar extends React.Component {
           {text && <span className="message-bar-text">{text}</span>}
           {link &&
             <a href={link} target="_blank" rel="noopener noreferrer" className="message-bar-link">
-              {linkText || link}
+              {linkText || <FormattedMessage id="msg.more-info" defaultMessage="More info" />}
             </a>
           }
 

--- a/assets/scripts/app/MessageBar.jsx
+++ b/assets/scripts/app/MessageBar.jsx
@@ -1,50 +1,84 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Transition } from 'react-transition-group'
-import { t } from '../app/locale'
+import { injectIntl, intlShape } from 'react-intl'
 
 const TRANSITION_DURATION = 250
 const TRANSITION_BASE_STYLE = {
   transition: `margin ${TRANSITION_DURATION}ms ease-out`
 }
 
-export default class MessageBar extends React.Component {
+class MessageBar extends React.Component {
+  static propTypes = {
+    intl: intlShape.isRequired,
+    message: PropTypes.shape({
+      display: PropTypes.bool,
+      lede: PropTypes.string,
+      text: PropTypes.string,
+      link: PropTypes.string,
+      linkText: PropTypes.string
+    })
+  }
+
+  static defaultProps = {
+    message: {
+      display: false
+    }
+  }
+
   constructor (props) {
     super(props)
 
     this.state = {
-      visible: true,
       height: 0
     }
 
-    this.el = null
+    this.el = React.createRef()
   }
 
   onClickDismiss = (event) => {
-    const height = this.el.getBoundingClientRect().height
+    const height = this.el.current.getBoundingClientRect().height
 
     this.setState({
-      visible: false,
       height
     })
   }
 
   render () {
-    // No messages to display for now, so return null from this component.
-    // For now, manually edit this render and deploy for messages.
-    return null
+    const { display, lede, text, link, linkText } = this.props.message
 
-    /* eslint-disable no-unreachable */
-    const margin = (this.state.visible) ? 0 : `-${this.state.height}px`
+    // If no one turns this on explicitly, don't display anything
+    if (!display || (!lede && !text && !link)) return null
 
     return (
-      <Transition in={this.state.visible} timeout={TRANSITION_DURATION} unmountOnExit>
-        <div className="message-bar" ref={(ref) => { this.el = ref }} style={{ ...TRANSITION_BASE_STYLE, marginTop: margin }}>
-          <strong className="message-bar-intro">Heads up!</strong>
-          <span className="message-bar-text">Streetmix will be offline for maintainance on January 1, 2018 at 19:00 GMT.</span>
-          <a href="https://twitter.com/streetmix/" target="_blank" rel="noopener noreferrer" className="message-bar-link">Follow us on Twitter for updates.</a>
-          <button className="close" onClick={this.onClickDismiss} title={t('btn.dismiss', 'Dismiss')}>×</button>
+      <Transition in={display} timeout={TRANSITION_DURATION} unmountOnExit>
+        <div
+          className="message-bar"
+          ref={this.el}
+          style={{
+            ...TRANSITION_BASE_STYLE,
+            marginTop: `-${this.state.height}px`
+          }}
+        >
+          {lede && <strong className="message-bar-intro">{lede}</strong>}
+          {text && <span className="message-bar-text">{text}</span>}
+          {link &&
+            <a href={link} target="_blank" rel="noopener noreferrer" className="message-bar-link">
+              {linkText || link}
+            </a>
+          }
+
+          <button
+            className="close"
+            onClick={this.onClickDismiss}
+            title={this.props.intl.formatMessage({ id: 'btn.dismiss', defaultMessage: 'Dismiss' })}
+          >
+            ×
+          </button>
         </div>
       </Transition>
     )
   }
 }
+
+export default injectIntl(MessageBar)

--- a/assets/scripts/app/__tests__/MessageBar.test.js
+++ b/assets/scripts/app/__tests__/MessageBar.test.js
@@ -1,0 +1,118 @@
+/* eslint-env jest */
+import React from 'react'
+import MessageBar from '../MessageBar'
+import { shallowWithIntl, mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
+import { mockIntl } from '../../../../test/__mocks__/react-intl'
+
+const TEST_MESSAGE = {
+  display: true,
+  lede: 'Heads up!',
+  text: 'Streetmix will be offline for maintainance on January 1, 2018 at 19:00 GMT.',
+  link: 'https://twitter.com/streetmix/',
+  linkText: 'Follow us on Twitter for updates.'
+}
+
+describe('MessageBar', () => {
+  it('renders without crashing', () => {
+    const wrapper = shallowWithIntl(<MessageBar intl={mockIntl} message={TEST_MESSAGE} />)
+    expect(wrapper.exists()).toEqual(true)
+  })
+
+  describe('conditions that render nothing', () => {
+    it('renders nothing if message is not provided', () => {
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} />)
+      expect(wrapper.html()).toEqual(null)
+    })
+
+    it('renders nothing if message is the empty object', () => {
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={{}} />)
+      expect(wrapper.html()).toEqual(null)
+    })
+
+    it('renders nothing if message’s display property is false', () => {
+      const message = { ...TEST_MESSAGE, display: false }
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={message} />)
+      expect(wrapper.html()).toEqual(null)
+    })
+
+    it('renders nothing if message’s display property is true but has no other properties', () => {
+      const message = { display: true }
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={message} />)
+      expect(wrapper.html()).toEqual(null)
+    })
+  })
+
+  describe('conditions that render something', () => {
+    it('renders an entire message', () => {
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={TEST_MESSAGE} />)
+      expect(wrapper.find('.message-bar-intro').text()).toEqual(TEST_MESSAGE.lede)
+      expect(wrapper.find('.message-bar-text').text()).toEqual(TEST_MESSAGE.text)
+      expect(wrapper.find('a').prop('href')).toEqual(TEST_MESSAGE.link)
+      expect(wrapper.find('a').text()).toEqual(TEST_MESSAGE.linkText)
+    })
+
+    it('renders only the lede', () => {
+      const message = {
+        display: true,
+        lede: TEST_MESSAGE.lede
+      }
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={message} />)
+      expect(wrapper.find('.message-bar-intro').text()).toEqual(message.lede)
+      expect(wrapper.find('.message-bar-text').exists()).toEqual(false)
+      expect(wrapper.find('a').exists()).toEqual(false)
+    })
+
+    it('renders only the message text', () => {
+      const message = {
+        display: true,
+        text: TEST_MESSAGE.text
+      }
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={message} />)
+      expect(wrapper.find('.message-bar-intro').exists()).toEqual(false)
+      expect(wrapper.find('.message-bar-text').text()).toEqual(message.text)
+      expect(wrapper.find('a').exists()).toEqual(false)
+    })
+
+    it('renders only the link', () => {
+      const message = {
+        display: true,
+        link: TEST_MESSAGE.link,
+        linkText: TEST_MESSAGE.linkText
+      }
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={message} />)
+      expect(wrapper.find('.message-bar-intro').exists()).toEqual(false)
+      expect(wrapper.find('.message-bar-text').exists()).toEqual(false)
+      expect(wrapper.find('a').prop('href')).toEqual(TEST_MESSAGE.link)
+      expect(wrapper.find('a').text()).toEqual(TEST_MESSAGE.linkText)
+    })
+
+    it('renders placeholder link text', () => {
+      const message = {
+        display: true,
+        link: TEST_MESSAGE.link
+      }
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={message} />)
+      expect(wrapper.find('.message-bar-intro').exists()).toEqual(false)
+      expect(wrapper.find('.message-bar-text').exists()).toEqual(false)
+      expect(wrapper.find('a').prop('href')).toEqual(TEST_MESSAGE.link)
+      expect(wrapper.find('a').text()).toEqual('More info')
+    })
+
+    it('renders the close button', () => {
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={TEST_MESSAGE} />)
+      expect(wrapper.find('.close').exists()).toEqual(true)
+    })
+  })
+
+  describe('dismiss', () => {
+    it.skip('handles clicking the close button', () => {
+      // Apparently, you can't spy on a method declared as a class field property.
+      // Ongoing discussion:
+      // https://github.com/airbnb/enzyme/issues/365
+      const spy = MessageBar.prototype.onClickDismiss = jest.fn()
+      const wrapper = mountWithIntl(<MessageBar intl={mockIntl} message={TEST_MESSAGE} />)
+      wrapper.find('.close').simulate('click')
+      expect(spy).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
The `MessageBar` component has been refactored so that in order to display a message it must be passed in via its props. It is no longer hardcoded as a "test" message. Instead, the "test" message is moved to an actual test.

An additional "More info" string is added to the translation file as the default link text, if a link is provided to the component.