### PR TITLE
Undoing a segment removal no longer animates all segments

### DIFF
--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -304,7 +304,7 @@ export function saveStreetToServerIfNecessary () {
 }
 
 // Copies only the data necessary for save/undo.
-export function trimStreetData (street) {
+export function trimStreetData (street, saveSegmentId = true) {
   var newData = {}
 
   newData.schemaVersion = street.schemaVersion
@@ -343,7 +343,9 @@ export function trimStreetData (street) {
     if (street.segments[i].randSeed) {
       segment.randSeed = street.segments[i].randSeed
     }
-
+    if (saveSegmentId) {
+      segment.id = street.segments[i].id
+    }
     newData.segments.push(segment)
   }
 

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -248,8 +248,8 @@ export function fetchStreetForVerification () {
 }
 
 function receiveStreetForVerification (transmission) {
-  const localStreetData = trimStreetData(latestVerificationStreet)
-  const serverStreetData = trimStreetData(unpackStreetDataFromServerTransmission(transmission))
+  const localStreetData = trimStreetData(latestVerificationStreet, false)
+  const serverStreetData = trimStreetData(unpackStreetDataFromServerTransmission(transmission), false)
 
   if (JSON.stringify(localStreetData) !== JSON.stringify(serverStreetData)) {
     console.log('NOT EQUAL')
@@ -360,7 +360,7 @@ export function unpackServerStreetData (transmission, id, namespacedId, checkIfN
 
 export function packServerStreetData () {
   var data = {}
-  data.street = trimStreetData(store.getState().street)
+  data.street = trimStreetData(store.getState().street, false)
 
   // Those go above data in the structure, so they need to be cleared here
   delete data.street.name


### PR DESCRIPTION
When saving the current street state on the undo stack, the segment ids are not saved. This means that when the user undos a removal of a segment, all the segments that were on the street get new segment ids leading to the <Segment> components with the old segment ids to get switched away.

The solution I have found is to specify whether or not to save the segment ids when calling trimStreetData with the default value as true. It is only when we are saving the street data to the database that we are not saving the segment ids. Also when checking if the local street data is equal to the server street data, the segment ids do not get compared since the server street data does not have the segment ids.

This solves the switching away of segments when undoing a removal of a segment. Instead, the previously removed segment simply gets rendered back on the street with a transition. If the user redos the removal of the segment, the segment does get the switching away animation.

Resolves #1058