### PR TITLE
EmptySegment component

### DIFF
--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux'
 import SkyBackground from './SkyBackground'
 import ScrollIndicators from './ScrollIndicators'
 import Building from '../segments/Building'
+import EmptySegment from '../segments/EmptySegment'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { animate, getElAbsolutePos } from '../util/helpers'
 import { MAX_CUSTOM_STREET_WIDTH } from '../streets/width'
@@ -210,8 +211,8 @@ class StreetView extends React.Component {
                 calculateBuildingPerspective={this.calculateBuildingPerspective}
               />
               <div id="street-section-editable" ref={(ref) => { this.streetSectionEditable = ref }} />
-              <div id="street-section-left-empty-space" className="segment empty" />
-              <div id="street-section-right-empty-space" className="segment empty" />
+              <EmptySegment position="left" />
+              <EmptySegment position="right" />
               <section id="street-section-dirt" style={dirtStyle} />
             </section>
           </section>

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -76,8 +76,6 @@ export async function initialize () {
 
   window.dispatchEvent(new window.CustomEvent('stmx:init'))
 
-  // fillEmptySegments()
-
   processUrl()
   processMode()
   if (store.getState().errors.abortEverything) {

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -6,7 +6,7 @@ import { app } from '../preinit/app_settings'
 import { debug } from '../preinit/debug_settings'
 import { system } from '../preinit/system_capabilities'
 import { initializeFlagSubscribers } from '../app/flag_utils'
-import { fillEmptySegments, segmentsChanged } from '../segments/view'
+import { segmentsChanged } from '../segments/view'
 import { onNewStreetLastClick } from '../streets/creation'
 import {
   createDomFromData,
@@ -76,7 +76,7 @@ export async function initialize () {
 
   window.dispatchEvent(new window.CustomEvent('stmx:init'))
 
-  fillEmptySegments()
+  // fillEmptySegments()
 
   processUrl()
   processMode()

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import MeasurementText from '../ui/MeasurementText'
 import { TILE_SIZE } from '../segments/view'
+import { t } from '../app/locale'
 
 class EmptySegment extends React.Component {
   static propTypes = {
@@ -68,7 +69,7 @@ class EmptySegment extends React.Component {
 
     return (
       <div id={id} className="segment empty" ref={(ref) => { this.streetEmptySegment = ref }}>
-        <span className="name" />
+        <span className="name"> { t('section.empty', 'Empty space') } </span>
         <span className="width">
           <MeasurementText value={this.state.width} units={this.props.units} />
         </span>

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+class EmptySegment extends React.Component {
+  render () {
+    return (
+      <div className="segment empty">
+        <span className="name" />
+        <span className="width" />
+        <span className="grid" />
+      </div>
+    )
+  }
+}
+
+export default EmptySegment

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import MeasurementText from '../ui/MeasurementText'
-import TILE_SIZE from '../segments/view'
+import { TILE_SIZE } from '../segments/view'
 
 class EmptySegment extends React.Component {
   static propTypes = {
@@ -21,9 +21,8 @@ class EmptySegment extends React.Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { remainingWidth, occupiedWidth } = this.props
-    if ((remainingWidth && prevProps.remainingWidth !== remainingWidth) ||
-        (occupiedWidth && prevProps.occupiedWidth !== occupiedWidth)) {
+    const { remainingWidth } = this.props
+    if (remainingWidth && prevProps.remainingWidth !== remainingWidth) {
       this.repositionEmptySegment()
     }
   }
@@ -33,17 +32,19 @@ class EmptySegment extends React.Component {
   }
 
   showEmptySegment = (width) => {
+    this.setState({ width: width / TILE_SIZE })
+
     this.streetEmptySegment.classList.add('visible')
     if (this.props.position === 'right') {
       width--
     }
+
     this.streetEmptySegment.style.width = width + 'px'
   }
 
   repositionEmptySegment = () => {
     const { remainingWidth, occupiedWidth, position } = this.props
     let width
-
     if (remainingWidth <= 0) {
       this.hideEmptySegment()
     } else {
@@ -69,7 +70,7 @@ class EmptySegment extends React.Component {
       <div id={id} className="segment empty" ref={(ref) => { this.streetEmptySegment = ref }}>
         <span className="name" />
         <span className="width">
-          <MeasurementText width={this.state.width} units={this.props.units} />
+          <MeasurementText value={this.state.width} units={this.props.units} />
         </span>
         <span className="grid" />
       </div>

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -83,7 +83,8 @@ function mapStateToProps (state) {
   return {
     remainingWidth: state.street.remainingWidth,
     occupiedWidth: state.street.occupiedWidth,
-    units: state.street.units
+    units: state.street.units,
+    locale: state.locale.locale
   }
 }
 

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -1,15 +1,88 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import MeasurementText from '../ui/MeasurementText'
+import TILE_SIZE from '../segments/view'
 
 class EmptySegment extends React.Component {
+  static propTypes = {
+    remainingWidth: PropTypes.number,
+    occupiedWidth: PropTypes.number,
+    units: PropTypes.number,
+    position: PropTypes.string
+  }
+
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      width: 0
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    const { remainingWidth, occupiedWidth } = this.props
+    if ((remainingWidth && prevProps.remainingWidth !== remainingWidth) ||
+        (occupiedWidth && prevProps.occupiedWidth !== occupiedWidth)) {
+      this.repositionEmptySegment()
+    }
+  }
+
+  hideEmptySegment = () => {
+    this.streetEmptySegment.classList.remove('visible')
+  }
+
+  showEmptySegment = (width) => {
+    this.streetEmptySegment.classList.add('visible')
+    if (this.props.position === 'right') {
+      width--
+    }
+    this.streetEmptySegment.style.width = width + 'px'
+  }
+
+  repositionEmptySegment = () => {
+    const { remainingWidth, occupiedWidth, position } = this.props
+    let width
+
+    if (remainingWidth <= 0) {
+      this.hideEmptySegment()
+    } else {
+      if (!occupiedWidth) {
+        width = remainingWidth * TILE_SIZE
+        if (position === 'right') {
+          this.hideEmptySegment()
+        } else {
+          this.showEmptySegment(width)
+        }
+      } else {
+        width = remainingWidth / 2 * TILE_SIZE
+        this.showEmptySegment(width)
+      }
+    }
+  }
+
   render () {
+    const { position } = this.props
+    const id = 'street-section-' + position + '-empty-space'
+
     return (
-      <div className="segment empty">
+      <div id={id} className="segment empty" ref={(ref) => { this.streetEmptySegment = ref }}>
         <span className="name" />
-        <span className="width" />
+        <span className="width">
+          <MeasurementText width={this.state.width} units={this.props.units} />
+        </span>
         <span className="grid" />
       </div>
     )
   }
 }
 
-export default EmptySegment
+function mapStateToProps (state) {
+  return {
+    remainingWidth: state.street.remainingWidth,
+    occupiedWidth: state.street.occupiedWidth,
+    units: state.street.units
+  }
+}
+
+export default connect(mapStateToProps)(EmptySegment)

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -17,7 +17,8 @@ class EmptySegment extends React.Component {
     super(props)
 
     this.state = {
-      width: 0
+      widthValue: 0,
+      segmentWidth: 0
     }
   }
 
@@ -33,14 +34,12 @@ class EmptySegment extends React.Component {
   }
 
   showEmptySegment = (width) => {
-    this.setState({ width: width / TILE_SIZE })
-
     this.streetEmptySegment.classList.add('visible')
-    if (this.props.position === 'right') {
-      width--
-    }
 
-    this.streetEmptySegment.style.width = width + 'px'
+    this.setState({
+      widthValue: width / TILE_SIZE,
+      segmentWidth: (this.props.position === 'right') ? width - 1 : width
+    })
   }
 
   repositionEmptySegment = () => {
@@ -65,13 +64,17 @@ class EmptySegment extends React.Component {
 
   render () {
     const { position } = this.props
-    const id = 'street-section-' + position + '-empty-space'
+
+    const style = {
+      width: this.state.segmentWidth + 'px',
+      right: (position === 'right') ? '1px' : 'auto'
+    }
 
     return (
-      <div id={id} className="segment empty" ref={(ref) => { this.streetEmptySegment = ref }}>
+      <div className="segment empty" ref={(ref) => { this.streetEmptySegment = ref }} style={style}>
         <span className="name"> { t('section.empty', 'Empty space') } </span>
         <span className="width">
-          <MeasurementText value={this.state.width} units={this.props.units} />
+          <MeasurementText value={this.state.widthValue} units={this.props.units} />
         </span>
         <span className="grid" />
       </div>

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -4,11 +4,11 @@ import { system } from '../preinit/system_capabilities'
 import { saveStreetToServerIfNecessary, createDataFromDom } from '../streets/data_model'
 import { recalculateWidth } from '../streets/width'
 import { getElAbsolutePos } from '../util/helpers'
-import { prettifyWidth } from '../util/width_units'
+// import { prettifyWidth } from '../util/width_units'
 import { draggingMove } from './drag_and_drop'
 import { getSegmentInfo, getSegmentVariantInfo, getSpriteDef } from './info'
 import { drawProgrammaticPeople } from './people'
-import { t } from '../app/locale'
+// import { t } from '../app/locale'
 import {
   RESIZE_TYPE_INITIAL,
   suppressMouseEnter,
@@ -387,26 +387,26 @@ export function createSegmentDom (segment) {
     segment.width * TILE_SIZE, segment.unmovable, false, segment.randSeed)
 }
 
-function fillEmptySegment (el) {
-  let innerEl
-  innerEl = document.createElement('span')
-  innerEl.classList.add('name')
-  innerEl.textContent = t('section.empty', 'Empty space')
-  el.appendChild(innerEl)
+// function fillEmptySegment (el) {
+//   let innerEl
+//   innerEl = document.createElement('span')
+//   innerEl.classList.add('name')
+//   innerEl.textContent = t('section.empty', 'Empty space')
+//   el.appendChild(innerEl)
 
-  innerEl = document.createElement('span')
-  innerEl.classList.add('width')
-  el.appendChild(innerEl)
+//   innerEl = document.createElement('span')
+//   innerEl.classList.add('width')
+//   el.appendChild(innerEl)
 
-  innerEl = document.createElement('span')
-  innerEl.classList.add('grid')
-  el.appendChild(innerEl)
-}
+//   innerEl = document.createElement('span')
+//   innerEl.classList.add('grid')
+//   el.appendChild(innerEl)
+// }
 
-export function fillEmptySegments () {
-  fillEmptySegment(document.querySelector('#street-section-left-empty-space'))
-  fillEmptySegment(document.querySelector('#street-section-right-empty-space'))
-}
+// export function fillEmptySegments () {
+//   fillEmptySegment(document.querySelector('#street-section-left-empty-space'))
+//   fillEmptySegment(document.querySelector('#street-section-right-empty-space'))
+// }
 
 export function repositionSegments () {
   let width, el
@@ -573,42 +573,42 @@ export function switchSegmentElAway (el) {
   }, SEGMENT_SWITCHING_TIME)
 }
 
-function hideEmptySegment (position) {
-  document.querySelector('#street-section-' + position + '-empty-space')
-    .classList.remove('visible')
-}
+// function hideEmptySegment (position) {
+//   document.querySelector('#street-section-' + position + '-empty-space')
+//     .classList.remove('visible')
+// }
 
-function showEmptySegment (position, width) {
-  document.querySelector('#street-section-' + position + '-empty-space .width').innerHTML =
-    prettifyWidth(width / TILE_SIZE, store.getState().street.units, { markup: true })
-  document.querySelector('#street-section-' + position + '-empty-space')
-    .classList.add('visible')
+// function showEmptySegment (position, width) {
+//   document.querySelector('#street-section-' + position + '-empty-space .width').innerHTML =
+//     prettifyWidth(width / TILE_SIZE, store.getState().street.units, { markup: true })
+//   document.querySelector('#street-section-' + position + '-empty-space')
+//     .classList.add('visible')
 
-  if (position === 'right') {
-    width-- // So that the rules align
-  }
-  document.querySelector('#street-section-' + position + '-empty-space')
-    .style.width = width + 'px'
-}
+//   if (position === 'right') {
+//     width-- // So that the rules align
+//   }
+//   document.querySelector('#street-section-' + position + '-empty-space')
+//     .style.width = width + 'px'
+// }
 
-function repositionEmptySegments () {
-  let width
-  const street = store.getState().street
-  if (street.remainingWidth <= 0) {
-    hideEmptySegment('left')
-    hideEmptySegment('right')
-  } else {
-    if (!street.occupiedWidth) {
-      width = street.remainingWidth * TILE_SIZE
-      showEmptySegment('left', width)
-      hideEmptySegment('right')
-    } else {
-      width = street.remainingWidth / 2 * TILE_SIZE
-      showEmptySegment('left', width)
-      showEmptySegment('right', width)
-    }
-  }
-}
+// function repositionEmptySegments () {
+//   let width
+//   const street = store.getState().street
+//   if (street.remainingWidth <= 0) {
+//     hideEmptySegment('left')
+//     hideEmptySegment('right')
+//   } else {
+//     if (!street.occupiedWidth) {
+//       width = street.remainingWidth * TILE_SIZE
+//       showEmptySegment('left', width)
+//       hideEmptySegment('right')
+//     } else {
+//       width = street.remainingWidth / 2 * TILE_SIZE
+//       showEmptySegment('left', width)
+//       showEmptySegment('right', width)
+//     }
+//   }
+// }
 
 /**
  * Set `readDataFromDom` to false to prevent re-reading of segment
@@ -633,7 +633,7 @@ export function segmentsChanged (readDataFromDom = true, reassignElementRefs = f
   }
 
   recalculateWidth()
-  repositionEmptySegments()
+  // repositionEmptySegments()
   applyWarningsToSegments()
 
   for (var i in segments) {

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -413,7 +413,7 @@ export function repositionSegments () {
   var left = 0
   var noMoveLeft = 0
 
-  var extraWidth = 0
+  // var extraWidth = 0
 
   const street = store.getState().street
   for (let i in street.segments) {
@@ -421,11 +421,11 @@ export function repositionSegments () {
 
     if (el === draggingMove.segmentBeforeEl) {
       left += DRAGGING_MOVE_HOLE_WIDTH
-      extraWidth += DRAGGING_MOVE_HOLE_WIDTH
+      // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
 
       if (!draggingMove.segmentAfterEl) {
         left += DRAGGING_MOVE_HOLE_WIDTH
-        extraWidth += DRAGGING_MOVE_HOLE_WIDTH
+        // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
       }
     }
 
@@ -444,11 +444,11 @@ export function repositionSegments () {
 
     if (el === draggingMove.segmentAfterEl) {
       left += DRAGGING_MOVE_HOLE_WIDTH
-      extraWidth += DRAGGING_MOVE_HOLE_WIDTH
+      // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
 
       if (!draggingMove.segmentBeforeEl) {
         left += DRAGGING_MOVE_HOLE_WIDTH
-        extraWidth += DRAGGING_MOVE_HOLE_WIDTH
+        // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
       }
     }
   }
@@ -473,17 +473,17 @@ export function repositionSegments () {
     }
   }
 
-  if (system.cssTransform) {
-    document.querySelector('#street-section-left-empty-space')
-      .style[system.cssTransform] = 'translateX(' + (-extraWidth / 2) + 'px)'
-    document.querySelector('#street-section-right-empty-space')
-      .style[system.cssTransform] = 'translateX(' + (extraWidth / 2) + 'px)'
-  } else {
-    document.querySelector('#street-section-left-empty-space')
-      .style.marginLeft = -(extraWidth / 2) + 'px'
-    document.querySelector('#street-section-right-empty-space')
-      .style.marginLeft = (extraWidth / 2) + 'px'
-  }
+  // if (system.cssTransform) {
+  //   document.querySelector('#street-section-left-empty-space')
+  //     .style[system.cssTransform] = 'translateX(' + (-extraWidth / 2) + 'px)'
+  //   document.querySelector('#street-section-right-empty-space')
+  //     .style[system.cssTransform] = 'translateX(' + (extraWidth / 2) + 'px)'
+  // } else {
+  //   document.querySelector('#street-section-left-empty-space')
+  //     .style.marginLeft = -(extraWidth / 2) + 'px'
+  //   document.querySelector('#street-section-right-empty-space')
+  //     .style.marginLeft = (extraWidth / 2) + 'px'
+  // }
 }
 
 export function changeSegmentVariantLegacy (dataNo, variantName, variantChoice) {

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -392,19 +392,15 @@ export function repositionSegments () {
   var left = 0
   var noMoveLeft = 0
 
-  // var extraWidth = 0
-
   const street = store.getState().street
   for (let i in street.segments) {
     el = street.segments[i].el
 
     if (el === draggingMove.segmentBeforeEl) {
       left += DRAGGING_MOVE_HOLE_WIDTH
-      // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
 
       if (!draggingMove.segmentAfterEl) {
         left += DRAGGING_MOVE_HOLE_WIDTH
-        // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
       }
     }
 
@@ -423,11 +419,9 @@ export function repositionSegments () {
 
     if (el === draggingMove.segmentAfterEl) {
       left += DRAGGING_MOVE_HOLE_WIDTH
-      // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
 
       if (!draggingMove.segmentBeforeEl) {
         left += DRAGGING_MOVE_HOLE_WIDTH
-        // extraWidth += DRAGGING_MOVE_HOLE_WIDTH
       }
     }
   }
@@ -451,18 +445,6 @@ export function repositionSegments () {
       el.style.left = el.savedLeft + 'px'
     }
   }
-
-  // if (system.cssTransform) {
-  //   document.querySelector('#street-section-left-empty-space')
-  //     .style[system.cssTransform] = 'translateX(' + (-extraWidth / 2) + 'px)'
-  //   document.querySelector('#street-section-right-empty-space')
-  //     .style[system.cssTransform] = 'translateX(' + (extraWidth / 2) + 'px)'
-  // } else {
-  //   document.querySelector('#street-section-left-empty-space')
-  //     .style.marginLeft = -(extraWidth / 2) + 'px'
-  //   document.querySelector('#street-section-right-empty-space')
-  //     .style.marginLeft = (extraWidth / 2) + 'px'
-  // }
 }
 
 export function changeSegmentVariantLegacy (dataNo, variantName, variantChoice) {

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -387,27 +387,6 @@ export function createSegmentDom (segment) {
     segment.width * TILE_SIZE, segment.unmovable, false, segment.randSeed)
 }
 
-// function fillEmptySegment (el) {
-//   let innerEl
-//   innerEl = document.createElement('span')
-//   innerEl.classList.add('name')
-//   innerEl.textContent = t('section.empty', 'Empty space')
-//   el.appendChild(innerEl)
-
-//   innerEl = document.createElement('span')
-//   innerEl.classList.add('width')
-//   el.appendChild(innerEl)
-
-//   innerEl = document.createElement('span')
-//   innerEl.classList.add('grid')
-//   el.appendChild(innerEl)
-// }
-
-// export function fillEmptySegments () {
-//   fillEmptySegment(document.querySelector('#street-section-left-empty-space'))
-//   fillEmptySegment(document.querySelector('#street-section-right-empty-space'))
-// }
-
 export function repositionSegments () {
   let width, el
   var left = 0
@@ -573,43 +552,6 @@ export function switchSegmentElAway (el) {
   }, SEGMENT_SWITCHING_TIME)
 }
 
-// function hideEmptySegment (position) {
-//   document.querySelector('#street-section-' + position + '-empty-space')
-//     .classList.remove('visible')
-// }
-
-// function showEmptySegment (position, width) {
-//   document.querySelector('#street-section-' + position + '-empty-space .width').innerHTML =
-//     prettifyWidth(width / TILE_SIZE, store.getState().street.units, { markup: true })
-//   document.querySelector('#street-section-' + position + '-empty-space')
-//     .classList.add('visible')
-
-//   if (position === 'right') {
-//     width-- // So that the rules align
-//   }
-//   document.querySelector('#street-section-' + position + '-empty-space')
-//     .style.width = width + 'px'
-// }
-
-// function repositionEmptySegments () {
-//   let width
-//   const street = store.getState().street
-//   if (street.remainingWidth <= 0) {
-//     hideEmptySegment('left')
-//     hideEmptySegment('right')
-//   } else {
-//     if (!street.occupiedWidth) {
-//       width = street.remainingWidth * TILE_SIZE
-//       showEmptySegment('left', width)
-//       hideEmptySegment('right')
-//     } else {
-//       width = street.remainingWidth / 2 * TILE_SIZE
-//       showEmptySegment('left', width)
-//       showEmptySegment('right', width)
-//     }
-//   }
-// }
-
 /**
  * Set `readDataFromDom` to false to prevent re-reading of segment
  * data from the DOM. Do this whenever we refactor code to modify
@@ -633,7 +575,6 @@ export function segmentsChanged (readDataFromDom = true, reassignElementRefs = f
   }
 
   recalculateWidth()
-  // repositionEmptySegments()
   applyWarningsToSegments()
 
   for (var i in segments) {

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -4,11 +4,9 @@ import { system } from '../preinit/system_capabilities'
 import { saveStreetToServerIfNecessary, createDataFromDom } from '../streets/data_model'
 import { recalculateWidth } from '../streets/width'
 import { getElAbsolutePos } from '../util/helpers'
-// import { prettifyWidth } from '../util/width_units'
 import { draggingMove } from './drag_and_drop'
 import { getSegmentInfo, getSegmentVariantInfo, getSpriteDef } from './info'
 import { drawProgrammaticPeople } from './people'
-// import { t } from '../app/locale'
 import {
   RESIZE_TYPE_INITIAL,
   suppressMouseEnter,

--- a/assets/scripts/ui/MeasurementText.jsx
+++ b/assets/scripts/ui/MeasurementText.jsx
@@ -42,7 +42,7 @@ export default class MeasurementText extends React.Component {
       <span>
         {this.getMeasurementString(value, units)}
         <wbr />&#8202;
-        {(units === SETTINGS_UNITS_METRIC) ? 'm' : 'ft'}
+        {(units === SETTINGS_UNITS_METRIC) ? 'm' : "'" }
       </span>
     )
   }

--- a/assets/scripts/util/width_units.js
+++ b/assets/scripts/util/width_units.js
@@ -149,7 +149,7 @@ function convertImperialMeasurementToMetric (value) {
  * @param {Number} value, assuming imperial units
  * @returns {string} stringified value formatted with vulgar fractions
  */
-function getImperialMeasurementWithVulgarFractions (value) {
+export function getImperialMeasurementWithVulgarFractions (value) {
   // Determine if there is a vulgar fraction to display
   const remainder = value - Math.floor(value)
   const fraction = IMPERIAL_VULGAR_FRACTIONS[remainder.toString().substr(1)]


### PR DESCRIPTION
This PR migrates the empty segments to a React component and is the first step to migrating all street segments to React (issue #912)

**Note:** `EmptySegment` is passed in the `locale` from Redux in order to trigger the translation of the "Empty Space". I just noticed that the other street segments does not translate when locale changes. This is probably due to street segments being created in [`createSegment`](https://github.com/streetmix/streetmix/blob/c2aa89aa8a1690bec11f7d9ecb1e3c0379723954/assets/scripts/segments/view.js#L322) and the `name` not being updated. Until the remaining segments get rendered as React components, the only idea I have to change the segment names when locale is changed is through the `store.subscribe`. 

@louh I haven't implemented this idea yet because I was wondering if you could think of a better solution? Or should I just not translate any of the segments yet until all street segments are migrated to React?