### PR TITLE
Add tooltip translation strings for flex segments

### DIFF
--- a/assets/locales/en/segment-info.json
+++ b/assets/locales/en/segment-info.json
@@ -22,7 +22,7 @@
     "rideshare-pick-up": "Rideshare pick-up / drop-off",
     "bikeshare-station": "Bikeshare station",
     "foodtruck": "Food truck",
-    "flex-zone-curb": "Pick up / drop off waiting area",
+    "flex-zone-curb": "Pick-up / drop-off waiting area",
     "drive-lane": "Drive lane",
     "sharrow": "Sharrow",
     "turn-lane": "Turn lane",

--- a/assets/locales/en/segment-info.json
+++ b/assets/locales/en/segment-info.json
@@ -191,6 +191,10 @@
     "building|wide": "Wide building",
     "wayfinding-type|large": "Large",
     "wayfinding-type|medium": "Medium",
-    "wayfinding-type|small": "Small"
+    "wayfinding-type|small": "Small",
+    "flex|waiting-person": "Someone",
+    "flex|waiting-empty": "No one",
+    "flex|rideshare": "Rideshare",
+    "flex|taxi": "Taxi"
   }
 }

--- a/assets/locales/en/segment-info.json
+++ b/assets/locales/en/segment-info.json
@@ -192,8 +192,8 @@
     "wayfinding-type|large": "Large",
     "wayfinding-type|medium": "Medium",
     "wayfinding-type|small": "Small",
-    "person|sparse": "Someone",
-    "person|empty": "No one",
+    "waiting-area|sparse": "Someone",
+    "waiting-area|empty": "No one",
     "flex-type|rideshare": "Rideshare",
     "flex-type|taxi": "Taxi"
   }

--- a/assets/locales/en/segment-info.json
+++ b/assets/locales/en/segment-info.json
@@ -192,9 +192,9 @@
     "wayfinding-type|large": "Large",
     "wayfinding-type|medium": "Medium",
     "wayfinding-type|small": "Small",
-    "flex|waiting-person": "Someone",
-    "flex|waiting-empty": "No one",
-    "flex|rideshare": "Rideshare",
-    "flex|taxi": "Taxi"
+    "person|sparse": "Someone",
+    "person|empty": "No one",
+    "flex-type|rideshare": "Rideshare",
+    "flex-type|taxi": "Taxi"
   }
 }

--- a/assets/scripts/segments/info.json
+++ b/assets/scripts/segments/info.json
@@ -682,7 +682,7 @@
     "zIndex": 30,
     "defaultWidth": 4,
     "variants": [
-      "person",
+      "waiting-area",
       "orientation"
     ],
     "enableWithFlag": "SEGMENT_FLEX_ZONE",

--- a/assets/scripts/segments/variant_icons.js
+++ b/assets/scripts/segments/variant_icons.js
@@ -345,7 +345,7 @@ export const VARIANT_ICONS = {
       'title': 'Rideshare'
     }
   },
-  'person': {
+  'waiting-area': {
     'sparse': {
       'id': 'sidewalk-density-sparse',
       'title': 'Someone'


### PR DESCRIPTION
This adds translation strings for `Someone`, `No one`, `Rideshare` and `Taxi`. These are all tooltip strings.