### PR TITLE
InfoBubble: refactoring segment element reference

### DIFF
--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -355,7 +355,6 @@ body.segment-resize-dragging * {
   }
 }
 
-.segment.hide-drag-handles-when-inside-info-bubble .drag-handle,
 .segment.hide-drag-handles-when-description-shown .drag-handle {
   display: none !important;
 }

--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -355,10 +355,6 @@ body.segment-resize-dragging * {
   }
 }
 
-.segment.hide-drag-handles-when-description-shown .drag-handle {
-  display: none !important;
-}
-
 .segment.immediate-show-drag-handles .drag-handle {
   transition: none !important;
 }

--- a/assets/scripts/info_bubble/Description.jsx
+++ b/assets/scripts/info_bubble/Description.jsx
@@ -27,14 +27,7 @@ export class Description extends React.Component {
   onClickShow = () => {
     this.props.showDescription()
     this.props.updateBubbleDimensions()
-
-    // TODO refactor - segment element should handle this whenever descriptionVisible is true
-    if (this.props.segmentEl) {
-      this.props.segmentEl.classList.add('hide-drag-handles-when-description-shown')
-    }
-
     this.props.updateHoverPolygon()
-    // end TODO
 
     registerKeypress('esc', this.onClickHide)
     trackEvent('INTERACTION', 'LEARN_MORE', this.props.type, null, false)
@@ -43,14 +36,7 @@ export class Description extends React.Component {
   onClickHide = () => {
     this.props.hideDescription()
     this.props.updateBubbleDimensions()
-
-    // TODO refactor
-    if (this.props.segmentEl) {
-      this.props.segmentEl.classList.remove('hide-drag-handles-when-description-shown')
-    }
-
     this.props.updateHoverPolygon()
-    // end TODO
 
     deregisterKeypress('esc', this.onClickHide)
   }

--- a/assets/scripts/info_bubble/Description.jsx
+++ b/assets/scripts/info_bubble/Description.jsx
@@ -20,7 +20,6 @@ export class Description extends React.Component {
     descriptionVisible: PropTypes.bool.isRequired,
     showDescription: PropTypes.func.isRequired,
     hideDescription: PropTypes.func.isRequired,
-    segmentEl: PropTypes.object,
     infoBubbleEl: PropTypes.object
   }
 
@@ -80,7 +79,7 @@ export class Description extends React.Component {
   render () {
     const description = this.getDescriptionData(this.props.type, this.props.variantString)
 
-    if (!description || !this.props.segmentEl || !this.props.infoBubbleEl) return null
+    if (!description || !this.props.infoBubbleEl) return null
 
     // If the description text doesn't exist or hasn't been translated, bail.
     const text = t(`descriptions.${description.key}.text`, null, { ns: 'segment-info' })

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -160,23 +160,12 @@ class InfoBubble extends React.Component {
 
   // TODO: verify this continues to work with pointer / touch taps
   onMouseEnter = (event) => {
-    // TODO: refactor so segment element handles this
-    if (this.segmentEl) {
-      this.segmentEl.classList.add('hide-drag-handles-when-inside-info-bubble')
-    }
-
     this.props.setInfoBubbleMouseInside(true)
 
     this.updateHoverPolygon()
   }
 
   onMouseLeave = (event) => {
-    // TODO: Prevent pointer taps from flashing the drag handles
-    // TODO: refactor so segment element handles this
-    if (this.segmentEl) {
-      this.segmentEl.classList.remove('hide-drag-handles-when-inside-info-bubble')
-    }
-
     this.props.setInfoBubbleMouseInside(false)
 
     // Returns focus to body when pointer leaves the info bubble area

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -510,7 +510,6 @@ class InfoBubble extends React.Component {
           updateBubbleDimensions={this.updateBubbleDimensions}
           highlightTriangle={this.highlightTriangle}
           unhighlightTriangle={this.unhighlightTriangle}
-          segmentEl={this.segmentEl}
           infoBubbleEl={this.el.current}
           updateHoverPolygon={this.updateHoverPolygon}
         />

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -479,7 +479,7 @@ class InfoBubble extends React.Component {
     let widthOrHeightControl
     switch (type) {
       case INFO_BUBBLE_TYPE_SEGMENT:
-        widthOrHeightControl = <WidthControl segmentEl={this.segmentEl} position={position} />
+        widthOrHeightControl = <WidthControl position={position} />
         break
       case INFO_BUBBLE_TYPE_LEFT_BUILDING:
       case INFO_BUBBLE_TYPE_RIGHT_BUILDING:

--- a/assets/scripts/info_bubble/WidthControl.jsx
+++ b/assets/scripts/info_bubble/WidthControl.jsx
@@ -12,7 +12,7 @@ import {
   RESIZE_TYPE_TYPING,
   resizeSegment,
   incrementSegmentWidth,
-  scheduleControlsFadeout
+  resumeFadeoutControls
 } from '../segments/resizing'
 import {
   prettifyWidth,
@@ -27,7 +27,6 @@ class WidthControl extends React.Component {
     intl: intlShape.isRequired,
     touch: PropTypes.bool,
     segment: PropTypes.object, // eslint-disable-line react/no-unused-prop-types
-    segmentEl: PropTypes.object, // TODO: this is the actual DOM element; only here for legacy reasons
     position: PropTypes.number,
     value: PropTypes.number,
     units: PropTypes.number,
@@ -74,22 +73,18 @@ class WidthControl extends React.Component {
   }
 
   onClickIncrement = (event) => {
-    const segmentEl = this.props.segmentEl
     const precise = event.shiftKey
 
     incrementSegmentWidth(this.props.position, true, precise, this.props.value)
-    scheduleControlsFadeout(segmentEl)
-
+    resumeFadeoutControls()
     trackEvent('INTERACTION', 'CHANGE_WIDTH', 'DECREMENT_BUTTON', null, true)
   }
 
   onClickDecrement = (event) => {
-    const segmentEl = this.props.segmentEl
     const precise = event.shiftKey
 
     incrementSegmentWidth(this.props.position, false, precise, this.props.value)
-    scheduleControlsFadeout(segmentEl)
-
+    resumeFadeoutControls()
     trackEvent('INTERACTION', 'CHANGE_WIDTH', 'INCREMENT_BUTTON', null, true)
   }
 

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -69,7 +69,6 @@ export const infoBubble = {
         el.classList.remove('immediate-show-drag-handles')
       }
       infoBubble.segmentEl.classList.remove('hide-drag-handles-when-description-shown')
-      infoBubble.segmentEl.classList.remove('hide-drag-handles-when-inside-info-bubble')
       infoBubble.segmentEl.classList.remove('show-drag-handles')
       infoBubble.segmentEl = null
     }

--- a/assets/scripts/info_bubble/info_bubble.js
+++ b/assets/scripts/info_bubble/info_bubble.js
@@ -68,7 +68,6 @@ export const infoBubble = {
       } else {
         el.classList.remove('immediate-show-drag-handles')
       }
-      infoBubble.segmentEl.classList.remove('hide-drag-handles-when-description-shown')
       infoBubble.segmentEl.classList.remove('show-drag-handles')
       infoBubble.segmentEl = null
     }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -9,7 +9,7 @@ import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter, increme
 import { TILE_SIZE } from './constants'
 import { removeSegment, removeAllSegments } from './remove'
 import { SETTINGS_UNITS_METRIC } from '../users/constants'
-import { infoBubble, isDescriptionVisible } from '../info_bubble/info_bubble'
+import { infoBubble } from '../info_bubble/info_bubble'
 import { INFO_BUBBLE_TYPE_SEGMENT } from '../info_bubble/constants'
 import { KEYS } from '../app/keyboard_commands'
 import { trackEvent } from '../app/event_tracking'
@@ -31,6 +31,7 @@ class Segment extends React.Component {
     updatePerspective: PropTypes.func,
     locale: PropTypes.string,
     infoBubbleHovered: PropTypes.bool,
+    descriptionVisible: PropTypes.bool,
     suppressMouseEnter: PropTypes.bool.isRequired
   }
 
@@ -172,7 +173,7 @@ class Segment extends React.Component {
       case KEYS.BACKSPACE:
       case KEYS.DELETE:
         // Prevent deletion from occurring if the description is visible
-        if (isDescriptionVisible()) return
+        if (this.props.descriptionVisible) return
 
         // If the shift key is pressed, we remove all segments
         if (event.shiftKey === true) {
@@ -236,8 +237,8 @@ class Segment extends React.Component {
             <span className="width">
               <MeasurementText value={widthValue} units={this.props.units} locale={this.props.locale} />
             </span>
-            <span className="drag-handle left" style={{ display: (this.props.infoBubbleHovered ? 'none' : 'block') }} ref={(ref) => { this.dragHandleLeft = ref }}>‹</span>
-            <span className="drag-handle right" style={{ display: (this.props.infoBubbleHovered ? 'none' : 'block') }} ref={(ref) => { this.dragHandleRight = ref }}>›</span>
+            <span className="drag-handle left" style={{ display: ((this.props.infoBubbleHovered || this.props.descriptionVisible) ? 'none' : 'block') }} ref={(ref) => { this.dragHandleLeft = ref }}>‹</span>
+            <span className="drag-handle right" style={{ display: ((this.props.infoBubbleHovered || this.props.descriptionVisible) ? 'none' : 'block') }} ref={(ref) => { this.dragHandleRight = ref }}>›</span>
             <span className={'grid' + (this.props.units === SETTINGS_UNITS_METRIC ? ' units-metric' : ' units-imperial')} />
           </React.Fragment>
         }
@@ -272,7 +273,8 @@ function mapStateToProps (state) {
   return {
     cssTransform: state.system.cssTransform,
     locale: state.locale.locale,
-    infoBubbleHovered: state.infoBubble.mouseInside
+    infoBubbleHovered: state.infoBubble.mouseInside,
+    descriptionVisible: state.infoBubble.descriptionVisible
   }
 }
 

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -30,6 +30,7 @@ class Segment extends React.Component {
     updateSegmentData: PropTypes.func,
     updatePerspective: PropTypes.func,
     locale: PropTypes.string,
+    infoBubbleHovered: PropTypes.bool,
     suppressMouseEnter: PropTypes.bool.isRequired
   }
 
@@ -235,8 +236,8 @@ class Segment extends React.Component {
             <span className="width">
               <MeasurementText value={widthValue} units={this.props.units} locale={this.props.locale} />
             </span>
-            <span className="drag-handle left" ref={(ref) => { this.dragHandleLeft = ref }}>‹</span>
-            <span className="drag-handle right" ref={(ref) => { this.dragHandleRight = ref }}>›</span>
+            <span className="drag-handle left" style={{ display: (this.props.infoBubbleHovered ? 'none' : 'block') }} ref={(ref) => { this.dragHandleLeft = ref }}>‹</span>
+            <span className="drag-handle right" style={{ display: (this.props.infoBubbleHovered ? 'none' : 'block') }} ref={(ref) => { this.dragHandleRight = ref }}>›</span>
             <span className={'grid' + (this.props.units === SETTINGS_UNITS_METRIC ? ' units-metric' : ' units-imperial')} />
           </React.Fragment>
         }
@@ -270,7 +271,8 @@ class Segment extends React.Component {
 function mapStateToProps (state) {
   return {
     cssTransform: state.system.cssTransform,
-    locale: state.locale.locale
+    locale: state.locale.locale,
+    infoBubbleHovered: state.infoBubble.mouseInside
   }
 }
 


### PR DESCRIPTION
Two `InfoBubble` subcomponents, `WidthControl` and `Description`, formerly relied on direct references to the segment's DOM element. With the recent `Segment` rework for the street, neither of these components require DOM element references. Furthermore, the `Segment` component can now take over drag handle visibility state by reading the info bubble's state from Redux.

(The drag handles themselves will be refactored away into its own component in a later PR.)