### PR TITLE
Make Chinese (Traditional) & Portuguese (Br) level 2

### DIFF
--- a/app/data/locales.json
+++ b/app/data/locales.json
@@ -9,7 +9,7 @@
     "label": "Chinese (Traditional)",
     "value": "zh-Hant",
     "key": "i18n.lang.zh-hant",
-    "level": 1
+    "level": 2
   },
   {
     "label": "English",
@@ -51,7 +51,7 @@
     "label": "Portuguese (Brazil)",
     "value": "pt-BR",
     "key": "i18n.lang.pt-br",
-    "level": 1
+    "level": 2
   },
   {
     "label": "Spanish",


### PR DESCRIPTION
Chinese and Portuguese translations are moving along and with that comes the need to view the translations on Staging. Currently, they are only accessible via the level 1 switch. However, level 1 has so many languages that Chinese gets cut off (and Japanese is entirely off the screen). In order to allow translators to see their work, we need to bump these up to level 2 so they can see translations from there.

If this is ok to merge, can we deploy it to staging after merging? 😁

![image](https://user-images.githubusercontent.com/12552044/41369749-c1f2e40e-6f13-11e8-9729-4fd46c75b873.png)