### PR TITLE
Issue #1053

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -129,6 +129,12 @@ class Segment extends React.Component {
       (event.keyCode === KEYS.MINUS_ALT) ||
       (event.keyCode === KEYS.MINUS_KEYPAD)
 
+    const positive = (event.keyCode === KEYS.EQUAL) ||
+      (event.keyCode === KEYS.EQUAL_ALT) ||
+      (event.keyCode === KEYS.PLUS_KEYPAD)
+
+    if (!negative && !positive) return
+
     const { widthValue } = this.calculateSegmentWidths(RESIZE_TYPE_INITIAL)
     incrementSegmentWidth(this.props.dataNo, !negative, event.shiftKey, widthValue)
     event.preventDefault()

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -133,7 +133,8 @@ class Segment extends React.Component {
       (event.keyCode === KEYS.EQUAL_ALT) ||
       (event.keyCode === KEYS.PLUS_KEYPAD)
 
-    if (!negative && !positive) return
+    const metaCtrlAlt = (event.metaKey || event.ctrlKey || event.altKey)
+    if (metaCtrlAlt || (!negative && !positive)) return
 
     const { widthValue } = this.calculateSegmentWidths(RESIZE_TYPE_INITIAL)
     incrementSegmentWidth(this.props.dataNo, !negative, event.shiftKey, widthValue)


### PR DESCRIPTION
`handleKeyDown` now checks if its a positive key or a negative key. If it is not either of them, then it returns instead of increasing the segment width. 

Resolves #1053