### PR TITLE
Do not render description prompts if it hasn't been translated

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -253,6 +253,9 @@
     "learn-more": "Learn more",
     "unknown": {
       "label": "Unknown"
+    },
+    "description": {
+      "photo-credit": "Photo:"
     }
   },
   "section": {

--- a/assets/scripts/info_bubble/Description.jsx
+++ b/assets/scripts/info_bubble/Description.jsx
@@ -74,6 +74,27 @@ export default class Description extends React.Component {
     }
   }
 
+  /**
+   * Given an array of strings, returns true if it's falsy, an empty array,
+   * or an array of empty strings.
+   *
+   * @param {Array} array
+   */
+  isEmptyText (array) {
+    if (!array) return true
+    if (Array.isArray(array)) {
+      if (array.length === 0) return true
+
+      let isEmpty = true
+      for (let i = 0; i < array.length; i++) {
+        if (array[i]) isEmpty = false
+      }
+      if (isEmpty) return true
+    }
+
+    return false
+  }
+
   renderText (text) {
     if (!text) return null
     return text.map((paragraph, index) => {
@@ -90,6 +111,12 @@ export default class Description extends React.Component {
 
     if (!description) return null
 
+    // If the description text hasn't been translated, bail.
+    const variantDescriptionText = t(`segments.${this.props.segment.type}.details.${this.props.segment.variantString}.description.text`, null, { ns: 'segment-info' })
+    const segmentDescriptionText = t(`segments.${this.props.segment.type}.description.text`, null, { ns: 'segment-info' })
+    const displayDescription = variantDescriptionText || segmentDescriptionText
+    if (!displayDescription || this.isEmptyText(displayDescription)) return null
+
     // Get translated text for prompt, if it exists
     const defaultPrompt = description.prompt || <FormattedMessage id="segments.learn-more" defaultMessage="Learn more" />
 
@@ -103,14 +130,23 @@ export default class Description extends React.Component {
       <img src={`/images/info-bubble-examples/${description.image}`} />
     ) : null
 
-    const lede = (description.lede) ? (
-      <p className="description-lede">{description.lede}</p>
+    const variantLede = t(`segments.${this.props.segment.type}.details.${this.props.segment.variantString}.description.lede`, null, { ns: 'segment-info' })
+    const segmentLede = t(`segments.${this.props.segment.type}.description.lede`, description.lede, { ns: 'segment-info' })
+    const displayLede = variantLede || segmentLede
+    const lede = (displayLede) ? (
+      <p className="description-lede">{displayLede}</p>
     ) : null
 
-    const text = this.renderText(description.text)
+    const text = this.renderText(displayDescription)
 
-    const caption = (description.imageCaption) ? (
-      <footer>Photo: {description.imageCaption}</footer>
+    const variantImageCaption = t(`segments.${this.props.segment.type}.details.${this.props.segment.variantString}.description.imageCaption`, null, { ns: 'segment-info' })
+    const segmentImageCaption = t(`segments.${this.props.segment.type}.description.imageCaption`, description.imageCaption, { ns: 'segment-info' })
+    const displayImageCaption = variantImageCaption || segmentImageCaption
+    const caption = (displayImageCaption) ? (
+      <footer>
+        <FormattedMessage id="segments.description.photo-credit" defaultMessage="Photo:" />&nbsp;
+        {displayImageCaption}
+      </footer>
     ) : null
 
     return (

--- a/assets/scripts/store/actions/locale.js
+++ b/assets/scripts/store/actions/locale.js
@@ -5,13 +5,13 @@ import { API_URL } from '../../app/config'
 // { key1: { key2: "string" }} => { "key1.key2": "string" }
 // This is because react-intl expects to look up translations this way.
 // ES6-ported function from https://gist.github.com/penguinboy/762197
-// This is quite simple; it does not address arrays or null values, since
-// the responses from the server will not be containing those.
+// Ignores arrays and passes them through unchanged.
+// Does not address null values, since the responses from the server will not be containing those.
 function flattenObject (obj) {
   const toReturn = {}
   let flatObject
   Object.keys(obj).forEach(i => {
-    if (typeof obj[i] === 'object') {
+    if (typeof obj[i] === 'object' && !Array.isArray(obj[i])) {
       flatObject = flattenObject(obj[i])
       Object.keys(flatObject).forEach(x => {
         toReturn[i + '.' + x] = flatObject[x]


### PR DESCRIPTION
Resolves #881.

All of the info bubble / description code is still pretty messy, but this is an effort at solving this particular problem without having to rewrite any of the code (structurally) under it, which can be resolved at a later time.

@treyhahn While working on this, I noticed that photo credits begin with a "Photo:" text that has not been translated, and I've included an addition to the translation file here.