### PR TITLE
Turn on Polish and Finnish

### DIFF
--- a/app/data/locales.json
+++ b/app/data/locales.json
@@ -25,7 +25,7 @@
     "name": "Finnish",
     "value": "fi",
     "key": "i18n.lang.fi",
-    "level": 2
+    "level": 3
   },
   {
     "label": "Français",
@@ -53,7 +53,7 @@
     "name": "Polish",
     "value": "pl",
     "key": "i18n.lang.pl",
-    "level": 2
+    "level": 3
   },
   {
     "label": "Português (Brasil)",


### PR DESCRIPTION
This switches Polish and Finnish to "Level 3", meaning they will show up publicly in production Streetmix.

DO NOT MERGE THIS YET! :) The launch for these languages is planned for June 26.