### PR TITLE
Localize segment titles in the palette

### DIFF
--- a/assets/scripts/app/locale.js
+++ b/assets/scripts/app/locale.js
@@ -54,10 +54,10 @@ function initRtlChangedListener () {
 }
 
 export function t (key, fallback, options = {}) {
-  const messages = store.getState().locale.messages
+  const locale = store.getState().locale
   if (options.ns === 'segment-info') {
-    return messages['segmentInfo.' + key] || fallback
+    return locale.segmentInfo[key] || fallback
   } else {
-    return messages[key] || fallback
+    return locale.messages[key] || fallback
   }
 }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -7,6 +7,7 @@ import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter } from '
 import { drawSegmentContents, getVariantInfoDimensions, segmentsChanged, TILE_SIZE } from './view'
 import { SETTINGS_UNITS_METRIC } from '../users/localization'
 import { infoBubble, INFO_BUBBLE_TYPE_SEGMENT } from '../info_bubble/info_bubble'
+import { t } from '../app/locale'
 
 const WIDTH_PALETTE_MULTIPLIER = 4 // Dupe from palette.js
 const SEGMENT_Y_NORMAL = 265
@@ -75,7 +76,14 @@ class Segment extends React.Component {
   render () {
     const segmentInfo = getSegmentInfo(this.props.type)
     const variantInfo = getSegmentVariantInfo(this.props.type, this.props.variantString)
-    const name = variantInfo.name || segmentInfo.name
+    const defaultName = variantInfo.name || segmentInfo.name // the name to display if there isn't a localized version of it
+
+    // Get localized names from store, fall back to segment default names if translated
+    // text is not found. TODO: port to react-intl/formatMessage later.
+    const localizedVariantName = t(`segments.${this.props.type}.details.${this.props.variantString}.name`, null, { ns: 'segment-info' })
+    const localizedName = t(`segments.${this.props.type}.name`, defaultName, { ns: 'segment-info' })
+    const title = localizedVariantName || localizedName
+
     const width = this.calculateWidth(RESIZE_TYPE_INITIAL)
     const segmentWidth = this.props.width // may need to double check this. setSegmentContents() was called with other widths
 
@@ -106,12 +114,11 @@ class Segment extends React.Component {
         data-variant-string={this.props.variantString}
         data-rand-seed={this.props.randSeed}
         data-width={width}
-        title={this.props.forPalette ? segmentInfo.name : null}>
+        title={this.props.forPalette ? localizedName : null}>
         {!this.props.forPalette &&
           <React.Fragment>
             <span className="name">
-              {/* TODO: localize */}
-              {name}
+              {title}
             </span>
             <span className="width">
               <MeasurementText value={width} units={this.props.units} />

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -81,8 +81,8 @@ class Segment extends React.Component {
     // Get localized names from store, fall back to segment default names if translated
     // text is not found. TODO: port to react-intl/formatMessage later.
     const localizedVariantName = t(`segments.${this.props.type}.details.${this.props.variantString}.name`, null, { ns: 'segment-info' })
-    const localizedName = t(`segments.${this.props.type}.name`, defaultName, { ns: 'segment-info' })
-    const title = localizedVariantName || localizedName
+    const localizedSegmentName = t(`segments.${this.props.type}.name`, defaultName, { ns: 'segment-info' })
+    const displayName = localizedVariantName || localizedSegmentName
 
     const width = this.calculateWidth(RESIZE_TYPE_INITIAL)
     const segmentWidth = this.props.width // may need to double check this. setSegmentContents() was called with other widths
@@ -114,11 +114,11 @@ class Segment extends React.Component {
         data-variant-string={this.props.variantString}
         data-rand-seed={this.props.randSeed}
         data-width={width}
-        title={this.props.forPalette ? localizedName : null}>
+        title={this.props.forPalette ? localizedSegmentName : null}>
         {!this.props.forPalette &&
           <React.Fragment>
             <span className="name">
-              {title}
+              {displayName}
             </span>
             <span className="width">
               <MeasurementText value={width} units={this.props.units} />

--- a/assets/scripts/store/actions/index.js
+++ b/assets/scripts/store/actions/index.js
@@ -64,6 +64,7 @@ export const SET_INFO_BUBBLE_MOUSE_INSIDE = 'SET_INFO_BUBBLE_MOUSE_INSIDE'
 
 /* locale */
 export const SET_LOCALE = 'SET_LOCALE'
+export const SET_SEGMENT_TRANSLATIONS = 'SET_SEGMENT_TRANSLATIONS'
 
 /* map */
 export const SET_MAP_STATE = 'SET_MAP_STATE'

--- a/assets/scripts/store/actions/locale.js
+++ b/assets/scripts/store/actions/locale.js
@@ -1,4 +1,4 @@
-import { SET_LOCALE } from './index'
+import { SET_LOCALE, SET_SEGMENT_TRANSLATIONS } from './index'
 import { API_URL } from '../../app/config'
 
 // Flattens a nested object from translation response, e.g.
@@ -34,6 +34,13 @@ export function setLocale (locale, messages) {
   }
 }
 
+function setSegmentInfoTranslations (messages) {
+  return {
+    type: SET_SEGMENT_TRANSLATIONS,
+    messages: flattenObject(messages)
+  }
+}
+
 export function changeLocale (locale) {
   return (dispatch) => {
     Promise.all([
@@ -41,8 +48,10 @@ export function changeLocale (locale) {
       window.fetch(`${API_URL}v1/translate/${locale}/segment-info`).then((r) => r.json())
     ]).then((responses) => {
       const messages = responses[0]
-      messages.segmentInfo = responses[1]
+      const segmentInfo = responses[1]
+
       dispatch(setLocale(locale, messages))
+      dispatch(setSegmentInfoTranslations(segmentInfo))
     })
   }
 }

--- a/assets/scripts/store/reducers/locale.js
+++ b/assets/scripts/store/reducers/locale.js
@@ -1,11 +1,12 @@
-import { SET_LOCALE } from '../actions'
+import { SET_LOCALE, SET_SEGMENT_TRANSLATIONS } from '../actions'
 
 const initialState = {
   // Default language is set by browser, or is English if undetermined
   // Substitute 'en' for 'en-US' locales
   // TODO: make that unnecessary
   locale: navigator.language.replace('en-US', 'en') || 'en',
-  messages: {}
+  messages: {},
+  segmentInfo: {}
 }
 
 const locale = (state = initialState, action) => {
@@ -15,6 +16,11 @@ const locale = (state = initialState, action) => {
         ...state,
         locale: action.locale,
         messages: action.messages
+      }
+    case SET_SEGMENT_TRANSLATIONS:
+      return {
+        ...state,
+        segmentInfo: action.messages
       }
     default:
       return state


### PR DESCRIPTION
This also moves segment info translations into a separate property in Redux to keep it separate from main application translations.

Resolves #902.