### PR TITLE
Add Patricio to humans.txt

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -90,6 +90,7 @@
     Carlos Jimenez, Portuguese (Brazil)
     Stephan Garcia, Portuguese (Brazil)
     Paco Marquez, Spanish (Mexico)
+    Patricio M. Ruiz Abrín, Spanish (Mexico)
     Jakob Fahlstedt, Swedish
 
 


### PR DESCRIPTION
Patricio is a new Spanish expert reviewer and translator. He also helped us with the shift/delete issue (#878).