### PR TITLE
RemoveButton: use segment position instead of segment element

### DIFF
--- a/assets/scripts/app/keyboard_commands.js
+++ b/assets/scripts/app/keyboard_commands.js
@@ -24,7 +24,9 @@ export const KEYS = {
   PLUS_KEYPAD: 107,
   MINUS: 189,
   MINUS_ALT: 173, // Firefox
-  MINUS_KEYPAD: 109
+  MINUS_KEYPAD: 109,
+  BACKSPACE: 8,
+  DELETE: 46
 }
 
 export function onGlobalKeyDown (event) {

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -501,7 +501,7 @@ class InfoBubble extends React.Component {
         <Triangle highlight={this.state.highlightTriangle} />
         <header>
           <div className="info-bubble-header-label">{this.getName()}</div>
-          <RemoveButton enabled={canBeDeleted} segment={this.segmentEl} />
+          {canBeDeleted && <RemoveButton segment={this.props.dataNo} />}
         </header>
         <div className="info-bubble-controls">
           <IntlProvider

--- a/assets/scripts/info_bubble/RemoveButton.jsx
+++ b/assets/scripts/info_bubble/RemoveButton.jsx
@@ -7,12 +7,10 @@ import { removeSegment, removeAllSegments } from '../segments/remove'
 class RemoveButton extends React.PureComponent {
   static propTypes = {
     intl: intlShape.isRequired,
-    enabled: PropTypes.bool,
-    segment: PropTypes.object // TODO: this is the actual DOM element; change it to a value
+    segment: PropTypes.number
   }
 
   static defaultProps = {
-    enabled: true,
     segment: null
   }
 
@@ -20,20 +18,23 @@ class RemoveButton extends React.PureComponent {
     // Prevent this “leaking” to a segment below
     event.preventDefault()
 
+    const { segment } = this.props
+
+    // Bail if segment is not provided; do not check for falsy. 0 is valid value for segment
+    if (segment === undefined || segment === null) return
+
     // Power move: a shift key will remove all segments
     if (event.shiftKey) {
       removeAllSegments()
+      trackEvent('INTERACTION', 'REMOVE_ALL_SEGMENTS', 'BUTTON', null, true)
     } else {
       // Otherwise, remove one segment
-      removeSegment(this.props.segment) // this is the reference to the actual element.
+      removeSegment(segment)
+      trackEvent('INTERACTION', 'REMOVE_SEGMENT', 'BUTTON', null, true)
     }
-
-    trackEvent('INTERACTION', 'REMOVE_SEGMENT', 'BUTTON', null, true)
   }
 
   render () {
-    if (!this.props.enabled) return null
-
     return (
       <button
         className="info-bubble-remove"
@@ -41,7 +42,7 @@ class RemoveButton extends React.PureComponent {
         title={this.props.intl.formatMessage({ id: 'tooltip.remove-segment', defaultMessage: 'Remove segment' })}
         onClick={this.onClick}
       >
-        <FormattedMessage id="btn.remove" defaultMessage="remove" />
+        <FormattedMessage id="btn.remove" defaultMessage="Remove" />
       </button>
     )
   }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -7,8 +7,9 @@ import { CSSTransition } from 'react-transition-group'
 import { getSegmentVariantInfo, getSegmentInfo } from '../segments/info'
 import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter, incrementSegmentWidth } from './resizing'
 import { TILE_SIZE } from './constants'
+import { removeSegment, removeAllSegments } from './remove'
 import { SETTINGS_UNITS_METRIC } from '../users/constants'
-import { infoBubble } from '../info_bubble/info_bubble'
+import { infoBubble, isDescriptionVisible } from '../info_bubble/info_bubble'
 import { INFO_BUBBLE_TYPE_SEGMENT } from '../info_bubble/constants'
 import { KEYS } from '../app/keyboard_commands'
 import { trackEvent } from '../app/event_tracking'
@@ -125,23 +126,65 @@ class Segment extends React.Component {
     )
   }
 
-  handleKeyDown = (event) => {
-    const negative = (event.keyCode === KEYS.MINUS) ||
-      (event.keyCode === KEYS.MINUS_ALT) ||
-      (event.keyCode === KEYS.MINUS_KEYPAD)
-
-    const positive = (event.keyCode === KEYS.EQUAL) ||
-      (event.keyCode === KEYS.EQUAL_ALT) ||
-      (event.keyCode === KEYS.PLUS_KEYPAD)
-
-    const metaCtrlAlt = (event.metaKey || event.ctrlKey || event.altKey)
-    if (metaCtrlAlt || (!negative && !positive)) return
-
+  /**
+   * Decreases segment width
+   *
+   * @param {Number} position - segment position
+   * @param {Boolean} finetune - true if shift key is pressed
+   */
+  decrementSegmentWidth (position, finetune) {
     const { widthValue } = this.calculateSegmentWidths(RESIZE_TYPE_INITIAL)
-    incrementSegmentWidth(this.props.dataNo, !negative, event.shiftKey, widthValue)
-    event.preventDefault()
+    incrementSegmentWidth(position, false, finetune, widthValue)
+  }
 
-    trackEvent('INTERACTION', 'CHANGE_WIDTH', 'KEYBOARD', null, true)
+  /**
+   * Increases segment width
+   *
+   * @param {Number} position - segment position
+   * @param {Boolean} finetune - true if shift key is pressed
+   */
+  incrementSegmentWidth (position, finetune) {
+    const { widthValue } = this.calculateSegmentWidths(RESIZE_TYPE_INITIAL)
+    incrementSegmentWidth(position, true, finetune, widthValue)
+  }
+
+  handleKeyDown = (event) => {
+    switch (event.keyCode) {
+      case KEYS.MINUS:
+      case KEYS.MINUS_ALT:
+      case KEYS.MINUS_KEYPAD:
+        if (event.metaKey || event.ctrlKey || event.altKey) return
+
+        event.preventDefault()
+        this.decrementSegmentWidth(this.props.dataNo, event.shiftKey)
+        trackEvent('INTERACTION', 'CHANGE_WIDTH', 'KEYBOARD', null, true)
+        break
+      case KEYS.EQUAL:
+      case KEYS.EQUAL_ALT:
+      case KEYS.PLUS_KEYPAD:
+        if (event.metaKey || event.ctrlKey || event.altKey) return
+
+        event.preventDefault()
+        this.incrementSegmentWidth(this.props.dataNo, event.shiftKey)
+        trackEvent('INTERACTION', 'CHANGE_WIDTH', 'KEYBOARD', null, true)
+        break
+      case KEYS.BACKSPACE:
+      case KEYS.DELETE:
+        // Prevent deletion from occurring of the description is visible
+        if (isDescriptionVisible()) return
+
+        // If the shift key is pressed, we remove all segments
+        if (event.shiftKey === true) {
+          removeAllSegments()
+          trackEvent('INTERACTION', 'REMOVE_ALL_SEGMENTS', 'KEYBOARD', null, true)
+        } else {
+          removeSegment(this.props.dataNo)
+          trackEvent('INTERACTION', 'REMOVE_SEGMENT', 'KEYBOARD', null, true)
+        }
+        break
+      default:
+        break
+    }
   }
 
   render () {

--- a/assets/scripts/segments/hover.js
+++ b/assets/scripts/segments/hover.js
@@ -1,8 +1,0 @@
-/**
- * Get the currently hovered segment
- * This is for keyboard commands (e.g. "delete") that
- * act on whichever is segment is being hovered upon
- */
-export function getHoveredSegmentEl () {
-  return document.querySelector('.segment.hover')
-}

--- a/assets/scripts/segments/remove.js
+++ b/assets/scripts/segments/remove.js
@@ -1,7 +1,5 @@
-import { registerKeypress } from '../app/keypress'
 import { showStatusMessage } from '../app/status_message'
-import { infoBubble, isDescriptionVisible } from '../info_bubble/info_bubble'
-import { getHoveredSegmentEl } from './hover'
+import { infoBubble } from '../info_bubble/info_bubble'
 import { segmentsChanged } from './view'
 import { t } from '../locales/locale'
 import { removeSegment as removeSegmentActionCreator, clearSegments } from '../store/actions/street'
@@ -10,13 +8,9 @@ import store from '../store'
 /**
  * Removes a segment, given the element to remove
  *
- * @param {Node} the segment element to remove
+ * @param {Number} position - segment to remove
  */
-export function removeSegment (el) {
-  if (!el || !el.parentNode) {
-    return
-  }
-
+export function removeSegment (position) {
   infoBubble.hide()
 
   // This makes sure that the drag handles on the segment
@@ -24,7 +18,7 @@ export function removeSegment (el) {
   infoBubble.hideSegment()
 
   // Update the store
-  store.dispatch(removeSegmentActionCreator(Number.parseInt(el.dataNo, 10), false))
+  store.dispatch(removeSegmentActionCreator(position, false))
 
   // update street data but do not re-read DOM
   segmentsChanged(false, true)
@@ -42,28 +36,3 @@ export function removeAllSegments () {
   infoBubble.hide()
   showStatusMessage(t('toast.all-segments-deleted', 'All segments have been removed.'), true)
 }
-
-// Register keyboard shortcuts for segment removal
-registerKeypress(['backspace', 'delete'], {
-  trackAction: 'REMOVE_SEGMENT',
-  // Prevent deletion from occurring of the description is visible
-  condition: function () { return !isDescriptionVisible() }
-}, function () {
-  let el = getHoveredSegmentEl()
-  removeSegment(el)
-})
-
-// Power shortcut for removing ALL segments. This is not
-// advertised anywhere in the UI.
-registerKeypress(['shift backspace', 'shift delete'], {
-  trackAction: 'Remove all segments',
-  // Prevent deletion from occurring of the description is visible
-  // Also, we don't need to know which segment is being hovered,
-  // but we should only execute this IF an segment is being hovered
-  // This prevents this key command from executing anywhere
-  condition: function () {
-    return !isDescriptionVisible() && getHoveredSegmentEl()
-  }
-}, function () {
-  removeAllSegments()
-})


### PR DESCRIPTION
Refactors the segment removal interface. The primary goal was to stop passing the actual segment DOM element in as a prop and use the segment `dataNo` (e.g. `position`) instead.

This led to a small slew of related revisions:

- The `RemoveButton` component no longer has its own `enabled` prop. If the InfoBubble doesn't want to render it, it won't render it.
- Shortcut key listeners (for backspace and delete) are no longer globally registered to the window. It uses the same key listener used for increment/decrement (which listens only when the mouse is hovering a segment) instead.
- This means we can remove `hover.js` which was only used for the purpose of knowing which segment a mouse cursor might be hovering over.

Tiny fixes:
- Make event tracking related to segment removal more consistent.
- Capitalize the "R" in the fallback message for "Remove."
