### PR TITLE
Move "no streets yet" to its own string

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -263,7 +263,8 @@
     "all": "All streets",
     "twitter-link": "Twitter profile",
     "delete-street-tooltip": "Delete street",
-    "street-count": "{count, plural, =0 {No streets yet} one {# street} other {# streets}}",
+    "street-count": "{count, plural, one {# street} other {# streets}}",
+    "no-streets": "No streets yet",
     "sign-in": "Sign in with Twitter for your personal street gallery"
   },
   "users": {


### PR DESCRIPTION
We are doing this so that our plural strings work in the Transifex UI. Transifex supports the language plural forms specified here: http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html

Having a separate string here for the ‘0’ form brings us into compliance with this and will create a better experience for translators.