### PR TITLE
LocaleDropdown/MenusContainer: port unsafe lifecycle methods

### DIFF
--- a/assets/scripts/menus/LocaleDropdown.jsx
+++ b/assets/scripts/menus/LocaleDropdown.jsx
@@ -115,9 +115,20 @@ export class LocaleDropdown extends React.Component {
   constructor (props) {
     super(props)
 
+    // Will be set by `getDerivedStateFromProps`
     this.state = {
-      level: this.determineLevel(props)
+      level: null
     }
+  }
+
+  static getDerivedStateFromProps (nextProps) {
+    // The lowest level marked "true" takes priority.
+    let level = 4
+    if (nextProps.level3) level = 3
+    if (nextProps.level2) level = 2
+    if (nextProps.level1) level = 1
+
+    return { level }
   }
 
   componentDidMount () {
@@ -129,24 +140,12 @@ export class LocaleDropdown extends React.Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.setState({ level: this.determineLevel(nextProps) })
-  }
-
   onShow () {
     trackEvent('Interaction', 'Open settings menu', null, null, false)
   }
 
   onChange = (event) => {
     this.props.changeLocale(event.target.value)
-  }
-
-  determineLevel = (props) => {
-    let level = 4
-    if (props.level3) level = 3
-    if (props.level2) level = 2
-    if (props.level1) level = 1
-    return level
   }
 
   renderLocaleOptions = () => {

--- a/assets/scripts/menus/MenusContainer.jsx
+++ b/assets/scripts/menus/MenusContainer.jsx
@@ -30,6 +30,20 @@ class MenusContainer extends React.PureComponent {
     }
   }
 
+  static getDerivedStateFromProps (nextProps, prevState) {
+    // If menus are being cleared, handle this. Since active menu is a prop, it
+    // can be cleared from anywhere, so this handles changes in active menu state.
+    // Clear active menu state only if props have changed from an active menu
+    // state to a no-menu state, this prevents side effects from running needlessly.
+    if (prevState.activeMenuPos && !nextProps.activeMenu) {
+      return {
+        activeMenuPos: null
+      }
+    }
+
+    return null
+  }
+
   componentDidMount () {
     // Hide menus if page loses visibility.
     document.addEventListener('visibilitychange', () => {
@@ -42,13 +56,10 @@ class MenusContainer extends React.PureComponent {
     registerKeypress('esc', this.hideAllMenus)
   }
 
-  componentWillReceiveProps (nextProps) {
-    // If menus are being cleared, handle this. Since active menu is a prop, it
-    // can be cleared from anywhere, so this handles changes in active menu state.
-    // Only call `handleMenuClear` if props have changed from an active menu
-    // state to a no-menu state, this prevents side effects from running needlessly.
-    if (this.props.activeMenu && !nextProps.activeMenu) {
-      this.handleMenuClear()
+  componentDidUpdate (prevProps, prevState, snapshot) {
+    // Force document.body to become the active element when there is no longer an active menu.
+    if (prevProps.activeMenu && !this.props.activeMenu) {
+      document.body.focus()
     }
   }
 
@@ -72,22 +83,6 @@ class MenusContainer extends React.PureComponent {
       activeMenuPos: activeMenu ? position : null
     })
     this.props.showMenu(activeMenu)
-  }
-
-  /**
-   * Handles component state and DOM changes when menus are cleared. Called from
-   * `componentWillReceiveProps()` which will check if props have actually changed.
-   */
-  handleMenuClear = () => {
-    this.setState({
-      activeMenuPos: null
-    })
-
-    // Force document.body to become the active element.
-    // NOTE: prop change check is performed in `componentWillReceiveProps()`
-    // because we do not want to re-focus needlessly on document.body if there
-    // were no menus to hide.
-    document.body.focus()
   }
 
   hideAllMenus = () => {


### PR DESCRIPTION
In React 16.3, `componentWillReceiveProps ` is now [marked "UNSAFE"](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops) and will be removed in React 17. This PR represents a step toward the work described in issue #914.

In this instance, using the new `static getDerivedStateFromProps()` and `componentDidUpdate()` should cover functionality previously used by `componentWillReceiveProps`.