### PR TITLE
Animating removal of segments

### DIFF
--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -15,6 +15,29 @@ class StreetEditable extends React.Component {
     updatePerspective: PropTypes.func.isRequired
   }
 
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      segmentRemoved: false,
+      numSegments: props.street.segments.length
+    }
+  }
+
+  static getDerivedStateFromProps (nextProps, prevState) {
+    const prevNumSegments = prevState.numSegments
+    const currNumSegments = nextProps.street.segments.length
+
+    if (currNumSegments !== prevNumSegments) {
+      return {
+        numSegments: currNumSegments,
+        segmentsRemoved: (currNumSegments === prevNumSegments - 1)
+      }
+    }
+
+    return null
+  }
+
   componentDidUpdate (prevProps) {
     const { onResized } = this.props
 

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -15,29 +15,6 @@ class StreetEditable extends React.Component {
     updatePerspective: PropTypes.func.isRequired
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      segmentRemoved: false,
-      numSegments: props.street.segments.length
-    }
-  }
-
-  static getDerivedStateFromProps (nextProps, prevState) {
-    const prevNumSegments = prevState.numSegments
-    const currNumSegments = nextProps.street.segments.length
-
-    if (currNumSegments !== prevNumSegments) {
-      return {
-        numSegments: currNumSegments,
-        segmentsRemoved: (currNumSegments === prevNumSegments - 1)
-      }
-    }
-
-    return null
-  }
-
   componentDidUpdate (prevProps) {
     const { onResized } = this.props
 

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -15,29 +15,6 @@ class StreetEditable extends React.Component {
     updatePerspective: PropTypes.func.isRequired
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      segmentRemoved: false,
-      numSegments: props.street.segments.length
-    }
-  }
-
-  static getDerivedStateFromProps (nextProps, prevState) {
-    const prevNumSegments = prevState.numSegments
-    const currNumSegments = nextProps.street.segments.length
-
-    if (currNumSegments !== prevNumSegments) {
-      return {
-        numSegments: currNumSegments,
-        segmentsRemoved: (currNumSegments === prevNumSegments - 1)
-      }
-    }
-
-    return null
-  }
-
   componentDidUpdate (prevProps) {
     const { onResized } = this.props
 
@@ -69,8 +46,14 @@ class StreetEditable extends React.Component {
     return (currPos * TILE_SIZE)
   }
 
+  handleExitAnimations = (child) => {
+    return React.cloneElement(child, {
+      exit: !(this.props.street.immediateRemoval)
+    })
+  }
+
   renderStreetSegments = () => {
-    const { segments, units } = this.props.street
+    const { segments, units, immediateRemoval } = this.props.street
 
     return segments.map((segment, i) => {
       const segmentWidth = (segment.width * TILE_SIZE)
@@ -85,10 +68,11 @@ class StreetEditable extends React.Component {
 
       const segmentEl = (
         <CSSTransition
-          key={i}
+          key={segment.id}
           timeout={250}
           classNames="switching-away"
-          onExit={(el) => { this.props.updatePerspective(el) }}
+          exit={!(immediateRemoval)}
+          onExit={(el) => { this.props.updatePerspective(el, true) }}
         >
           <Segment
             key={segment.id}
@@ -123,7 +107,7 @@ class StreetEditable extends React.Component {
         style={style}
         ref={(ref) => { this.streetSectionEditable = ref }}
       >
-        <TransitionGroup enter={false} exit={this.state.segmentRemoved}>
+        <TransitionGroup key={this.props.street.id} component={null} childFactory={this.handleExitAnimations}>
           {this.renderStreetSegments()}
         </TransitionGroup>
       </div>

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -73,6 +73,7 @@ class StreetEditable extends React.Component {
           classNames="switching-away"
           exit={!(immediateRemoval)}
           onExit={(el) => { this.props.updatePerspective(el, true) }}
+          unmountOnExit
         >
           <Segment
             key={segment.id}

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -17,6 +17,7 @@ import { infoBubble } from '../info_bubble/info_bubble'
 import { animate, getElAbsolutePos } from '../util/helpers'
 import { MAX_CUSTOM_STREET_WIDTH } from '../streets/width'
 import { BUILDING_SPACE } from '../segments/buildings'
+import { SHORT_DELAY } from '../segments/resizing'
 import { TILE_SIZE } from '../segments/constants'
 import { app } from '../preinit/app_settings'
 
@@ -176,6 +177,14 @@ class StreetView extends React.Component {
   updatePerspective = (el, switchSegmentAway) => {
     if (!el) return
 
+    if (switchSegmentAway) {
+      document.body.classList.add('immediate-segment-resize')
+      window.setTimeout(function () {
+        document.body.classList.remove('immediate-segment-resize')
+      }, SHORT_DELAY)
+      el.style.left = el.savedLeft + 'px'
+    }
+
     const pos = getElAbsolutePos(el)
     const scrollPos = (this.streetSectionOuter && this.streetSectionOuter.scrollLeft) || this.state.scrollPos
     const perspective = -(pos[0] - scrollPos - (this.props.system.viewportWidth / 2))
@@ -183,10 +192,6 @@ class StreetView extends React.Component {
     el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.perspectiveOrigin = (perspective / 2) + 'px 50%'
-
-    if (switchSegmentAway) {
-      el.style.left = el.savedLeft + 'px'
-    }
   }
 
   render () {

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -192,6 +192,10 @@ class StreetView extends React.Component {
     el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.perspectiveOrigin = (perspective / 2) + 'px 50%'
+
+    if (switchSegmentAway) {
+      el.style.left = el.savedLeft + 'px'
+    }
   }
 
   render () {

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -177,7 +177,8 @@ class StreetView extends React.Component {
     if (!el) return
 
     const pos = getElAbsolutePos(el)
-    const perspective = -(pos[0] - this.streetSectionOuter.scrollLeft - (this.props.system.viewportWidth / 2))
+    const scrollPos = (this.streetSectionOuter && this.streetSectionOuter.scrollLeft) || this.state.scrollPos
+    const perspective = -(pos[0] - scrollPos - (this.props.system.viewportWidth / 2))
 
     el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -173,7 +173,7 @@ class StreetView extends React.Component {
     })
   }
 
-  updatePerspective = (el) => {
+  updatePerspective = (el, switchSegmentAway) => {
     if (!el) return
 
     const pos = getElAbsolutePos(el)
@@ -183,6 +183,10 @@ class StreetView extends React.Component {
     el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.perspectiveOrigin = (perspective / 2) + 'px 50%'
+
+    if (switchSegmentAway) {
+      el.style.left = el.savedLeft + 'px'
+    }
   }
 
   render () {

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -17,7 +17,6 @@ import { infoBubble } from '../info_bubble/info_bubble'
 import { animate, getElAbsolutePos } from '../util/helpers'
 import { MAX_CUSTOM_STREET_WIDTH } from '../streets/width'
 import { BUILDING_SPACE } from '../segments/buildings'
-import { SHORT_DELAY } from '../segments/resizing'
 import { TILE_SIZE } from '../segments/constants'
 import { app } from '../preinit/app_settings'
 
@@ -176,14 +175,6 @@ class StreetView extends React.Component {
 
   updatePerspective = (el, switchSegmentAway) => {
     if (!el) return
-
-    if (switchSegmentAway) {
-      document.body.classList.add('immediate-segment-resize')
-      window.setTimeout(function () {
-        document.body.classList.remove('immediate-segment-resize')
-      }, SHORT_DELAY)
-      el.style.left = el.savedLeft + 'px'
-    }
 
     const pos = getElAbsolutePos(el)
     const scrollPos = (this.streetSectionOuter && this.streetSectionOuter.scrollLeft) || this.state.scrollPos

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -192,10 +192,6 @@ class StreetView extends React.Component {
     el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.MozPerspectiveOrigin = (perspective / 2) + 'px 50%'
     el.style.perspectiveOrigin = (perspective / 2) + 'px 50%'
-
-    if (switchSegmentAway) {
-      el.style.left = el.savedLeft + 'px'
-    }
   }
 
   render () {

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -173,7 +173,7 @@ class StreetView extends React.Component {
     })
   }
 
-  updatePerspective = (el, switchSegmentAway) => {
+  updatePerspective = (el) => {
     if (!el) return
 
     const pos = getElAbsolutePos(el)

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -328,7 +328,7 @@ class InfoBubble extends React.Component {
    * TODO: consolidate this with the dim calc in updateBubbleDimensions? do we need snapshot here?
    */
   setInfoBubblePosition = () => {
-    if (!this.segmentEl || !this.el || !this.el.current) return
+    if (!this.segmentEl || !this.el || !this.el.current || !this.props.visible) return
 
     // Determine dimensions and X/Y layout
     const bubbleWidth = this.el.current.offsetWidth

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -34,7 +34,8 @@ class Segment extends React.Component {
     dataNo: PropTypes.number,
     updateSegmentData: PropTypes.func,
     updatePerspective: PropTypes.func,
-    locale: PropTypes.string
+    locale: PropTypes.string,
+    suppressMouseEnter: PropTypes.bool.isRequired
   }
 
   static defaultProps = {
@@ -108,7 +109,7 @@ class Segment extends React.Component {
   }
 
   onSegmentMouseEnter = (event) => {
-    if (suppressMouseEnter() || this.props.forPalette) return
+    if (this.props.suppressMouseEnter || suppressMouseEnter() || this.props.forPalette) return
 
     infoBubble.considerShowing(event, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)
   }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -39,7 +39,8 @@ class Segment extends React.Component {
   }
 
   static defaultProps = {
-    units: SETTINGS_UNITS_METRIC
+    units: SETTINGS_UNITS_METRIC,
+    suppressMouseEnter: false
   }
 
   constructor (props) {

--- a/assets/scripts/segments/remove.js
+++ b/assets/scripts/segments/remove.js
@@ -38,7 +38,7 @@ export function removeSegment (el) {
  */
 export function removeAllSegments () {
   store.dispatch(clearSegments())
-  segmentsChanged()
+  segmentsChanged(false)
   infoBubble.hide()
   showStatusMessage(t('toast.all-segments-deleted'), true)
 }

--- a/assets/scripts/segments/remove.js
+++ b/assets/scripts/segments/remove.js
@@ -24,7 +24,7 @@ export function removeSegment (el) {
   infoBubble.hideSegment()
 
   // Update the store
-  store.dispatch(removeSegmentActionCreator(window.parseInt(el.dataNo, 10), false))
+  store.dispatch(removeSegmentActionCreator(Number.parseInt(el.dataNo, 10), false))
 
   // update street data but do not re-read DOM
   segmentsChanged(false, true)

--- a/assets/scripts/segments/remove.js
+++ b/assets/scripts/segments/remove.js
@@ -24,7 +24,7 @@ export function removeSegment (el) {
   infoBubble.hideSegment()
 
   // Update the store
-  store.dispatch(removeSegmentActionCreator(window.parseInt(el.dataNo, 10)))
+  store.dispatch(removeSegmentActionCreator(window.parseInt(el.dataNo, 10), false))
 
   // update street data but do not re-read DOM
   segmentsChanged(false, true)

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -40,10 +40,11 @@ export function addSegment (index, segment) {
   }
 }
 
-export function removeSegment (index) {
+export function removeSegment (index, immediate = true) {
   return {
     type: REMOVE_SEGMENT,
-    index
+    index,
+    immediate
   }
 }
 
@@ -65,7 +66,8 @@ export function updateSegments (segments) {
 export function clearSegments () {
   return {
     type: UPDATE_SEGMENTS,
-    segments: []
+    segments: [],
+    immediate: true
   }
 }
 

--- a/assets/scripts/store/reducers/__tests__/street.test.js
+++ b/assets/scripts/store/reducers/__tests__/street.test.js
@@ -5,6 +5,7 @@ import * as actions from '../../actions/street'
 describe('street reducer', () => {
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({
+      immediateRemoval: true,
       segments: []
     })
   })
@@ -14,6 +15,7 @@ describe('street reducer', () => {
     expect(
       reducer(undefined, actions.addSegment(0, { type: 'foo' }))
     ).toEqual({
+      immediateRemoval: true,
       segments: [
         { type: 'foo' }
       ]
@@ -66,6 +68,7 @@ describe('street reducer', () => {
 
   it('should handle REMOVE_SEGMENT', () => {
     const existingStreet = {
+      immediateRemoval: true,
       segments: [
         { type: 'foo' },
         { type: 'bar' },
@@ -78,6 +81,7 @@ describe('street reducer', () => {
     expect(
       reducer({...existingStreet}, actions.removeSegment(1))
     ).toEqual({
+      immediateRemoval: true,
       segments: [
         { type: 'foo' },
         { type: 'baz' },
@@ -89,6 +93,7 @@ describe('street reducer', () => {
     expect(
       reducer({...existingStreet}, actions.removeSegment(0))
     ).toEqual({
+      immediateRemoval: true,
       segments: [
         { type: 'bar' },
         { type: 'baz' },

--- a/assets/scripts/store/reducers/street.js
+++ b/assets/scripts/store/reducers/street.js
@@ -72,7 +72,6 @@ const street = (state = initialState, action) => {
     }
     case UPDATE_SEGMENTS:
       const immediate = action.immediate || state.immediateRemoval
-      console.log(immediate)
       return {
         ...state,
         segments: action.segments,

--- a/assets/scripts/store/reducers/street.js
+++ b/assets/scripts/store/reducers/street.js
@@ -27,7 +27,8 @@ import {
 import { getVariantString } from '../../segments/variant_utils'
 
 const initialState = {
-  segments: []
+  segments: [],
+  immediateRemoval: true
 }
 
 const MAX_BUILDING_HEIGHT = 20
@@ -51,7 +52,8 @@ const street = (state = initialState, action) => {
     case REMOVE_SEGMENT:
       return {
         ...state,
-        segments: state.segments.filter((element, index) => index !== action.index)
+        segments: state.segments.filter((element, index) => index !== action.index),
+        immediateRemoval: action.immediate
       }
     case MOVE_SEGMENT: {
       const toMove = Object.assign({}, state.segments[action.index])
@@ -69,9 +71,12 @@ const street = (state = initialState, action) => {
       }
     }
     case UPDATE_SEGMENTS:
+      const immediate = action.immediate || state.immediateRemoval
+      console.log(immediate)
       return {
         ...state,
-        segments: action.segments
+        segments: action.segments,
+        immediateRemoval: immediate
       }
     case CHANGE_SEGMENT_WIDTH: {
       const copy = [...state.segments]

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -371,7 +371,6 @@ export function createDataFromDom () {
     segment.el = el
     segment.warnings = []
     segment.id = originalSegmentId
-    console.log(segment.id)
     segments.push(segment)
   }
   store.dispatch(updateSegments(segments))

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -371,6 +371,7 @@ export function createDataFromDom () {
     segment.el = el
     segment.warnings = []
     segment.id = originalSegmentId
+    console.log(segment.id)
     segments.push(segment)
   }
   store.dispatch(updateSegments(segments))


### PR DESCRIPTION
As a continuation of the work done in #1019, switching away animations of segments when removed is now React friendly. 

Things to note:
- I am passing a new prop to the Segment component called `suppressMouseEnter` which does the same job as `_suppressMouseEnter` in `resizing.js`. By setting `_suppressMouseEnter`, the infoBubble does not get shown when dragging the resize handles. Similarly we do not want the infoBubble to be shown while the segment is getting removed (when a segment is removed, the mouse may end up hovering over the next segment when it gets moved over), suppressMouseEnter tells the Segment component not to call the infoBubble. Eventually I am thinking we will remove the global `_suppressMouseEnter` from `resizing.js` and just depend on passing the prop, but since resizing a segment is still vanilla Javascript I haven't done that yet. 
- There is a new variable I am saving in Redux called `immediateRemoval` (if you can suggest a better name, please do!). This is being saved in the Redux street state and states whether or not a segment should animate away when removed. You set this value when you are dispatching the `removeSegment` action. The default value is true, meaning a segment should be immediately removed and not animated away. 