### PR TITLE
Remove old "number-floors" strings

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -236,10 +236,7 @@
     "decrease-width": "Decrease width (hold Shift for more precision)",
     "add-floor": "Add floor",
     "remove-floor": "Remove floor",
-    "floors-count": "{count, plural, one {# floor} other {# floors}}",
-    "number-floor": "{number} floor",
-    "number-floors": "{number} floors",
-    "number-floors-large": "{number} floors"
+    "floors-count": "{count, plural, one {# floor} other {# floors}}"
   },
   "street": {
     "default-name": "Unnamed St",


### PR DESCRIPTION
The translations have been migrated over in Transifex, so these old keys are now safe to delete. We are now using the new plural format as specified in format.js.