### PR TITLE
removed global streetSectionCanvasLeft

### DIFF
--- a/assets/scripts/app/window_resize.js
+++ b/assets/scripts/app/window_resize.js
@@ -1,16 +1,8 @@
 import { infoBubble } from '../info_bubble/info_bubble'
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
-import { BUILDING_SPACE } from '../segments/buildings'
-import { TILE_SIZE } from '../segments/view'
 import store from '../store'
 import { windowResize } from '../store/actions/system'
-
-let streetSectionCanvasLeft
-
-export function getStreetSectionCanvasLeft () {
-  return streetSectionCanvasLeft
-}
 
 let streetSectionTop
 
@@ -51,22 +43,6 @@ export function onResize () {
 
   document.querySelector('#street-section-dirt').style.height =
     streetSectionDirtPos + 'px'
-
-  // The following lines were removed in 7f6ea939fd50c6bcb7cb31200cfd1888f31550a9
-  // but it caused the drag/drop of elements to not work anymore.
-  const street = store.getState().street
-
-  streetSectionCanvasLeft =
-    ((system.viewportWidth - (street.width * TILE_SIZE)) / 2) - BUILDING_SPACE
-  if (streetSectionCanvasLeft < 0) {
-    streetSectionCanvasLeft = 0
-  }
-  document.querySelector('#street-section-canvas').style.left =
-    streetSectionCanvasLeft + 'px'
-
-  document.querySelector('#street-section-editable').style.width =
-    (street.width * TILE_SIZE) + 'px'
-  // end trouble lines
 
   infoBubble.show(true)
 }

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -1,9 +1,6 @@
 import { trackEvent } from '../app/event_tracking'
 import { loseAnyFocus } from '../util/focus'
-import {
-  getStreetSectionCanvasLeft,
-  getStreetSectionTop
-} from '../app/window_resize'
+import { getStreetSectionTop } from '../app/window_resize'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { app } from '../preinit/app_settings'
 import { system } from '../preinit/system_capabilities'
@@ -505,7 +502,8 @@ export function onBodyMouseDown (event) {
 function makeSpaceBetweenSegments (x, y) {
   let farLeft, farRight
   const street = store.getState().street
-  var left = x - getStreetSectionCanvasLeft()
+  const streetSectionCanvasLeft = document.querySelector('#street-section-canvas').style.left
+  var left = x - Number.parseFloat(streetSectionCanvasLeft, 10)
 
   var selectedSegmentBefore = null
   var selectedSegmentAfter = null

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -503,7 +503,7 @@ function makeSpaceBetweenSegments (x, y) {
   let farLeft, farRight
   const street = store.getState().street
   const streetSectionCanvasLeft = document.querySelector('#street-section-canvas').style.left
-  var left = x - Number.parseFloat(streetSectionCanvasLeft, 10)
+  var left = x - Number.parseFloat(streetSectionCanvasLeft)
 
   var selectedSegmentBefore = null
   var selectedSegmentAfter = null


### PR DESCRIPTION
Using `document.querySelector('#street-section-canvas').style.left` in `makeSpaceBetweenSegments`

It looks like the drag/drop segments is working now and the repeating buildings on narrow streets is good too on my side. 