### PR TITLE
Remove duplicate language key

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -58,9 +58,6 @@
       "send": "Send message",
       "confirm": "We got it. Thanks!",
       "error": "We’re sorry, there was a problem sending feedback at this time. Please try again later."
-    },
-    "language": {
-      "heading": "Language"
     }
   },
   "settings": {


### PR DESCRIPTION
We should not merge this PR until after the new settings bar is completed and the old string is no longer needed.