### PR TITLE
Port drag guides to React component

### DIFF
--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -209,6 +209,7 @@ body.segment-resize-dragging .drag-handle.floating,
   border-left: 1px dashed fade-out(black, 0.6);
   border-right: 1px dashed fade-out(black, 0.6);
   box-sizing: border-box;
+  pointer-events: none;
 
   &::before,
   &::after {

--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -200,7 +200,7 @@ body.segment-resize-dragging .drag-handle.floating,
   transform: none;
 }
 
-.segment .guide {
+.segment-guide {
   position: absolute;
   z-index: $z-07-segment-guide;
   left: 50%;
@@ -210,41 +210,39 @@ body.segment-resize-dragging .drag-handle.floating,
   border-right: 1px dashed fade-out(black, 0.6);
   box-sizing: border-box;
   pointer-events: none;
+}
 
-  &::before,
-  &::after {
-    width: 50px;
-    position: absolute;
-    box-sizing: border-box;
-    pointer-events: none;
-    bottom: 400px;
-    font-size: 11px;
-    color: fade-out(black, 0.4);
-  }
+.segment-guide-max-before,
+.segment-guide-max-after,
+.segment-guide-min-before,
+.segment-guide-min-after {
+  width: 50px;
+  position: absolute;
+  box-sizing: border-box;
+  pointer-events: none;
+  bottom: 400px;
+  font-size: 11px;
+  color: fade-out(black, 0.4);
+}
 
-  &.max::before {
-    content: 'Max »';
-    left: -55px;
-    text-align: right;
-  }
+.segment-guide-max-before {
+  left: -55px;
+  text-align: right;
+}
 
-  &.max::after {
-    content: '« Max';
-    right: -55px;
-    text-align: left;
-  }
+.segment-guide-max-after {
+  right: -55px;
+  text-align: left;
+}
 
-  &.min::before {
-    content: '« Min';
-    left: 5px;
-    text-align: left;
-  }
+.segment-guide-min-before {
+  left: 5px;
+  text-align: left;
+}
 
-  &.min::after {
-    content: 'Min »';
-    right: 5px;
-    text-align: right;
-  }
+.segment-guide-min-after {
+  right: 5px;
+  text-align: right;
 }
 
 .segment .grid {

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -267,6 +267,10 @@
     },
     "description": {
       "photo-credit": "Photo:"
+    },
+    "resize": {
+      "min": "Min",
+      "max": "Max"
     }
   },
   "section": {

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -178,18 +178,16 @@ class InfoBubble extends React.Component {
     const mouseX = event.pageX
     const mouseY = event.pageY
 
+    if (this.props.visible) {
+      if (!infoBubble._withinHoverPolygon(mouseX, mouseY)) {
+        infoBubble.show(false)
+      }
+    }
+
     window.clearTimeout(this.hoverPolygonUpdateTimerId)
 
     this.hoverPolygonUpdateTimerId = window.setTimeout(() => {
       this.updateHoverPolygon(mouseX, mouseY)
-
-      // After updating hover polygon, see if mouse is inside of it and hide the
-      // info bubble if it isn't.
-      if (this.props.visible) {
-        if (!infoBubble._withinHoverPolygon(mouseX, mouseY)) {
-          infoBubble.show(false)
-        }
-      }
     }, 50)
   }
 

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import MeasurementText from '../ui/MeasurementText'
 import SegmentCanvas from './SegmentCanvas'
 import SegmentDragHandles from './SegmentDragHandles'
+import SegmentDragGuides from './SegmentDragGuides'
 import { CSSTransition } from 'react-transition-group'
 import { getSegmentVariantInfo, getSegmentInfo } from '../segments/info'
 import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter, incrementSegmentWidth } from './resizing'
@@ -238,6 +239,7 @@ class Segment extends React.Component {
             </span>
             <span className={'grid' + (this.props.units === SETTINGS_UNITS_METRIC ? ' units-metric' : ' units-imperial')} />
             <SegmentDragHandles width={width} />
+            <SegmentDragGuides width={width} type={this.props.type} variantString={this.props.variantString} dataNo={this.props.dataNo} />
           </React.Fragment>
         }
         <CSSTransition

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { IntlProvider } from 'react-intl'
 import MeasurementText from '../ui/MeasurementText'
 import SegmentCanvas from './SegmentCanvas'
 import SegmentDragHandles from './SegmentDragHandles'
@@ -32,6 +33,7 @@ class Segment extends React.Component {
     updateSegmentData: PropTypes.func,
     updatePerspective: PropTypes.func,
     locale: PropTypes.string,
+    localeMessages: PropTypes.object,
     infoBubbleHovered: PropTypes.bool,
     descriptionVisible: PropTypes.bool,
     suppressMouseEnter: PropTypes.bool.isRequired
@@ -239,7 +241,13 @@ class Segment extends React.Component {
             </span>
             <span className={'grid' + (this.props.units === SETTINGS_UNITS_METRIC ? ' units-metric' : ' units-imperial')} />
             <SegmentDragHandles width={width} />
-            <SegmentDragGuides width={width} type={this.props.type} variantString={this.props.variantString} dataNo={this.props.dataNo} />
+            <IntlProvider
+              locale={this.props.locale}
+              key={this.props.locale}
+              messages={this.props.localeMessages}
+            >
+              <SegmentDragGuides width={width} type={this.props.type} variantString={this.props.variantString} dataNo={this.props.dataNo} />
+            </IntlProvider>
           </React.Fragment>
         }
         <CSSTransition
@@ -273,6 +281,7 @@ function mapStateToProps (state) {
   return {
     cssTransform: state.system.cssTransform,
     locale: state.locale.locale,
+    localeMessages: state.locale.messages,
     infoBubbleHovered: state.infoBubble.mouseInside,
     descriptionVisible: state.infoBubble.descriptionVisible
   }

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -36,12 +36,18 @@ export class SegmentDragGuides extends React.Component {
       }
     })
     window.addEventListener('stmx:hide_segment_guides', (e) => {
-      if (e.detail.dataNo === this.props.dataNo) {
-        this.setState({
-          show: false
-        })
-      }
+      this.setState({
+        show: false
+      })
     })
+  }
+
+  getStyle = (width) => {
+    const pixelWidth = width * TILE_SIZE
+    return {
+      width: `${pixelWidth}px`,
+      marginLeft: (-pixelWidth / 2) + 'px'
+    }
   }
 
   render () {
@@ -51,35 +57,17 @@ export class SegmentDragGuides extends React.Component {
     let minGuide, maxGuide
 
     if (variantInfo.minWidth) {
-      const width = variantInfo.minWidth * TILE_SIZE
-      const style = {
-        width: `${width}px`,
-        marginLeft: (-width / 2) + 'px'
-      }
-
-      minGuide = <div className="guide min" style={style} />
+      minGuide = <div className="guide min" style={this.getStyle(variantInfo.minWidth)} />
     }
 
-    const remainingWidth = this.props.remainingWidth + this.props.width
+    const remainingWidth = this.props.remainingWidth + (this.props.width / TILE_SIZE)
 
     if (remainingWidth &&
       (((!variantInfo.minWidth) && (remainingWidth >= MIN_SEGMENT_WIDTH)) || (remainingWidth >= variantInfo.minWidth)) &&
       ((!variantInfo.maxWidth) || (remainingWidth <= variantInfo.maxWidth))) {
-      const width = remainingWidth * TILE_SIZE
-      const style = {
-        width: `${width}px`,
-        marginLeft: (-width / 2) + 'px'
-      }
-
-      maxGuide = <div className="guide max" style={style} />
+      maxGuide = <div className="guide max" style={this.getStyle(remainingWidth)} />
     } else if (variantInfo.maxWidth) {
-      const width = variantInfo.maxWidth * TILE_SIZE
-      const style = {
-        width: `${width}px`,
-        marginLeft: (-width / 2) + 'px'
-      }
-
-      maxGuide = <div className="guide max" style={style} />
+      maxGuide = <div className="guide max" style={this.getStyle(variantInfo.maxWidth)} />
     }
 
     return (

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { TILE_SIZE } from './constants'
+import { getSegmentVariantInfo } from '../segments/info'
+import { MIN_SEGMENT_WIDTH } from '../segments/resizing'
+
+export class SegmentDragGuides extends React.Component {
+  static propTypes = {
+    type: PropTypes.string.isRequired,
+    variantString: PropTypes.string.isRequired,
+    width: PropTypes.number,
+    dataNo: PropTypes.number,
+    remainingWidth: PropTypes.number
+  }
+
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      show: false
+    }
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    return (this.state.show !== nextState.show)
+  }
+
+  componentDidMount () {
+    // Listen for events to show/hide
+    window.addEventListener('stmx:show_segment_guides', (e) => {
+      if (e.detail.dataNo === this.props.dataNo) {
+        this.setState({
+          show: true
+        })
+      }
+    })
+    window.addEventListener('stmx:hide_segment_guides', (e) => {
+      if (e.detail.dataNo === this.props.dataNo) {
+        this.setState({
+          show: false
+        })
+      }
+    })
+  }
+
+  render () {
+    if (!this.state.show) return null
+
+    const variantInfo = getSegmentVariantInfo(this.props.type, this.props.variantString)
+    let minGuide, maxGuide
+
+    if (variantInfo.minWidth) {
+      const width = variantInfo.minWidth * TILE_SIZE
+      const style = {
+        width: `${width}px`,
+        marginLeft: (-width / 2) + 'px'
+      }
+
+      minGuide = <div className="guide min" style={style} />
+    }
+
+    const remainingWidth = this.props.remainingWidth + this.props.width
+
+    if (remainingWidth &&
+      (((!variantInfo.minWidth) && (remainingWidth >= MIN_SEGMENT_WIDTH)) || (remainingWidth >= variantInfo.minWidth)) &&
+      ((!variantInfo.maxWidth) || (remainingWidth <= variantInfo.maxWidth))) {
+      const width = remainingWidth * TILE_SIZE
+      const style = {
+        width: `${width}px`,
+        marginLeft: (-width / 2) + 'px'
+      }
+
+      maxGuide = <div className="guide max" style={style} />
+    } else if (variantInfo.maxWidth) {
+      const width = variantInfo.maxWidth * TILE_SIZE
+      const style = {
+        width: `${width}px`,
+        marginLeft: (-width / 2) + 'px'
+      }
+
+      maxGuide = <div className="guide max" style={style} />
+    }
+
+    return (
+      <React.Fragment>
+        {minGuide}
+        {maxGuide}
+      </React.Fragment>
+    )
+  }
+}
+
+function mapStateToProps (state) {
+  return {
+    remainingWidth: state.street.remainingWidth
+  }
+}
+
+export default connect(mapStateToProps)(SegmentDragGuides)

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -29,17 +29,27 @@ export class SegmentDragGuides extends React.Component {
 
   componentDidMount () {
     // Listen for events to show/hide
-    window.addEventListener('stmx:show_segment_guides', (e) => {
-      if (e.detail.dataNo === this.props.dataNo) {
-        this.setState({
-          show: true
-        })
-      }
-    })
-    window.addEventListener('stmx:hide_segment_guides', (e) => {
+    window.addEventListener('stmx:show_segment_guides', this.showGuides)
+    window.addEventListener('stmx:hide_segment_guides', this.hideGuides)
+  }
+
+  componentWillUnmount () {
+    // Clean up when unmounted
+    window.removeEventListener('stmx:show_segment_guides', this.showGuides)
+    window.removeEventListener('stmx:hide_segment_guides', this.hideGuides)
+  }
+
+  showGuides = (event) => {
+    if (event.detail.dataNo === this.props.dataNo) {
       this.setState({
-        show: false
+        show: true
       })
+    }
+  }
+
+  hideGuides = (event) => {
+    this.setState({
+      show: false
     })
   }
 

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
 import { TILE_SIZE } from './constants'
 import { getSegmentVariantInfo } from '../segments/info'
 import { MIN_SEGMENT_WIDTH } from '../segments/resizing'
@@ -57,7 +58,12 @@ export class SegmentDragGuides extends React.Component {
     let minGuide, maxGuide
 
     if (variantInfo.minWidth) {
-      minGuide = <div className="guide min" style={this.getStyle(variantInfo.minWidth)} />
+      minGuide = (
+        <div className="segment-guide segment-guide-min" style={this.getStyle(variantInfo.minWidth)}>
+          <div className="segment-guide-min-before">« <FormattedMessage id="segment.resize.min" defaultMessage="Min" /></div>
+          <div className="segment-guide-min-after"><FormattedMessage id="segment.resize.min" defaultMessage="Min" /> »</div>
+        </div>
+      )
     }
 
     const remainingWidth = this.props.remainingWidth + (this.props.width / TILE_SIZE)
@@ -65,9 +71,19 @@ export class SegmentDragGuides extends React.Component {
     if (remainingWidth &&
       (((!variantInfo.minWidth) && (remainingWidth >= MIN_SEGMENT_WIDTH)) || (remainingWidth >= variantInfo.minWidth)) &&
       ((!variantInfo.maxWidth) || (remainingWidth <= variantInfo.maxWidth))) {
-      maxGuide = <div className="guide max" style={this.getStyle(remainingWidth)} />
+      maxGuide = (
+        <div className="segment-guide segment-guide-max" style={this.getStyle(remainingWidth)}>
+          <div className="segment-guide-max-before"><FormattedMessage id="segment.resize.max" defaultMessage="Max" /> »</div>
+          <div className="segment-guide-max-after">« <FormattedMessage id="segment.resize.max" defaultMessage="Max" /></div>
+        </div>
+      )
     } else if (variantInfo.maxWidth) {
-      maxGuide = <div className="guide max" style={this.getStyle(variantInfo.maxWidth)} />
+      maxGuide = (
+        <div className="segment-guide segment-guide-max" style={this.getStyle(variantInfo.maxWidth)}>
+          <div className="segment-guide-max-before"><FormattedMessage id="segment.resize.max" defaultMessage="Max" /> »</div>
+          <div className="segment-guide-max-after">« <FormattedMessage id="segment.resize.max" defaultMessage="Max" /></div>
+        </div>
+      )
     }
 
     return (

--- a/assets/scripts/segments/SegmentDragHandles.jsx
+++ b/assets/scripts/segments/SegmentDragHandles.jsx
@@ -9,19 +9,6 @@ export class SegmentDragHandles extends React.Component {
     descriptionVisible: PropTypes.bool
   }
 
-  constructor (props) {
-    super(props)
-
-    this.dragHandleLeft = React.createRef()
-    this.dragHandleRight = React.createRef()
-  }
-
-  componentDidMount () {
-    // TODO: do not store a reference to the element directly on the DOM.
-    this.dragHandleLeft.current.segmentEl = this.dragHandleLeft.current.parentNode
-    this.dragHandleRight.current.segmentEl = this.dragHandleLeft.current.parentNode
-  }
-
   render () {
     const display = (this.props.infoBubbleHovered || this.props.descriptionVisible)
       ? 'none' : null
@@ -35,8 +22,8 @@ export class SegmentDragHandles extends React.Component {
 
     return (
       <React.Fragment>
-        <span className="drag-handle drag-handle-left" style={{ display, left: adjustX }} ref={this.dragHandleLeft}>‹</span>
-        <span className="drag-handle drag-handle-right" style={{ display, right: adjustX }} ref={this.dragHandleRight}>›</span>
+        <span className="drag-handle drag-handle-left" style={{ display, left: adjustX }}>‹</span>
+        <span className="drag-handle drag-handle-right" style={{ display, right: adjustX }}>›</span>
       </React.Fragment>
     )
   }

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -105,7 +105,7 @@ export function changeDraggingType (newDraggingType) {
 }
 
 function handleSegmentResizeStart (event) {
-  let x, y, guideEl, width
+  let x, y
   if (app.readOnly) {
     return
   }
@@ -154,43 +154,8 @@ function handleSegmentResizeStart (event) {
 
   draggingResize.segmentEl.classList.add('hover')
 
-  const variantInfo = getSegmentVariantInfo(el.segmentEl.getAttribute('type'), el.segmentEl.getAttribute('variant-string'))
-
-  if (variantInfo.minWidth) {
-    guideEl = document.createElement('div')
-    guideEl.classList.add('guide')
-    guideEl.classList.add('min')
-
-    width = variantInfo.minWidth * TILE_SIZE
-    guideEl.style.width = width + 'px'
-    guideEl.style.marginLeft = (-width / 2) + 'px'
-    el.segmentEl.appendChild(guideEl)
-  }
-
-  var remainingWidth =
-  store.getState().street.remainingWidth + parseFloat(el.segmentEl.getAttribute('data-width'))
-
-  if (remainingWidth &&
-    (((!variantInfo.minWidth) && (remainingWidth >= MIN_SEGMENT_WIDTH)) || (remainingWidth >= variantInfo.minWidth)) &&
-    ((!variantInfo.maxWidth) || (remainingWidth <= variantInfo.maxWidth))) {
-    guideEl = document.createElement('div')
-    guideEl.classList.add('guide')
-    guideEl.classList.add('max')
-
-    width = remainingWidth * TILE_SIZE
-    guideEl.style.width = width + 'px'
-    guideEl.style.marginLeft = (-width / 2) + 'px'
-    el.segmentEl.appendChild(guideEl)
-  } else if (variantInfo.maxWidth) {
-    guideEl = document.createElement('div')
-    guideEl.classList.add('guide')
-    guideEl.classList.add('max')
-
-    width = variantInfo.maxWidth * TILE_SIZE
-    guideEl.style.width = width + 'px'
-    guideEl.style.marginLeft = (-width / 2) + 'px'
-    el.segmentEl.appendChild(guideEl)
-  }
+  // todo: refactor
+  window.dispatchEvent(new window.CustomEvent('stmx:show_segment_guides', { detail: { dataNo: window.parseInt(draggingResize.segmentEl.dataNo, 10) } }))
 
   infoBubble.hide()
   infoBubble.hideSegment(true)
@@ -796,14 +761,6 @@ function handleSegmentMoveEnd (event) {
 
   if (failedDrop) {
     infoBubble.show(true)
-  }
-}
-
-export function removeGuides (el) {
-  let guideEl = el.querySelector('.guide')
-  while (guideEl) {
-    guideEl.remove()
-    guideEl = el.querySelector('.guide')
   }
 }
 

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -149,8 +149,8 @@ function handleSegmentResizeStart (event) {
   draggingResize.elY = pos[1]
 
   draggingResize.originalX = draggingResize.elX
-  draggingResize.originalWidth = parseFloat(el.segmentEl.getAttribute('data-width'))
-  draggingResize.segmentEl = el.segmentEl
+  draggingResize.originalWidth = parseFloat(el.parentNode.getAttribute('data-width'))
+  draggingResize.segmentEl = el.parentNode
 
   draggingResize.segmentEl.classList.add('hover')
 
@@ -163,7 +163,7 @@ function handleSegmentResizeStart (event) {
   hideControls()
 
   window.setTimeout(function () {
-    el.segmentEl.classList.add('hover')
+    draggingResize.segmentEl.classList.add('hover')
   }, 0)
 }
 

--- a/assets/scripts/segments/resizing.js
+++ b/assets/scripts/segments/resizing.js
@@ -11,8 +11,7 @@ import {
 import {
   DRAGGING_TYPE_NONE,
   draggingResize,
-  changeDraggingType,
-  removeGuides
+  changeDraggingType
 } from './drag_and_drop'
 import { segmentsChanged } from './view'
 import store from '../store'
@@ -73,7 +72,8 @@ export function handleSegmentResizeEnd (event) {
 
   draggingResize.segmentEl.classList.add('immediate-show-drag-handles')
 
-  removeGuides(draggingResize.segmentEl)
+  // todo: refactor
+  window.dispatchEvent(new window.CustomEvent('stmx:hide_segment_guides', { detail: { dataNo: window.parseInt(draggingResize.segmentEl.dataNo, 10) } }))
 
   infoBubble.considerSegmentEl = draggingResize.segmentEl
   infoBubble.show(false)

--- a/assets/scripts/segments/resizing.js
+++ b/assets/scripts/segments/resizing.js
@@ -73,7 +73,7 @@ export function handleSegmentResizeEnd (event) {
   draggingResize.segmentEl.classList.add('immediate-show-drag-handles')
 
   // todo: refactor
-  window.dispatchEvent(new window.CustomEvent('stmx:hide_segment_guides', { detail: { dataNo: window.parseInt(draggingResize.segmentEl.dataNo, 10) } }))
+  window.dispatchEvent(new window.CustomEvent('stmx:hide_segment_guides'))
 
   infoBubble.considerSegmentEl = draggingResize.segmentEl
   infoBubble.show(false)


### PR DESCRIPTION
These drag guides had not been ported to React and were not being translated:

<img width="634" alt="screenshot 2018-06-26 09 39 44" src="https://user-images.githubusercontent.com/2553268/41936571-8711f648-795b-11e8-9d33-6effde30d64f.png">

This PR ports the vanilla JS to a React component, and moves the text from CSS content into inline elements that can be translated. Translation keys are proposed (`segment.resize.min` and `segment.resize.max`).

This PR does not introduce Redux state for dragging (though we likely will, eventually). It uses the stopgap method of custom events to communicate between vanilla JS and React.

With `handleSegmentResizeStart()` cleaned up, we also recognize an opportunity to remove the DOM element refs previously set in `SegmentDragHandles`.