### PR TITLE
React segments follow up

### DIFF
--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -31,7 +31,7 @@ class StreetEditable extends React.Component {
       this.props.setBuildingWidth(this.streetSectionEditable)
     }
 
-    if (prevProps.street.id !== this.props.street.id) {
+    if (prevProps.street.id !== this.props.street.id || prevProps.street.width !== this.props.street.width) {
       document.body.classList.add('immediate-segment-resize')
       window.setTimeout(function () {
         document.body.classList.remove('immediate-segment-resize')

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -6,7 +6,7 @@ import uuid from 'uuid'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
 import { TILE_SIZE } from '../segments/constants'
 import { getVariantArray } from '../segments/variant_utils'
-import { SHORT_DELAY } from '../segments/resizing'
+import { cancelSegmentResizeTransitions } from '../segments/resizing'
 
 class StreetEditable extends React.Component {
   static propTypes = {
@@ -32,10 +32,7 @@ class StreetEditable extends React.Component {
     }
 
     if (prevProps.street.id !== this.props.street.id || prevProps.street.width !== this.props.street.width) {
-      document.body.classList.add('immediate-segment-resize')
-      window.setTimeout(function () {
-        document.body.classList.remove('immediate-segment-resize')
-      }, SHORT_DELAY)
+      cancelSegmentResizeTransitions()
     }
   }
 

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -30,6 +30,13 @@ class StreetEditable extends React.Component {
     if (onResized && prevProps.onResized !== onResized) {
       this.props.setBuildingWidth(this.streetSectionEditable)
     }
+
+    if (prevProps.street.id !== this.props.street.id) {
+      document.body.classList.add('immediate-segment-resize')
+      window.setTimeout(function () {
+        document.body.classList.remove('immediate-segment-resize')
+      }, SHORT_DELAY)
+    }
   }
 
   updateSegmentData = (ref, dataNo, segmentPos) => {
@@ -45,10 +52,7 @@ class StreetEditable extends React.Component {
   }
 
   switchSegmentAway = (el) => {
-    document.body.classList.add('immediate-segment-resize')
-    window.setTimeout(function () {
-      document.body.classList.remove('immediate-segment-resize')
-    }, SHORT_DELAY)
+    el.classList.add('create')
     el.style.left = el.savedLeft + 'px'
 
     this.props.updatePerspective(el)

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -104,12 +104,6 @@ class Segment extends React.Component {
       width = normalizeSegmentWidth(width, resizeType)
     }
 
-    // TODO - copied from resizeSegment. make sure we don't need
-    // document.body.classList.add('immediate-segment-resize')
-    // window.setTimeout(function () {
-    //   document.body.classList.remove('immediate-segment-resize')
-    // }, SHORT_DELAY)
-
     width = (width * TILE_SIZE)
     return width
   }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import MeasurementText from '../ui/MeasurementText'
 import { CSSTransition } from 'react-transition-group'
 import { getSegmentVariantInfo, getSegmentInfo } from '../segments/info'
-import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, SHORT_DELAY, suppressMouseEnter } from './resizing'
+import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter } from './resizing'
 import { TILE_SIZE } from './constants'
 import { drawSegmentContents, getVariantInfoDimensions } from './view'
 import { SETTINGS_UNITS_METRIC } from '../users/localization'
@@ -104,10 +104,10 @@ class Segment extends React.Component {
     }
 
     // TODO - copied from resizeSegment. make sure we don't need
-    document.body.classList.add('immediate-segment-resize')
-    window.setTimeout(function () {
-      document.body.classList.remove('immediate-segment-resize')
-    }, SHORT_DELAY)
+    // document.body.classList.add('immediate-segment-resize')
+    // window.setTimeout(function () {
+    //   document.body.classList.remove('immediate-segment-resize')
+    // }, SHORT_DELAY)
 
     width = (width * TILE_SIZE)
     return width

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -69,6 +69,10 @@ class Segment extends React.Component {
 
     this.drawSegment(this.props.variantString, false)
 
+    if (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter) {
+      infoBubble.considerShowing(false, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)
+    }
+
     if (prevProps.variantString !== this.props.variantString) {
       this.switchSegments(prevProps.variantString)
     }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -69,7 +69,8 @@ class Segment extends React.Component {
 
     this.drawSegment(this.props.variantString, false)
 
-    if (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter) {
+    if (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter &&
+        infoBubble.considerSegmentEl === this.streetSegment) {
       infoBubble.considerShowing(false, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)
     }
 

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -754,6 +754,11 @@ function handleSegmentMoveEnd (event) {
       newIndex = (newIndex > oldIndex) ? newIndex - 1 : newIndex
     }
 
+    document.body.classList.add('immediate-segment-resize')
+    window.setTimeout(function () {
+      document.body.classList.remove('immediate-segment-resize')
+    }, SHORT_DELAY)
+
     if (draggingMove.type === DRAGGING_TYPE_MOVE_TRANSFER) {
       const originalSegmentId = store.getState().street.segments[oldIndex].id
       newSegment.id = originalSegmentId

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -24,7 +24,8 @@ import {
   normalizeSegmentWidth,
   scheduleControlsFadeout,
   cancelFadeoutControls,
-  hideControls
+  hideControls,
+  cancelSegmentResizeTransitions
 } from './resizing'
 import { getVariantArray, getVariantString } from './variant_utils'
 import { TILE_SIZE } from './constants'
@@ -754,10 +755,7 @@ function handleSegmentMoveEnd (event) {
       newIndex = (newIndex > oldIndex) ? newIndex - 1 : newIndex
     }
 
-    document.body.classList.add('immediate-segment-resize')
-    window.setTimeout(function () {
-      document.body.classList.remove('immediate-segment-resize')
-    }, SHORT_DELAY)
+    cancelSegmentResizeTransitions()
 
     if (draggingMove.type === DRAGGING_TYPE_MOVE_TRANSFER) {
       const originalSegmentId = store.getState().street.segments[oldIndex].id

--- a/assets/scripts/segments/resizing.js
+++ b/assets/scripts/segments/resizing.js
@@ -68,10 +68,7 @@ export function resizeSegment (el, resizeType, width, updateEdit, palette, initi
     width = normalizeSegmentWidth(width, resizeType)
   }
 
-  document.body.classList.add('immediate-segment-resize')
-  window.setTimeout(function () {
-    document.body.classList.remove('immediate-segment-resize')
-  }, SHORT_DELAY)
+  cancelSegmentResizeTransitions()
 
   el.style.width = (width * TILE_SIZE) + 'px'
   el.setAttribute('data-width', width)
@@ -246,4 +243,11 @@ export function hideControls () {
       infoBubble.hideSegment(true)
     }, 0)
   }
+}
+
+export function cancelSegmentResizeTransitions () {
+  document.body.classList.add('immediate-segment-resize')
+  window.setTimeout(function () {
+    document.body.classList.remove('immediate-segment-resize')
+  }, SHORT_DELAY)
 }

--- a/assets/scripts/segments/resizing.js
+++ b/assets/scripts/segments/resizing.js
@@ -68,6 +68,11 @@ export function resizeSegment (el, resizeType, width, updateEdit, palette, initi
     width = normalizeSegmentWidth(width, resizeType)
   }
 
+  document.body.classList.add('immediate-segment-resize')
+  window.setTimeout(function () {
+    document.body.classList.remove('immediate-segment-resize')
+  }, SHORT_DELAY)
+
   el.style.width = (width * TILE_SIZE) + 'px'
   el.setAttribute('data-width', width)
 

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -1,7 +1,5 @@
 import { images } from '../app/load_resources'
 import { t } from '../app/locale'
-import { infoBubble } from '../info_bubble/info_bubble'
-import { INFO_BUBBLE_TYPE_SEGMENT } from '../info_bubble/constants'
 import { system } from '../preinit/system_capabilities'
 import { saveStreetToServerIfNecessary, createDataFromDom } from '../streets/data_model'
 import { recalculateWidth } from '../streets/width'
@@ -9,12 +7,7 @@ import { draggingMove } from './drag_and_drop'
 import { getSegmentInfo, getSegmentVariantInfo, getSpriteDef } from './info'
 import { drawProgrammaticPeople } from './people'
 import { TILE_SIZE, TILESET_POINT_PER_PIXEL } from './constants'
-import {
-  RESIZE_TYPE_INITIAL,
-  suppressMouseEnter,
-  resizeSegment,
-  applyWarningsToSegments
-} from './resizing'
+import { applyWarningsToSegments } from './resizing'
 import store from '../store'
 
 const CANVAS_HEIGHT = 480
@@ -323,73 +316,6 @@ export function getLocaleSegmentName (type, variantString) {
   return t(key, defaultName, { ns: 'segment-info' })
 }
 
-export function createSegment (type, variantString, width, isUnmovable, palette, randSeed) {
-  let innerEl, dragHandleEl
-  var el = document.createElement('div')
-  el.classList.add('segment')
-  el.setAttribute('type', type)
-  el.setAttribute('variant-string', variantString)
-  if (randSeed) {
-    el.setAttribute('rand-seed', randSeed)
-  }
-
-  if (isUnmovable) {
-    el.classList.add('unmovable')
-  }
-
-  const segmentInfo = getSegmentInfo(type)
-
-  if (!palette) {
-    el.style.zIndex = segmentInfo.zIndex
-
-    const name = getLocaleSegmentName(type, variantString)
-
-    innerEl = document.createElement('span')
-    innerEl.classList.add('name')
-    innerEl.innerHTML = name
-    el.appendChild(innerEl)
-
-    innerEl = document.createElement('span')
-    innerEl.classList.add('width')
-    el.appendChild(innerEl)
-
-    dragHandleEl = document.createElement('span')
-    dragHandleEl.classList.add('drag-handle')
-    dragHandleEl.classList.add('left')
-    dragHandleEl.segmentEl = el
-    dragHandleEl.innerHTML = '‹'
-    el.appendChild(dragHandleEl)
-
-    dragHandleEl = document.createElement('span')
-    dragHandleEl.classList.add('drag-handle')
-    dragHandleEl.classList.add('right')
-    dragHandleEl.segmentEl = el
-    dragHandleEl.innerHTML = '›'
-    el.appendChild(dragHandleEl)
-
-    innerEl = document.createElement('span')
-    innerEl.classList.add('grid')
-    el.appendChild(innerEl)
-  } else {
-    el.setAttribute('title', segmentInfo.name)
-  }
-
-  if (width) {
-    resizeSegment(el, RESIZE_TYPE_INITIAL, width / TILE_SIZE, true, palette, true)
-  }
-
-  if (!palette) {
-    el.addEventListener('pointerenter', onSegmentMouseEnter)
-    el.addEventListener('pointerleave', onSegmentMouseLeave)
-  }
-  return el
-}
-
-export function createSegmentDom (segment) {
-  return createSegment(segment.type, segment.variantString,
-    segment.width * TILE_SIZE, segment.unmovable, false, segment.randSeed)
-}
-
 export function repositionSegments () {
   let width, el
   var left = 0
@@ -482,16 +408,4 @@ export function segmentsChanged (readDataFromDom = true, reassignElementRefs = f
   }
 
   saveStreetToServerIfNecessary()
-}
-
-function onSegmentMouseEnter (event) {
-  if (suppressMouseEnter()) {
-    return
-  }
-
-  infoBubble.considerShowing(event, this, INFO_BUBBLE_TYPE_SEGMENT)
-}
-
-function onSegmentMouseLeave () {
-  infoBubble.dontConsiderShowing()
 }


### PR DESCRIPTION
- After switching away animation is completed, infoBubble now reappears and highlights hovered segment. 
- When removing a segment, the remaining segments now slide in to fill gap instead filling the gap immediately. 
- Removed definitions of functions that are no longer used

(Reference #912)