### PR TITLE
Port BlockingShield to React component. Resolves #808

### DIFF
--- a/app/views/404.hbs
+++ b/app/views/404.hbs
@@ -21,7 +21,7 @@
         <div class="front-clouds"></div>
       </div>
       <div class="error-content">
-        <div class="streetmix-logo"></div>             
+        <div class="streetmix-logo"></div>
         <h1><span>Page not found.</span></h1>
         <div>
           <span>Oh, boy. There is no page with this address!</span><br>

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -59,27 +59,6 @@
       <div class="streetmix-logo"></div>
       <div class="loading-spinner"></div>
     </div>
-    <div id="blocking-shield">
-      <div class="message"></div>
-      <div class="try-again">
-        Streetmix is having trouble connecting to the Internet.
-        <br>
-        <button id="blocking-shield-try-again">Try again</button>
-        <button id="blocking-shield-cancel">Cancel</button>
-      </div>
-      <div class="too-slow">
-        Streetmix wasn’t able to connect to the Internet in awhile now.
-        <br>
-        <br>
-        You might want to reload the page and try again. Please note you
-        might lose the latest change to the street. Sorry!
-        <br>
-        <br>
-        <button id="blocking-shield-reload">
-          Reload
-        </button>
-      </div>
-    </div>
 
     {{! Mount point for React }}
     <div id="react-app" class="app"></div>

--- a/assets/css/_blocking-shield.scss
+++ b/assets/css/_blocking-shield.scss
@@ -13,13 +13,13 @@
   }
 
   &.visible {
-    display: block;
+    display: flex;
   }
 
   &.darken,
   &.darken-immediately {
     background: fade-out($sky-colour, 0.15);
-    color: black;
+    color: rgb(116, 77, 77);
   }
 
   &.darken {
@@ -32,13 +32,5 @@
 
   .message {
     @include large-message-text;
-  }
-
-  .blocking-shield-content {
-    position: absolute;
-    margin-top: 20px;
-    left: 0;
-    right: 0;
-    text-align: center;
   }
 }

--- a/assets/css/_blocking-shield.scss
+++ b/assets/css/_blocking-shield.scss
@@ -19,7 +19,7 @@
   &.darken,
   &.darken-immediately {
     background: fade-out($sky-colour, 0.15);
-    color: rgb(116, 77, 77);
+    color: black;
   }
 
   &.darken {

--- a/assets/css/_blocking-shield.scss
+++ b/assets/css/_blocking-shield.scss
@@ -9,7 +9,7 @@
   cursor: wait;
 
   button {
-    cursor: auto;
+    cursor: pointer;
   }
 
   &.visible {

--- a/assets/css/_blocking-shield.scss
+++ b/assets/css/_blocking-shield.scss
@@ -1,18 +1,19 @@
 
-#blocking-shield {
+.blocking-shield {
   @include blocking-shield;
 
   z-index: $z-09-blocking-shield;
+  display: none;
   background: transparent;
   color: transparent;
   cursor: wait;
 
-  * {
-    cursor: wait;
-  }
-
   button {
     cursor: auto;
+  }
+
+  &.visible {
+    display: block;
   }
 
   &.darken,
@@ -33,30 +34,11 @@
     @include large-message-text;
   }
 
-  .try-again,
-  .too-slow {
-    display: none;
+  .blocking-shield-content {
     position: absolute;
     margin-top: 20px;
     left: 0;
     right: 0;
     text-align: center;
-  }
-
-  &.show-try-again .try-again,
-  &.show-too-slow .too-slow {
-    display: block;
-  }
-
-  #blocking-shield-cancel {
-    display: none;
-  }
-
-  &.show-cancel #blocking-shield-cancel {
-    display: inline-block;
-  }
-
-  &:not(.visible) {
-    display: none;
   }
 }

--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -17,6 +17,7 @@ import Flash from './Flash'
 import DebugInfo from './DebugInfo'
 import Gallery from '../gallery/Gallery'
 import GalleryShield from '../gallery/GalleryShield'
+import BlockingShield from './BlockingShield'
 import BlockingError from './BlockingError'
 import StreetView from './StreetView'
 import DebugHoverPolygon from '../info_bubble/DebugHoverPolygon'
@@ -36,6 +37,7 @@ class App extends React.PureComponent {
           messages={this.props.locale.messages}
         >
           <React.Fragment>
+            <BlockingShield />
             <BlockingError />
             <Gallery />
             <NotificationBar notification={NOTIFICATION} />

--- a/assets/scripts/app/BlockingShield.jsx
+++ b/assets/scripts/app/BlockingShield.jsx
@@ -1,0 +1,135 @@
+/**
+ * It's kinda the same as BlockingError, but not
+ *
+ * Blocking shield is an overlay over the screen that prevents
+ * interaction. At its most basic version it is fully transparent
+ * and allows other UI to take priority (e.g. gallery). At other
+ * times it can be "darkened" (creating a translucent overlay)
+ * showing messages or errors.
+ */
+import React from 'react'
+import { FormattedMessage } from 'react-intl'
+import { goReload } from './routing'
+import { blockingCancel, blockingTryAgain } from '../util/fetch_blocking'
+
+const BLOCKING_SHIELD_DARKEN_DELAY = 800
+const BLOCKING_SHIELD_TOO_SLOW_DELAY = 10000
+
+export default class BlockingShield extends React.Component {
+  constructor (props) {
+    super(props)
+
+    this.el = React.createRef()
+    this.blockingShieldTimerId = -1
+    this.blockingShieldTooSlowTimerId = -1
+
+    this.state = {
+      visible: false,
+      mode: 'load',
+      errorType: null,
+      darken: false,
+      showCancel: false
+    }
+  }
+
+  componentDidMount () {
+    window.addEventListener('stmx:show_blocking_shield', (event) => {
+      this.setState({
+        visible: true,
+        mode: event.detail.mode || 'load'
+      })
+
+      this.blockingShieldTimerId = window.setTimeout(() => {
+        this.setState({ darken: true })
+      }, BLOCKING_SHIELD_DARKEN_DELAY)
+
+      this.blockingShieldTooSlowTimerId = window.setTimeout(() => {
+        this.setState({ errorType: 'too-slow' })
+      }, BLOCKING_SHIELD_TOO_SLOW_DELAY)
+    })
+
+    window.addEventListener('stmx:darken_blocking_shield', (event) => {
+      this.setState({
+        visible: true,
+        immediate: true,
+        errorType: 'try-again',
+        showCancel: event.detail.showCancel
+      })
+    })
+
+    window.addEventListener('stmx:hide_blocking_shield', (event) => {
+      this.setState({
+        visible: false,
+        immediate: false,
+        errorType: null,
+        showCancel: false
+      })
+    })
+  }
+
+  componentDidUpdate (prevProps, prevState) {
+    this.clearTimers()
+  }
+
+  clearTimers = () => {
+    window.clearTimeout(this.blockingShieldTimerId)
+    window.clearTimeout(this.blockingShieldTooSlowTimerId)
+  }
+
+  blockingTryAgain = (event) => {
+    this.setState({
+      errorType: null,
+      showCancel: false
+    })
+
+    blockingTryAgain()
+  }
+
+  render () {
+    const classNames = ['blocking-shield']
+
+    if (this.state.visible) {
+      classNames.push('visible')
+    }
+    if (this.state.immediate) {
+      classNames.push('darken-immediately')
+    }
+    if (this.state.darken) {
+      classNames.push('darken')
+    }
+
+    return (
+      <div className={classNames.join(' ')} ref={this.el}>
+        <div className="message">
+          {(this.state.mode === 'load') && <FormattedMessage id="msg.loading" defaultMessage="Loading…" />}
+          {(this.state.mode === 'remix') && <FormattedMessage id="msg.remixing" defaultMessage="Remixing…" />}
+        </div>
+        {(this.state.errorType === 'try-again') &&
+          <div className="blocking-shield-content">
+            <FormattedMessage id="msg.no-connection" defaultMessage="Streetmix is having trouble connecting to the Internet." />
+            <br />
+            <button onClick={this.blockingTryAgain}>
+              <FormattedMessage id="btn.try-again" defaultMessage="Try again" />
+            </button>
+            {this.state.showCancel &&
+              <button onClick={blockingCancel}>
+                <FormattedMessage id="btn.cancel" defaultMessage="Cancel" />
+              </button>
+            }
+          </div>
+        }
+        {(this.state.errorType === 'too-slow') &&
+          <div className="blocking-shield-content">
+            <FormattedMessage id="msg.slow-connection-1" defaultMessage="Streetmix wasn’t able to connect to the Internet in awhile now." />
+            <br /><br />
+            <FormattedMessage id="msg.slow-connection-2" defaultMessage="You might want to reload the page and try again. Please note you might lose the latest change to the street. Sorry!" />
+            <br /><br />
+            <button onClick={goReload}>
+              <FormattedMessage id="btn.reload" defaultMessage="Reload" />
+            </button>
+          </div>
+        }
+      </div>
+    )
+  }
+}

--- a/assets/scripts/app/BlockingShield.jsx
+++ b/assets/scripts/app/BlockingShield.jsx
@@ -34,6 +34,8 @@ export default class BlockingShield extends React.Component {
 
   componentDidMount () {
     window.addEventListener('stmx:show_blocking_shield', (event) => {
+      this.clearTimers()
+
       this.setState({
         visible: true,
         mode: event.detail.mode || 'load'
@@ -49,6 +51,8 @@ export default class BlockingShield extends React.Component {
     })
 
     window.addEventListener('stmx:darken_blocking_shield', (event) => {
+      this.clearTimers()
+
       this.setState({
         visible: true,
         immediate: true,
@@ -58,6 +62,8 @@ export default class BlockingShield extends React.Component {
     })
 
     window.addEventListener('stmx:hide_blocking_shield', (event) => {
+      this.clearTimers()
+
       this.setState({
         visible: false,
         immediate: false,
@@ -65,10 +71,6 @@ export default class BlockingShield extends React.Component {
         showCancel: false
       })
     })
-  }
-
-  componentDidUpdate (prevProps, prevState) {
-    this.clearTimers()
   }
 
   clearTimers = () => {
@@ -105,9 +107,10 @@ export default class BlockingShield extends React.Component {
           {(this.state.mode === 'remix') && <FormattedMessage id="msg.remixing" defaultMessage="Remixing…" />}
         </div>
         {(this.state.errorType === 'try-again') &&
-          <div className="blocking-shield-content">
-            <FormattedMessage id="msg.no-connection" defaultMessage="Streetmix is having trouble connecting to the Internet." />
-            <br />
+          <div className="error-content">
+            <p>
+              <FormattedMessage id="msg.no-connection" defaultMessage="Streetmix is having trouble connecting to the Internet." />
+            </p>
             <button onClick={this.blockingTryAgain}>
               <FormattedMessage id="btn.try-again" defaultMessage="Try again" />
             </button>
@@ -119,11 +122,13 @@ export default class BlockingShield extends React.Component {
           </div>
         }
         {(this.state.errorType === 'too-slow') &&
-          <div className="blocking-shield-content">
-            <FormattedMessage id="msg.slow-connection-1" defaultMessage="Streetmix wasn’t able to connect to the Internet in awhile now." />
-            <br /><br />
-            <FormattedMessage id="msg.slow-connection-2" defaultMessage="You might want to reload the page and try again. Please note you might lose the latest change to the street. Sorry!" />
-            <br /><br />
+          <div className="error-content">
+            <p>
+              <FormattedMessage id="msg.slow-connection-1" defaultMessage="Streetmix wasn’t able to connect to the Internet in awhile now." />
+            </p>
+            <p>
+              <FormattedMessage id="msg.slow-connection-2" defaultMessage="You might want to reload the page and try again. Please note you might lose the latest change to the street. Sorry!" />
+            </p>
             <button onClick={goReload}>
               <FormattedMessage id="btn.reload" defaultMessage="Reload" />
             </button>

--- a/assets/scripts/app/BlockingShield.jsx
+++ b/assets/scripts/app/BlockingShield.jsx
@@ -27,6 +27,7 @@ export default class BlockingShield extends React.Component {
       visible: false,
       mode: 'load',
       errorType: null,
+      immediate: false,
       darken: false,
       showCancel: false
     }
@@ -61,16 +62,7 @@ export default class BlockingShield extends React.Component {
       })
     })
 
-    window.addEventListener('stmx:hide_blocking_shield', (event) => {
-      this.clearTimers()
-
-      this.setState({
-        visible: false,
-        immediate: false,
-        errorType: null,
-        showCancel: false
-      })
-    })
+    window.addEventListener('stmx:hide_blocking_shield', this.hide)
   }
 
   clearTimers = () => {
@@ -78,13 +70,31 @@ export default class BlockingShield extends React.Component {
     window.clearTimeout(this.blockingShieldTooSlowTimerId)
   }
 
-  blockingTryAgain = (event) => {
+  onClickTryAgain = (event) => {
     this.setState({
       errorType: null,
       showCancel: false
     })
 
     blockingTryAgain()
+  }
+
+  onClickCancel = (event) => {
+    this.hide()
+
+    blockingCancel()
+  }
+
+  hide = () => {
+    this.clearTimers()
+
+    this.setState({
+      visible: false,
+      errorType: null,
+      immediate: false,
+      darken: false,
+      showCancel: false
+    })
   }
 
   render () {
@@ -109,13 +119,16 @@ export default class BlockingShield extends React.Component {
         {(this.state.errorType === 'try-again') &&
           <div className="error-content">
             <p>
-              <FormattedMessage id="msg.no-connection" defaultMessage="Streetmix is having trouble connecting to the Internet." />
+              <FormattedMessage
+                id="msg.no-connection"
+                defaultMessage="Streetmix is having trouble connecting to the Internet."
+              />
             </p>
-            <button onClick={this.blockingTryAgain}>
+            <button onClick={this.onClickTryAgain}>
               <FormattedMessage id="btn.try-again" defaultMessage="Try again" />
             </button>
             {this.state.showCancel &&
-              <button onClick={blockingCancel}>
+              <button onClick={this.onClickCancel}>
                 <FormattedMessage id="btn.cancel" defaultMessage="Cancel" />
               </button>
             }
@@ -124,10 +137,17 @@ export default class BlockingShield extends React.Component {
         {(this.state.errorType === 'too-slow') &&
           <div className="error-content">
             <p>
-              <FormattedMessage id="msg.slow-connection-1" defaultMessage="Streetmix wasn’t able to connect to the Internet in awhile now." />
+              <FormattedMessage
+                id="msg.slow-connection-1"
+                defaultMessage="Streetmix wasn’t able to connect to the Internet in awhile now."
+              />
             </p>
             <p>
-              <FormattedMessage id="msg.slow-connection-2" defaultMessage="You might want to reload the page and try again. Please note you might lose the latest change to the street. Sorry!" />
+              <FormattedMessage
+                id="msg.slow-connection-2"
+                defaultMessage="You might want to reload the page and try again. Please note
+                  you might lose the latest change to the street. Sorry!"
+              />
             </p>
             <button onClick={goReload}>
               <FormattedMessage id="btn.reload" defaultMessage="Reload" />

--- a/assets/scripts/app/blocking_shield.js
+++ b/assets/scripts/app/blocking_shield.js
@@ -3,7 +3,7 @@ export function showBlockingShield (mode = 'load') {
 }
 
 export function darkenBlockingShield (showCancel = false) {
-  window.dispatchEvent(new window.CustomEvent('stmx:darken_blocking_shield', { detail: { showCancel } }))
+  window.dispatchEvent(new window.CustomEvent('stmx:darken_blocking_shield', { detail: { showCancel: !!showCancel } }))
 }
 
 export function hideBlockingShield () {

--- a/assets/scripts/app/blocking_shield.js
+++ b/assets/scripts/app/blocking_shield.js
@@ -1,63 +1,11 @@
-/**
- * Blocking shield is an overlay over the screen that prevents
- * interaction. At its most basic version it is fully transparent
- * and allows other UI to take priority (e.g. gallery). At other
- * times it can be "darkened" (creating a translucent overlay)
- * showing messages or errors.
- */
-import { t } from './locale'
-import { goReload } from './routing'
-
-import { blockingCancel, blockingTryAgain } from '../util/fetch_blocking'
-
-const BLOCKING_SHIELD_DARKEN_DELAY = 800
-const BLOCKING_SHIELD_TOO_SLOW_DELAY = 10000
-
-let blockingShieldTimerId = -1
-let blockingShieldTooSlowTimerId = -1
-
-export function attachBlockingShieldEventListeners () {
-  // Adds event listeners to the respond to buttons.
-  document.querySelector('#blocking-shield-cancel').addEventListener('pointerdown', blockingCancel)
-  document.querySelector('#blocking-shield-try-again').addEventListener('pointerdown', blockingTryAgain)
-  document.querySelector('#blocking-shield-reload').addEventListener('pointerdown', goReload)
+export function showBlockingShield (mode = 'load') {
+  window.dispatchEvent(new window.CustomEvent('stmx:show_blocking_shield', { detail: { mode } }))
 }
 
-function clearBlockingShieldTimers () {
-  window.clearTimeout(blockingShieldTimerId)
-  window.clearTimeout(blockingShieldTooSlowTimerId)
-}
-
-export function showBlockingShield (message = t('msg.loading')) {
-  hideBlockingShield()
-  clearBlockingShieldTimers()
-
-  const shieldEl = document.querySelector('#blocking-shield')
-  shieldEl.querySelector('.message').innerHTML = message
-  shieldEl.classList.add('visible')
-
-  blockingShieldTimerId = window.setTimeout(function () {
-    shieldEl.classList.add('darken')
-  }, BLOCKING_SHIELD_DARKEN_DELAY)
-
-  blockingShieldTooSlowTimerId = window.setTimeout(function () {
-    shieldEl.classList.add('show-too-slow')
-  }, BLOCKING_SHIELD_TOO_SLOW_DELAY)
-}
-
-export function darkenBlockingShield (message) {
-  clearBlockingShieldTimers()
-  const shieldEl = document.querySelector('#blocking-shield')
-  shieldEl.classList.add('darken-immediately')
+export function darkenBlockingShield (showCancel = false) {
+  window.dispatchEvent(new window.CustomEvent('stmx:darken_blocking_shield', { detail: { showCancel } }))
 }
 
 export function hideBlockingShield () {
-  clearBlockingShieldTimers()
-  const shieldEl = document.querySelector('#blocking-shield')
-  shieldEl.classList.remove('visible')
-  shieldEl.classList.remove('darken')
-  shieldEl.classList.remove('darken-immediately')
-  shieldEl.classList.remove('show-try-again')
-  shieldEl.classList.remove('show-too-slow')
-  shieldEl.classList.remove('show-cancel')
+  window.dispatchEvent(new window.CustomEvent('stmx:hide_blocking_shield'))
 }

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -27,7 +27,6 @@ import { trackEvent } from './event_tracking'
 import { getMode, setMode, MODES, processMode } from './mode'
 import { processUrl, updatePageUrl } from './page_url'
 import { onResize } from './window_resize'
-import { attachBlockingShieldEventListeners } from './blocking_shield'
 import { startListening } from './keypress'
 import { registerKeypresses } from './keyboard_commands'
 import { infoBubble } from '../info_bubble/info_bubble'
@@ -51,7 +50,6 @@ function preInit () {
     updateSettingsFromCountryCode(language)
   }
 
-  attachBlockingShieldEventListeners()
   registerKeypresses()
   infoBubble.registerKeypresses()
 

--- a/assets/scripts/streets/remix.js
+++ b/assets/scripts/streets/remix.js
@@ -78,7 +78,7 @@ export function remixStreet () {
 
   var transmission = packServerStreetData()
 
-  newBlockingAjaxRequest(t('msg.remixing'),
+  newBlockingAjaxRequest('remix',
     {
       // TODO const
       url: API_URL + 'v1/streets',

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -417,7 +417,7 @@ export function scheduleSavingStreetToServer () {
 }
 
 export function fetchLastStreet () {
-  newBlockingAjaxRequest(t('msg.loading'),
+  newBlockingAjaxRequest('load',
     {
       // TODO const
       url: API_URL + 'v1/streets/' + getSettings().priorLastStreetId,

--- a/assets/scripts/util/fetch_blocking.js
+++ b/assets/scripts/util/fetch_blocking.js
@@ -30,16 +30,7 @@ export function newBlockingAjaxRequest (mode, request, doneFunc, cancelFunc) {
   blockingAjaxRequestDoneFunc = doneFunc
   blockingAjaxRequestCancelFunc = cancelFunc
 
-  window.fetch(blockingAjaxRequest.url, blockingAjaxRequest)
-    .then(response => {
-      if (!response.ok) {
-        throw response
-      }
-
-      return response.json()
-    })
-    .then(successBlockingAjaxRequest)
-    .catch(errorBlockingAjaxRequest)
+  makeBlockingAjaxRequest()
 }
 
 function successBlockingAjaxRequest (data) {
@@ -49,12 +40,10 @@ function successBlockingAjaxRequest (data) {
 }
 
 function errorBlockingAjaxRequest () {
-  darkenBlockingShield(!!blockingAjaxRequestCancelFunc)
+  darkenBlockingShield(blockingAjaxRequestCancelFunc)
 }
 
-// These export to the blocking shield to retry or cancel requests
-
-export function blockingTryAgain () {
+function makeBlockingAjaxRequest () {
   window.fetch(blockingAjaxRequest.url, blockingAjaxRequest)
     .then(response => {
       if (!response.ok) {
@@ -65,6 +54,12 @@ export function blockingTryAgain () {
     })
     .then(successBlockingAjaxRequest)
     .catch(errorBlockingAjaxRequest)
+}
+
+// These export to the blocking shield to retry or cancel requests
+
+export function blockingTryAgain () {
+  makeBlockingAjaxRequest()
 }
 
 export function blockingCancel () {

--- a/assets/scripts/util/fetch_blocking.js
+++ b/assets/scripts/util/fetch_blocking.js
@@ -63,7 +63,6 @@ export function blockingTryAgain () {
 }
 
 export function blockingCancel () {
-  hideBlockingShield()
   blockingAjaxRequestInProgress = false
   blockingAjaxRequestCancelFunc()
 }

--- a/assets/scripts/util/fetch_blocking.js
+++ b/assets/scripts/util/fetch_blocking.js
@@ -21,8 +21,8 @@ export function isblockingAjaxRequestInProgress () {
   return blockingAjaxRequestInProgress
 }
 
-export function newBlockingAjaxRequest (message, request, doneFunc, cancelFunc) {
-  showBlockingShield(message)
+export function newBlockingAjaxRequest (mode, request, doneFunc, cancelFunc) {
+  showBlockingShield(mode)
 
   blockingAjaxRequestInProgress = true
 
@@ -49,21 +49,12 @@ function successBlockingAjaxRequest (data) {
 }
 
 function errorBlockingAjaxRequest () {
-  if (blockingAjaxRequestCancelFunc) {
-    document.querySelector('#blocking-shield').classList.add('show-cancel')
-  }
-
-  document.querySelector('#blocking-shield').classList.add('show-try-again')
-
-  darkenBlockingShield()
+  darkenBlockingShield(!!blockingAjaxRequestCancelFunc)
 }
 
 // These export to the blocking shield to retry or cancel requests
 
 export function blockingTryAgain () {
-  document.querySelector('#blocking-shield').classList.remove('show-try-again')
-  document.querySelector('#blocking-shield').classList.remove('show-cancel')
-
   window.fetch(blockingAjaxRequest.url, blockingAjaxRequest)
     .then(response => {
       if (!response.ok) {


### PR DESCRIPTION
Last item to do on the localization milestone!

I originally thought this was going to be much harder to do, under the impression that one of the use cases of the "blocking shield" occurred on app load, as in, this is an error that could be displayed while the app is still loading. That was incorrect. This component is used whenever the app needs to make a request for a new street while "blocking" (in this case, preventing users from editing the current street in the meantime), and is seen when that request has stalled or failed for whatever reason (e.g. internet connection failure, server goes down suddenly, etc). Long story short, no problems in porting this to a React component.

This was also an opportunity to fix some styling issues that had caused the appearance of this component to decay over time because of changes to other parts of the application. (If this screen was observed in the last year, the text would have been positioned incorrectly.)

One last thing to note is how this port is structured. This component is "triggered" on an AJAX call and is either persisted in the case of request failure or hidden in the case of request success. A more appropriate way to implement this might be to also put the network requests into Redux thunks which causes subsequent actions to be performed in response to state changes. I decided not to explore this for the moment, instead relying on the current network requests to send browser events that then trigger the component to re-render accordingly. This simplifies the port, and we can tackle refactoring network requests later.
