### PR TITLE
Replace loading spinner

### DIFF
--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -56,9 +56,7 @@
 
     {{! Blocking elements pre-React }}
     <div id="loading">
-      {{! Don't show loading text because there could be a flash of untranslated text }}
-      <span data-i18n="msg.loading">&nbsp;</span>
-      <progress id="loading-progress" value="0" max="1"></progress>
+      <div class="loading-spinner"></div>
     </div>
     <div id="blocking-shield">
       <div class="message"></div>

--- a/assets/css/_chrome.scss
+++ b/assets/css/_chrome.scss
@@ -63,33 +63,24 @@ body.phone #loading {
   }
 }
 
-#loading-progress {
-  @include appearance(none);
+.loading-spinner::before {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 30px;
+  height: 30px;
+  margin-top: -15px;
+  margin-left: -15px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.75);
+  border-top-color: darken($ui-colour, 20%);
+  animation: spinner 0.75s linear infinite;
+}
 
-  display: block;
-  width: 200px;
-  height: 8px;
-  padding: 0;
-  margin: 0 auto;
-  margin-top: 5px;
-  border: 0;
-  border-top: 1px solid darken($ui-colour, 20%);
-  border-bottom: 1px solid darken($ui-colour, 20%);
-  background: transparent;
-  background-size: auto;
-  color: $off-white;
-
-  &::-webkit-progress-bar {
-    background: transparent;
-  }
-
-  &::-webkit-progress-value {
-    background: $off-white;
-  }
-
-  &::-moz-progress-bar {
-    background: $off-white;
-  }
+@keyframes spinner {
+  to { transform: rotate(360deg); }
 }
 
 // --------------------------------------------------------

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -98,8 +98,6 @@ export async function initialize () {
     updateSettingsFromCountryCode(geo.country_code)
   }
 
-  document.querySelector('#loading-progress').value++
-
   // Sign in
   // …sign in info from our API (if not previously cached) – and subsequent
   // street data if necessary (depending on the mode)

--- a/assets/scripts/app/load_resources.js
+++ b/assets/scripts/app/load_resources.js
@@ -17,13 +17,7 @@ const IMAGES_TO_BE_LOADED = [
 const SVGStagingEl = document.getElementById('svg')
 let loading = []
 
-// Set loading bar
-const loadingEl = document.getElementById('loading-progress')
-loadingEl.max += 3 // Legacy; this is for other things that must load
-
 export async function loadImages () {
-  loadingEl.max += IMAGES_TO_BE_LOADED.length
-
   for (let url of IMAGES_TO_BE_LOADED) {
     loading.push(loadImage(url))
   }
@@ -74,8 +68,6 @@ async function loadImage (url) {
 
       cacheSVGObject(id, svg, svgHTML)
     }
-
-    loadingEl.value++
 
     return body
   } catch (error) {

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -102,7 +102,6 @@ export async function loadSignIn () {
   }
 
   setSignInLoadedState(true)
-  document.querySelector('#loading-progress').value++
 
   _signInLoaded()
 


### PR DESCRIPTION
This doesn't seem related to #938, but it is! Currently, the loading screen will display "Loading" in the user's selected language when the language loads. With the shift to using `react-intl` -- and eventually, improving the initial asset-loading process -- we shouldn't assume these translations are actually available when the app is loading. (And they're not; there's always a few milliseconds of delay before we can modify the DOM to show the text.) Thankfully, there's a common convention to show a loading state and that's just a simple rotating spinner.

Along with this, we're removing the progress bar and the logic required to maintain and modify its state.

