### PR TITLE
Segment: port componentWillMount to safe lifecycle methods

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -32,23 +32,9 @@ class Segment extends React.Component {
     units: SETTINGS_UNITS_METRIC
   }
 
-  calculateWidth = (resizeType) => {
-    let width = this.props.width / TILE_SIZE
-    if (!this.props.forPalette) {
-      width = normalizeSegmentWidth(width, resizeType)
-    }
+  constructor (props) {
+    super(props)
 
-    // TODO - copied from resizeSegment. make sure we don't need
-    // document.body.classList.add('immediate-segment-resize')
-    // window.setTimeout(function () {
-    //   document.body.classList.remove('immediate-segment-resize')
-    // }, SHORT_DELAY)
-
-    width = (width * TILE_SIZE)
-    return width
-  }
-
-  componentWillMount = () => {
     this.initialRender = true
   }
 
@@ -71,6 +57,22 @@ class Segment extends React.Component {
       segmentsChanged()
       infoBubble.updateContents()
     }
+  }
+
+  calculateWidth = (resizeType) => {
+    let width = this.props.width / TILE_SIZE
+    if (!this.props.forPalette) {
+      width = normalizeSegmentWidth(width, resizeType)
+    }
+
+    // TODO - copied from resizeSegment. make sure we don't need
+    // document.body.classList.add('immediate-segment-resize')
+    // window.setTimeout(function () {
+    //   document.body.classList.remove('immediate-segment-resize')
+    // }, SHORT_DELAY)
+
+    width = (width * TILE_SIZE)
+    return width
   }
 
   render () {


### PR DESCRIPTION
In React 16.3, `componentWillMount` is now [deprecated and marked "UNSAFE"](https://reactjs.org/docs/react-component.html#unsafe_componentwillmount) and will be removed in React 17.

The only use of `componentWillMount` in the Streetmix codebase is in the `Segment` component.

This update uses the preferred method of [setting initial component state in the `constructor()` method](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html#initializing-state). I also moved `calculateWidth()` in the component so that it shows up after lifecycle methods but before `render()`.