### PR TITLE
Consolidate components inside of IntlProvider

### DIFF
--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -40,28 +40,17 @@ class App extends React.PureComponent {
           </React.Fragment>
         </IntlProvider>
         <div className="main-screen">
-          <GalleryShield />
-
-          <IntlProvider
-            locale={this.props.locale.locale}
-            key={`locale_${this.props.locale.locale}`}
-            messages={this.props.locale.messages}
-          >
-            <React.Fragment>
-              <MenusContainer />
-              <StreetNameCanvas />
-            </React.Fragment>
-          </IntlProvider>
-
-          <InfoBubble />
-          <DebugHoverPolygon />
-
           <IntlProvider
             locale={this.props.locale.locale}
             key={this.props.locale.locale}
             messages={this.props.locale.messages}
           >
             <React.Fragment>
+              <GalleryShield />
+              <MenusContainer />
+              <StreetNameCanvas />
+              <InfoBubble />
+              <DebugHoverPolygon />
               <WelcomePanel />
               <Palette />
               <DialogRoot />

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -6,7 +6,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { injectIntl } from 'react-intl'
+import { injectIntl, intlShape } from 'react-intl'
 import StreetName from '../streets/StreetName'
 import DateTimeRelative from '../app/DateTimeRelative'
 import { drawStreetThumbnail } from './thumbnail'
@@ -19,7 +19,7 @@ const THUMBNAIL_MULTIPLIER = 0.1 * 2
 export class GalleryStreetItem extends React.Component {
   static propTypes = {
     street: PropTypes.object.isRequired,
-    intl: PropTypes.object.isRequired,
+    intl: intlShape.isRequired,
     showStreetOwner: PropTypes.bool,
     selected: PropTypes.bool,
     allowDelete: PropTypes.bool,

--- a/assets/scripts/info_bubble/BuildingHeightControl.jsx
+++ b/assets/scripts/info_bubble/BuildingHeightControl.jsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { injectIntl, intlShape } from 'react-intl'
 import { debounce } from 'lodash'
-import { t } from '../app/locale'
 import { MAX_BUILDING_HEIGHT, BUILDINGS, calculateRealHeightNumber } from '../segments/buildings'
 import { addBuildingFloor, removeBuildingFloor, setBuildingFloorValue } from '../store/actions/street'
 import { prettifyWidth } from '../util/width_units'
@@ -13,6 +13,7 @@ const WIDTH_EDIT_INPUT_DELAY = 200
 
 class BuildingHeightControl extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     touch: PropTypes.bool,
     position: PropTypes.oneOf(['left', 'right']),
     variant: PropTypes.string,
@@ -239,7 +240,7 @@ class BuildingHeightControl extends React.Component {
       <input
         type="text"
         className="height"
-        title={t('tooltip.building-height', 'Change the number of floors')}
+        title={this.props.intl.formatMessage({ id: 'tooltip.building-height', defaultMessage: 'Change the number of floors' })}
         disabled={isNotFloored}
         value={isNotFloored ? '' : this.state.displayValue}
         onChange={this.onInput}
@@ -259,7 +260,7 @@ class BuildingHeightControl extends React.Component {
       <div className="non-variant building-height">
         <button
           className="increment"
-          title={t('tooltip.add-floor', 'Add floor')}
+          title={this.props.intl.formatMessage({ id: 'tooltip.add-floor', defaultMessage: 'Add floor' })}
           tabIndex={-1}
           onClick={this.onClickIncrement}
           disabled={isNotFloored || (this.props.value >= MAX_BUILDING_HEIGHT)}
@@ -269,7 +270,7 @@ class BuildingHeightControl extends React.Component {
         {inputEl}
         <button
           className="decrement"
-          title={t('tooltip.remove-floor', 'Remove floor')}
+          title={this.props.intl.formatMessage({ id: 'tooltip.remove-floor', defaultMessage: 'Remove floor' })}
           tabIndex={-1}
           onClick={this.onClickDecrement}
           disabled={isNotFloored || (this.props.value <= 1)}
@@ -308,4 +309,4 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(BuildingHeightControl)
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(BuildingHeightControl))

--- a/assets/scripts/info_bubble/BuildingHeightControl.jsx
+++ b/assets/scripts/info_bubble/BuildingHeightControl.jsx
@@ -216,12 +216,12 @@ class BuildingHeightControl extends React.Component {
    * @param {string} text - text string to display
    */
   prettifyHeight = (variant, position, floors) => {
-    // todo localize
-    let text = `${floors} floor`
-
-    if (floors > 1) {
-      text += 's'
-    }
+    let text = this.props.intl.formatMessage({
+      id: 'floors-count',
+      defaultMessage: '{count, plural, one {# floor} other {# floors}}'
+    }, {
+      count: floors
+    })
 
     const realHeight = calculateRealHeightNumber(variant, position, floors)
     const prettifiedHeight = prettifyWidth(realHeight, this.props.units)

--- a/assets/scripts/info_bubble/Description.jsx
+++ b/assets/scripts/info_bubble/Description.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 import Triangle from './Triangle'
 import { showDescription, hideDescription } from './description'
 import { trackEvent } from '../app/event_tracking'
@@ -87,7 +88,7 @@ export default class Description extends React.Component {
     if (!description) return null
 
     // Get translated text for prompt, if it exists
-    const defaultPrompt = description.prompt || t('segments.learn-more', 'Learn more')
+    const defaultPrompt = description.prompt || <FormattedMessage id="segments.learn-more" defaultMessage="Learn more" />
     const prompt = t(`segments.${this.props.type}.description.prompt`, defaultPrompt, { ns: 'segment-info' })
 
     // TODO: add alt text and requisite a11y attributes
@@ -128,7 +129,7 @@ export default class Description extends React.Component {
             onMouseOver={this.toggleHighlightTriangle}
             onMouseOut={this.toggleHighlightTriangle}
           >
-            {t('btn.close', 'Close')}
+            <FormattedMessage id="btn.close" defaultMessage="Close" />
           </div>
           <Triangle highlight={this.state.highlightTriangle} />
         </div>

--- a/assets/scripts/info_bubble/RemoveButton.jsx
+++ b/assets/scripts/info_bubble/RemoveButton.jsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { t } from '../app/locale'
+import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import { trackEvent } from '../app/event_tracking'
 import { removeSegment, removeAllSegments } from '../segments/remove'
 
-export default class RemoveButton extends React.PureComponent {
+class RemoveButton extends React.PureComponent {
   static propTypes = {
+    intl: intlShape.isRequired,
     enabled: PropTypes.bool,
     segment: PropTypes.object // TODO: this is the actual DOM element; change it to a value
   }
@@ -37,11 +38,13 @@ export default class RemoveButton extends React.PureComponent {
       <button
         className="info-bubble-remove"
         tabIndex={-1}
-        title={t('tooltip.remove-segment', 'Remove segment')}
+        title={this.props.intl.formatMessage({ id: 'tooltip.remove-segment', defaultMessage: 'Remove segment' })}
         onClick={this.onClick}
       >
-        {t('btn.remove', 'Remove')}
+        <FormattedMessage id="btn.remove" defaultMessage="remove" />
       </button>
     )
   }
 }
+
+export default injectIntl(RemoveButton)

--- a/assets/scripts/info_bubble/Triangle.jsx
+++ b/assets/scripts/info_bubble/Triangle.jsx
@@ -1,24 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export default class Triangle extends React.Component {
-  static propTypes = {
-    highlight: PropTypes.bool.isRequired
+export default function Triangle (props) {
+  const triangleClassNames = ['info-bubble-triangle']
+
+  if (props.highlight === true) {
+    triangleClassNames.push('info-bubble-triangle-highlight')
   }
 
-  static defaultProps = {
-    highlight: false
-  }
+  return (
+    <div className={triangleClassNames.join(' ')} />
+  )
+}
 
-  render () {
-    // Triangle is highlighted when description button is hovered
-    let triangleClassNames = ['info-bubble-triangle']
-    if (this.props.highlight === true) {
-      triangleClassNames.push('info-bubble-triangle-highlight')
-    }
+Triangle.prototype.propTypes = {
+  highlight: PropTypes.bool
+}
 
-    return (
-      <div className={triangleClassNames.join(' ')} />
-    )
-  }
+Triangle.prototype.defaultProps = {
+  highlight: false
 }

--- a/assets/scripts/info_bubble/Warnings.jsx
+++ b/assets/scripts/info_bubble/Warnings.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FormattedMessage } from 'react-intl'
 import {
   SEGMENT_WARNING_OUTSIDE,
   SEGMENT_WARNING_WIDTH_TOO_SMALL,
   SEGMENT_WARNING_WIDTH_TOO_LARGE
 } from '../streets/width'
-import { t } from '../app/locale'
 
 export default class Warnings extends React.Component {
   static propTypes = {
@@ -19,13 +19,13 @@ export default class Warnings extends React.Component {
     if (!segment) return null
 
     if (segment.warnings[SEGMENT_WARNING_OUTSIDE]) {
-      messages.push(t('segments.warnings.does-not-fit', 'This segment doesn’t fit within the street.'))
+      messages.push(<FormattedMessage id="segments.warnings.does-not-fit" defaultMessage="This segment doesn’t fit within the street." />)
     }
     if (segment.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL]) {
-      messages.push(t('segments.warnings.not-wide', 'This segment might not be wide enough.'))
+      messages.push(<FormattedMessage id="segments.warnings.not-wide" defaultMessage="This segment might not be wide enough." />)
     }
     if (segment.warnings[SEGMENT_WARNING_WIDTH_TOO_LARGE]) {
-      messages.push(t('segments.warnings.too-wide', 'This segment might be too wide.'))
+      messages.push(<FormattedMessage id="segments.warnings.too-wide" defaultMessage="This segment might be too wide." />)
     }
 
     if (messages.length > 0) {

--- a/assets/scripts/info_bubble/WidthControl.jsx
+++ b/assets/scripts/info_bubble/WidthControl.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { injectIntl, intlShape } from 'react-intl'
 import { debounce } from 'lodash'
 import { changeSegmentWidth } from '../store/actions/street'
-import { t } from '../app/locale'
 import { trackEvent } from '../app/event_tracking'
 import { KEYS } from '../app/keyboard_commands'
 
@@ -26,6 +26,7 @@ const WIDTH_EDIT_INPUT_DELAY = 200
 
 class WidthControl extends React.Component {
   static propTypes = {
+    intl: intlShape.isRequired,
     touch: PropTypes.bool,
     segment: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
     segmentEl: PropTypes.object, // TODO: this is the actual DOM element; only here for legacy reasons
@@ -260,7 +261,7 @@ class WidthControl extends React.Component {
       <input
         type="text"
         className="width"
-        title={t('tooltip.segment-width', 'Change width of the segment')}
+        title={this.props.intl.formatMessage({ id: 'tooltip.segment-width', defaultMessage: 'Change width of the segment' })}
         value={this.state.displayValue}
         onChange={this.onInput}
         onClick={this.onClickInput}
@@ -279,7 +280,7 @@ class WidthControl extends React.Component {
       <div className="non-variant">
         <button
           className="decrement"
-          title={t('tooltip.decrease-width', 'Decrease width (hold Shift for more precision)')}
+          title={this.props.intl.formatMessage({ id: 'tooltip.decrease-width', defaultMessage: 'Decrease width (hold Shift for more precision)' })}
           tabIndex={-1}
           onClick={this.onClickDecrement}
           disabled={this.props.value <= MIN_SEGMENT_WIDTH}
@@ -289,7 +290,7 @@ class WidthControl extends React.Component {
         {inputEl}
         <button
           className="increment"
-          title={t('tooltip.increase-width', 'Increase width (hold Shift for more precision)')}
+          title={this.props.intl.formatMessage({ id: 'tooltip.increase-width', defaultMessage: 'Increase width (hold Shift for more precision)' })}
           tabIndex={-1}
           onClick={this.onClickIncrement}
           disabled={this.props.value >= MAX_SEGMENT_WIDTH}
@@ -317,4 +318,4 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(WidthControl)
+export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(WidthControl))

--- a/assets/scripts/info_bubble/__tests__/Triangle.test.js
+++ b/assets/scripts/info_bubble/__tests__/Triangle.test.js
@@ -1,0 +1,21 @@
+/* eslint-env jest */
+import React from 'react'
+import Triangle from '../Triangle'
+import { shallow } from 'enzyme'
+
+describe('Triangle', () => {
+  it('renders an unhighlighted triangle by default', () => {
+    const wrapper = shallow(<Triangle />)
+    expect(wrapper.find('div').hasClass('info-bubble-triangle-highlight')).toEqual(false)
+  })
+
+  it('renders an highlighted triangle', () => {
+    const wrapper = shallow(<Triangle highlight />)
+    expect(wrapper.find('div').hasClass('info-bubble-triangle-highlight')).toEqual(true)
+  })
+
+  it('renders an unhighlighted triangle', () => {
+    const wrapper = shallow(<Triangle highlight={false} />)
+    expect(wrapper.find('div').hasClass('info-bubble-triangle-highlight')).toEqual(false)
+  })
+})


### PR DESCRIPTION
This allows us to use `react-intl` for components inside the `InfoBubble` (except for segment information, whose data are not part of this flow yet), which, most importantly, localizes the `floors` input box for the first time. Resolves #926.