### PR TITLE
Add flags to selectively disable editing street width, name, and update geotag

### DIFF
--- a/app/data/flags.json
+++ b/app/data/flags.json
@@ -1,6 +1,18 @@
 {
-  "GEOLOCATION": {
-    "label": "Geolocation",
+  "GEOTAG": {
+    "label": "Geotagging",
+    "defaultValue": true
+  },
+  "EDIT_STREET_WIDTH": {
+    "label": "Edit street width",
+    "defaultValue": true
+  },
+  "EDIT_STREET_NAME": {
+    "label": "Edit street name",
+    "defaultValue": true
+  },
+  "EDIT_BUILDINGS": {
+    "label": "Edit buildings",
     "defaultValue": true
   },
   "SAVE_UNDO": {

--- a/app/data/flags.json
+++ b/app/data/flags.json
@@ -1,18 +1,18 @@
 {
   "GEOTAG": {
-    "label": "Geotagging",
+    "label": "UI — Geotagging",
     "defaultValue": true
   },
   "EDIT_STREET_WIDTH": {
-    "label": "Edit street width",
+    "label": "UI — Edit street width",
     "defaultValue": true
   },
   "EDIT_STREET_NAME": {
-    "label": "Edit street name",
+    "label": "UI — Edit street name",
     "defaultValue": true
   },
   "EDIT_BUILDINGS": {
-    "label": "Edit buildings",
+    "label": "UI — Edit buildings",
     "defaultValue": true
   },
   "SAVE_UNDO": {

--- a/app/resources/v1/__tests__/flags.test.js
+++ b/app/resources/v1/__tests__/flags.test.js
@@ -20,7 +20,7 @@ describe('get api/v1/flags', function () {
       .then((response) => {
         expect(response.statusCode).toEqual(200)
         expect(response.get('Content-Type').toLowerCase()).toEqual('application/json; charset=utf-8')
-        expect(response.body.GEOTAG.label).toEqual('Geotagging')
+        expect(response.body.GEOTAG.label).toEqual('UI — Geotagging')
       })
   })
 })

--- a/app/resources/v1/__tests__/flags.test.js
+++ b/app/resources/v1/__tests__/flags.test.js
@@ -20,7 +20,7 @@ describe('get api/v1/flags', function () {
       .then((response) => {
         expect(response.statusCode).toEqual(200)
         expect(response.get('Content-Type').toLowerCase()).toEqual('application/json; charset=utf-8')
-        expect(response.body.GEOLOCATION.label).toEqual('Geolocation')
+        expect(response.body.GEOTAG.label).toEqual('Geotagging')
       })
   })
 })

--- a/assets/css/_street-metadata.scss
+++ b/assets/css/_street-metadata.scss
@@ -33,11 +33,6 @@
   }
 }
 
-body.edit-street-width .street-width {
-  display: none;
-  pointer-events: none;
-}
-
 .street-width-over {
   color: $warning-colour;
 }
@@ -46,12 +41,8 @@ body.edit-street-width .street-width {
   color: rgb(96, 96, 96);
 }
 
-#street-width {
+.street-width-select {
   width: 150px;
-}
-
-body:not(.edit-street-width) #street-width {
-  display: none;
 }
 
 body:not(.read-only) .street-metadata-author a:hover {

--- a/assets/css/_street-metadata.scss
+++ b/assets/css/_street-metadata.scss
@@ -11,11 +11,11 @@
   }
 }
 
-.street-width-read {
+.street-width {
   padding: 5px 0;
 }
 
-body:not(.read-only) .street-width-read {
+.street-width.street-width-editable {
   cursor: pointer;
 
   &:hover,
@@ -33,7 +33,7 @@ body:not(.read-only) .street-width-read {
   }
 }
 
-body.edit-street-width .street-width-read {
+body.edit-street-width .street-width {
   display: none;
   pointer-events: none;
 }

--- a/assets/scripts/streets/StreetMetaGeotag.jsx
+++ b/assets/scripts/streets/StreetMetaGeotag.jsx
@@ -9,62 +9,64 @@ export class StreetMetaGeotag extends React.Component {
   static propTypes = {
     editable: PropTypes.bool,
     street: PropTypes.any,
-    enableLocation: PropTypes.bool,
     showGeotagDialog: PropTypes.func
+  }
+
+  static defaultProps = {
+    editable: true
   }
 
   onClickGeotag = (event) => {
     event.preventDefault()
+
     if (!this.props.street.location) {
       trackEvent('Interaction', 'Clicked add location', null, null, true)
     } else {
       trackEvent('Interaction', 'Clicked existing location', null, null, true)
     }
+
     this.props.showGeotagDialog()
   }
 
   getGeotagText = () => {
     const { hierarchy } = this.props.street.location
     const unknownLabel = <FormattedMessage id="dialogs.geotag.unknown-location" defaultMessage="Unknown location" />
-    let text = ''
-    text = (hierarchy.locality) ? hierarchy.locality
+
+    let text = (hierarchy.locality) ? hierarchy.locality
       : (hierarchy.region) ? hierarchy.region
         : (hierarchy.neighbourhood) ? hierarchy.neighbourhood
           : null
+
     if (text && hierarchy.country) {
       text = text + ', ' + hierarchy.country
     }
+
     return text || unknownLabel
   }
 
-  renderGeotag = (street, isEditable) => {
-    const geotagText = (street.location)
+  render () {
+    // Render nothing if there is no street location, and geolocation is not enabled
+    if (!this.props.editable && !this.props.street.location) return null
+
+    // Determine what text label to render
+    const geotagText = (this.props.street.location)
       ? this.getGeotagText()
       : <FormattedMessage id="dialogs.geotag.add-location" defaultMessage="Add location" />
 
-    const geolocation = (
+    return (
       <span className="street-metadata-map">
-        { (isEditable) ? geotagText : (
-          <a onClick={this.onClickGeotag}>{geotagText}</a>
-        ) }
+        {(this.props.editable)
+          ? <a onClick={this.onClickGeotag}>{geotagText}</a>
+          : geotagText}
       </span>
     )
-
-    return (isEditable && !street.location) ? null : geolocation
-  }
-
-  render () {
-    const geolocation = (this.props.enableLocation) ? this.renderGeotag(this.props.street, this.props.editable) : null
-
-    return geolocation
   }
 }
 
 function mapStateToProps (state) {
   return {
     street: state.street,
-    editable: state.app.readOnly,
-    enableLocation: state.flags.GEOTAG.value
+    editable: !state.app.readOnly && state.flags.GEOTAG.value
   }
 }
 

--- a/assets/scripts/streets/StreetMetaGeotag.jsx
+++ b/assets/scripts/streets/StreetMetaGeotag.jsx
@@ -7,7 +7,7 @@ import { SHOW_DIALOG } from '../store/actions'
 
 export class StreetMetaGeotag extends React.Component {
   static propTypes = {
-    readOnly: PropTypes.bool,
+    editable: PropTypes.bool,
     street: PropTypes.any,
     enableLocation: PropTypes.bool,
     showGeotagDialog: PropTypes.func
@@ -37,24 +37,24 @@ export class StreetMetaGeotag extends React.Component {
     return text || unknownLabel
   }
 
-  renderGeotag = (street, readOnly) => {
+  renderGeotag = (street, isEditable) => {
     const geotagText = (street.location)
       ? this.getGeotagText()
       : <FormattedMessage id="dialogs.geotag.add-location" defaultMessage="Add location" />
 
     const geolocation = (
       <span className="street-metadata-map">
-        { (readOnly) ? geotagText : (
+        { (isEditable) ? geotagText : (
           <a onClick={this.onClickGeotag}>{geotagText}</a>
         ) }
       </span>
     )
 
-    return (readOnly && !street.location) ? null : geolocation
+    return (isEditable && !street.location) ? null : geolocation
   }
 
   render () {
-    const geolocation = (this.props.enableLocation) ? this.renderGeotag(this.props.street, this.props.readOnly) : null
+    const geolocation = (this.props.enableLocation) ? this.renderGeotag(this.props.street, this.props.editable) : null
 
     return geolocation
   }
@@ -63,7 +63,7 @@ export class StreetMetaGeotag extends React.Component {
 function mapStateToProps (state) {
   return {
     street: state.street,
-    readOnly: state.app.readOnly,
+    editable: state.app.readOnly,
     enableLocation: state.flags.GEOTAG.value
   }
 }

--- a/assets/scripts/streets/StreetMetaGeotag.jsx
+++ b/assets/scripts/streets/StreetMetaGeotag.jsx
@@ -64,7 +64,7 @@ function mapStateToProps (state) {
   return {
     street: state.street,
     readOnly: state.app.readOnly,
-    enableLocation: state.flags.GEOLOCATION.value
+    enableLocation: state.flags.GEOTAG.value
   }
 }
 

--- a/assets/scripts/streets/StreetMetaWidth.jsx
+++ b/assets/scripts/streets/StreetMetaWidth.jsx
@@ -23,9 +23,13 @@ const DEFAULT_STREET_WIDTHS = [40, 60, 80]
 export class StreetMetaWidth extends React.Component {
   static propTypes = {
     intl: intlShape,
-    readOnly: PropTypes.bool,
+    editable: PropTypes.bool,
     street: PropTypes.object,
     updateStreetWidth: PropTypes.func
+  }
+
+  static defaultProps = {
+    editable: true
   }
 
   constructor (props) {
@@ -94,17 +98,17 @@ export class StreetMetaWidth extends React.Component {
     const differenceClass = `street-width-read-difference ${difference.class}`
 
     // Do not display a title when street width is not editable
-    const title = (this.props.readOnly)
-      ? null
-      : this.props.intl.formatMessage({
+    const title = (this.props.editable)
+      ? this.props.intl.formatMessage({
         id: 'tooltip.street-width',
         defaultMessage: 'Change width of the street'
       })
+      : null
 
     // Apply "-editable" class if street width is editable to give it
     // additional styling to indicate editability.
     let className = 'street-width'
-    if (!this.props.readOnly) {
+    if (this.props.editable) {
       className += ' street-width-editable'
     }
 
@@ -194,7 +198,7 @@ export class StreetMetaWidth extends React.Component {
    * width is not read-only
    */
   clickStreetWidth = (event) => {
-    if (!this.props.readOnly) {
+    if (this.props.editable) {
       this.setState({
         isEditing: true
       })
@@ -270,7 +274,7 @@ export class StreetMetaWidth extends React.Component {
 
 function mapStateToProps (state) {
   return {
-    readOnly: state.app.readOnly || !state.flags.EDIT_STREET_WIDTH.value,
+    editable: !state.app.readOnly && state.flags.EDIT_STREET_WIDTH.value,
     street: state.street
   }
 }

--- a/assets/scripts/streets/StreetMetaWidth.jsx
+++ b/assets/scripts/streets/StreetMetaWidth.jsx
@@ -195,16 +195,22 @@ export class StreetMetaWidth extends React.Component {
     const difference = this.displayStreetWidthRemaining()
     const differenceClass = `street-width-read-difference ${difference.class}`
 
+    // Do not display a title when street width is not editable
+    const title = (this.props.readOnly)
+      ? null
+      : this.props.intl.formatMessage({id: 'tooltip.street-width', defaultMessage: 'Change width of the street'})
+
+    // Apply "-editable" class if street width is editable to give it
+    // additional styling to indicate editability.
+    let className = 'street-width'
+    if (!this.props.readOnly) {
+      className += ' street-width-editable'
+    }
+
     return (
       <span className="street-metadata-width">
-        <span
-          className="street-width-read"
-          title={this.props.intl.formatMessage({id: 'tooltip.street-width', defaultMessage: 'Change width of the street'})}
-          onClick={this.clickStreetWidth}
-        >
-          <span className="street-width-read-width">
-            <FormattedMessage id="width.label" defaultMessage="{width} width" values={{ width }} />
-          </span>
+        <span className={className} title={title} onClick={this.clickStreetWidth}>
+          <FormattedMessage id="width.label" defaultMessage="{width} width" values={{ width }} />
           &nbsp;
           <span className={differenceClass}>{difference.width}</span>
         </span>
@@ -216,7 +222,7 @@ export class StreetMetaWidth extends React.Component {
 
 function mapStateToProps (state) {
   return {
-    readOnly: state.app.readOnly,
+    readOnly: state.app.readOnly || !state.flags.EDIT_STREET_WIDTH.value,
     street: state.street
   }
 }

--- a/assets/scripts/streets/StreetNameCanvas.jsx
+++ b/assets/scripts/streets/StreetNameCanvas.jsx
@@ -124,7 +124,7 @@ class StreetNameCanvas extends React.Component {
 function mapStateToProps (state) {
   return {
     visible: state.ui.streetNameCanvasVisible,
-    editable: !state.app.readOnly,
+    editable: !state.app.readOnly && state.flags.EDIT_STREET_NAME.value,
     street: state.street
   }
 }

--- a/assets/scripts/streets/__tests__/StreetMetaGeotag.test.js
+++ b/assets/scripts/streets/__tests__/StreetMetaGeotag.test.js
@@ -27,7 +27,7 @@ describe('StreetMetaGeotag', () => {
       const wrapper = shallow(
         <StreetMetaGeotag.WrappedComponent
           street={testStreet}
-          readOnly
+          editable={false}
           enableLocation
           locale={{}}
         />
@@ -40,7 +40,7 @@ describe('StreetMetaGeotag', () => {
       const wrapper = shallow(
         <StreetMetaGeotag.WrappedComponent
           street={{}}
-          readOnly
+          editable={false}
           enableLocation
           locale={{}}
         />

--- a/assets/scripts/streets/__tests__/StreetMetaWidth.test.js
+++ b/assets/scripts/streets/__tests__/StreetMetaWidth.test.js
@@ -18,7 +18,7 @@ describe('StreetMetaWidth', () => {
   })
 
   it('does not allow street width to be edited if in read only mode', () => {
-    const wrapper = shallowWithIntl(<StreetMetaWidth street={{}} readOnly />)
+    const wrapper = shallowWithIntl(<StreetMetaWidth street={{}} editable={false} />)
 
     const streetWidthMenu = wrapper.find('.street-width')
     streetWidthMenu.simulate('click')

--- a/assets/scripts/streets/__tests__/StreetMetaWidth.test.js
+++ b/assets/scripts/streets/__tests__/StreetMetaWidth.test.js
@@ -20,9 +20,9 @@ describe('StreetMetaWidth', () => {
   it('does not allow street width to be edited if in read only mode', () => {
     const wrapper = shallowWithIntl(<StreetMetaWidth street={{}} readOnly />)
 
-    const streetWidthMenu = wrapper.find('.street-width-read')
+    const streetWidthMenu = wrapper.find('.street-width')
     streetWidthMenu.simulate('click')
-    const body = window.document.body
-    expect(body.classList.contains('edit-street-width')).toEqual(false)
+
+    expect(wrapper.state().isEditing).toEqual(false)
   })
 })


### PR DESCRIPTION
As part of a civic engagement session in New Rochelle this weekend, we are implementing granular editability features into the UI. Previously we had a app-level `readOnly` flag that affects the entire application, but in reality, there will be campaigns where things like street segments should be editable but other things would want to be locked (e.g. street name, width, and location). Here, I re-use the flags interface to toggle this, but the components involved will only have an `editable` prop which can theoretically be set via any interface.

In this PR:

- We introduce three new flags: the ability to edit the street name, street width, or side buildings. (Side buildings are not hooked up here in this PR.) They are enabled by default.
- The geotag flag, which was previously used to indicate whether the geotag feature was available to users, is now being used to indicate whether or not a location can be edited.
- The `StreetMetaWidth` component has been greatly refactored to make use of React component state instead of body classes to handle UI state. Additionally, the select menu has been given a `title` attribute to improve accessibility.
- The `StreetMetaGeotag` component has been refactored to reflect the new use of the `GEOTAG` flag, which simplfies its render logic.

