### PR TITLE
Icon library thought-experiment

### DIFF
--- a/assets/css/_menus.scss
+++ b/assets/css/_menus.scss
@@ -169,11 +169,33 @@ body.safari .menu {
     background: fade-out($ui-colour, 0.5);
   }
 
-  @mixin menu-item-selected {
+  .svg-inline--fa {
+    display: none;
+  }
+
+  &.menu-item-selected .svg-inline--fa {
+    display: inline-block;
     position: absolute;
-    left: 0;
-    top: 5px;
-    width: 32px;
+    margin-left: -16px;
+    margin-top: 2px;
+    font-size: 12px;
+    color: #1c99ce;
+
+    [dir='rtl'] & {
+      margin-left: auto;
+      margin-right: -16px;
+    }
+  }
+
+  &.menu-item-loading::before {
+    @include loading-spinner;
+
+    content: '';
+    position: absolute;
+    left: 16px;
+    top: 9px;
+    width: 13px;
+    height: 13px;
     padding-right: 3px;
     box-sizing: border-box;
     text-align: right;
@@ -187,25 +209,6 @@ body.safari .menu {
       padding-left: 3px;
       text-align: left;
     }
-  }
-
-  &.menu-item-selected::before {
-    @include menu-item-selected;
-
-    content: '✓';
-  }
-
-  &.menu-item-loading::before {
-    @include menu-item-selected;
-    @include loading-spinner;
-
-    content: '';
-
-    // Overrides menu-item-selected
-    left: 16px;
-    top: 9px;
-    width: 13px;
-    height: 13px;
 
     // Overrides loading-spinner
     border-width: 2px;

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -22,6 +22,10 @@ import './vendor/polyfills/Element.remove'
 // Redux
 import store from './store'
 
+// Font Awesome
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCheck } from '@fortawesome/free-solid-svg-icons'
+
 // Main object
 import { initialize } from './app/initialization'
 import App from './app/App'
@@ -33,6 +37,9 @@ if (window.location.hostname === 'streetmix.net' || window.location.hostname ===
     whitelistUrls: [/streetmix\.net/, /www\.streetmix\.net/]
   }).install()
 }
+
+// Load Font-Awesome icons
+library.add(faCheck)
 
 // Mount React components
 ReactDOM.render(

--- a/assets/scripts/menus/LocaleSelect.jsx
+++ b/assets/scripts/menus/LocaleSelect.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { FormattedMessage } from 'react-intl'
 import { DEFAULT_LOCALE } from '../locales/constants'
 import { getAvailableLocales, getActualLocaleFromRequested } from '../locales/locale'
@@ -34,6 +35,7 @@ export default class LocaleSelect extends React.Component {
 
       return (
         <li className={classNames.join(' ')} key={locale.value} onClick={(event) => this.props.selectLocale(locale.value)}>
+          <FontAwesomeIcon icon="check" />
           {/* &#x200E; prevents trailing parentheses from going in the wrong place in rtl languages */}
           <span>{locale.label}&#x200E;</span>
           <span className="menu-item-subtext">

--- a/assets/scripts/menus/SettingsMenu.jsx
+++ b/assets/scripts/menus/SettingsMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { FormattedMessage } from 'react-intl'
 import Menu from './Menu'
 import LocaleSelect from './LocaleSelect'
@@ -63,10 +64,12 @@ export class SettingsMenu extends React.PureComponent {
         </h2>
         <ul className="menu-item-group">
           <li className={`menu-item ${(this.props.units === SETTINGS_UNITS_METRIC) ? 'menu-item-selected' : ''}`} onClick={this.selectMetric}>
+            <FontAwesomeIcon icon="check" />
             {/* &#x200E; prevents trailing parentheses from going in the wrong place in rtl languages */}
             <FormattedMessage id="settings.units.metric" defaultMessage="Metric units (meters)" />&#x200E;
           </li>
           <li className={`menu-item ${(this.props.units === SETTINGS_UNITS_IMPERIAL) ? 'menu-item-selected' : ''}`} onClick={this.selectImperial}>
+            <FontAwesomeIcon icon="check" />
             <FormattedMessage id="settings.units.imperial" defaultMessage="Imperial units (feet)" />&#x200E;
           </li>
         </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -176,6 +176,36 @@
         }
       }
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.0.tgz",
+      "integrity": "sha512-raAiqWiXGZeQpFzz5fpLa6EQR3kSAK1cT5qaUanB9h4FatXvKEOPutDyeGQsF0hRtGfMb518Mzc7+LjBPDJCOg=="
+    },
+    "@fortawesome/fontawesome-svg-core": {
+      "version": "1.2.0-14",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.0-14.tgz",
+      "integrity": "sha512-V13Ou3UZ+Y0J5WTnhHDUmZFsz8ycxAyGaowrrPu7uuZXVT78/l4OCrOP6y5U6PdZoy3VJbZvkxCXZyTA6C32fA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.0-9"
+      }
+    },
+    "@fortawesome/free-solid-svg-icons": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.1.0.tgz",
+      "integrity": "sha512-MijNhBFEporjnyg1BDnyBWwypFa+RkmQFqX94NZa7xWGIKirvujw2JG0BRR9jQZPFHcI4pRzhXMxBxUUi786yA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.0"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.0.tgz",
+      "integrity": "sha512-CFulvjNIz/Z8SQ/Wikm8iPCiYDMVJKGVVh+9oxESpOgN8TIIK+bYOGv4HjOhjKKpKEHmns3n5vC/m6ormM8Y7A==",
+      "requires": {
+        "humps": "^2.0.1",
+        "prop-types": "^15.5.10"
+      }
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
@@ -7576,6 +7606,11 @@
           }
         }
       }
+    },
+    "humps": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/humps/-/humps-2.0.1.tgz",
+      "integrity": "sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao="
     },
     "husky": {
       "version": "0.14.3",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
     ]
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "1.2.0-14",
+    "@fortawesome/free-solid-svg-icons": "5.1.0",
+    "@fortawesome/react-fontawesome": "0.1.0",
     "@sendgrid/mail": "6.3.1",
     "@streetmix/icons": "0.4.4",
     "@streetmix/illustrations": "0.4.1",


### PR DESCRIPTION
When we shipped the settings menu I was not quite satisfied with the checkmark that we used there. It didn't seem to fit with the visual language there. Moreover, it relied entirely on system fonts to display it, which means we were up to the whims of the system. Here's what it looks like now (on Mac):

<img width="277" alt="screenshot 2018-06-27 09 17 06" src="https://user-images.githubusercontent.com/2553268/41988980-d33df052-7a0b-11e8-982a-4ae0adf9fec2.png">

Here's what it looks like (on Windows):

![screenshot 2018-06-27 11 39 43](https://user-images.githubusercontent.com/2553268/41989179-65fea6de-7a0c-11e8-82f8-735c06e38620.png)

On Windows the font used is much lighter and positioned at a slightly awkward baseline compared to the rest of the text.

I've been a big fan of [Font Awesome](https://fontawesome.com/), and it's also the icon library of choice for [Semantic UI](https://react.semantic-ui.com/) which is my go-to UI library, but neither is currently incorporated into Streetmix. As we build more functionality we may be considering importing those libraries to help us out. While looking into it more, I came across their checkmark, which is just what I had in mind (perhaps it's something I was already familiar with?): https://fontawesome.com/icons/check?style=solid

This PR is a thought experiment which imports the Font Awesome React bindings to display this checkmark, like so:

<img width="294" alt="screenshot 2018-06-27 09 16 48" src="https://user-images.githubusercontent.com/2553268/41989175-621d2e50-7a0c-11e8-9421-28e2ffad6b22.png">

However, it would be much simpler to use the `<svg>` code as-is, rather than import an entire library to add one icon. Therefore, we open ourselves up to this question:

**Do we want to use Font Awesome icons more in the future?**

The benefits of this include:

- Using [Plus](https://fontawesome.com/icons/plus?style=solid)/[Minus](https://fontawesome.com/icons/minus?style=solid) icons for increase/decrease buttons instead of `+` / `-` text. These are easier to read.
- Use [Undo](https://fontawesome.com/icons/undo-alt?style=solid)/[Redo](https://fontawesome.com/icons/redo-alt?style=solid) icons instead of text. In other languages, undo/redo can be very long. We currently complicate our code to recalculate of element widths to handle this text.
- Use a [Remove](https://fontawesome.com/icons/trash?style=solid) icon instead of text. In the early days, we had our [own icon](https://github.com/streetmix/icons/blob/master/svg/trashcan.svg), this was removed in favor of something more readable, which was just a text label. We can reconsider whether using a 3rd-party icon is more readable now.
- Have [brand icons](https://fontawesome.com/icons?d=gallery&s=brands) already ready for us to use. We currently don't have a Google icon (cc @flickz). Furthermore, this may mean we no longer need to maintain our own copy of the Twitter, Facebook, and GitHub icons.
- We have the library in place for more UI situations in which icons may be needed.
- Using this is free, with an affordable and non-expiring license in case need the Pro license.

Cons:

- Yet Another Library. The tradeoff between maintaining code / assets ourselves vs letting someone else maintain code and assets is not always a non-brainer, because the cost associated with dealing with large changes being made on the external side is punctuated and less predictable.
- Possibly much more additional byte overhead. (aka: increases loading times.)
- Satiation of certain types of UI, when it becomes "too overused," makes Streetmix look "less unique." Although, to be fair, this is not always a bad thing. The goal is to make the UI clear and immediately readable, so judicious use of common assets can be a strength.

All that being said, we're going to change the checkmark icon; the question is whether we want to incorporate Font-Awesome _now_, or implement this checkmark in a much more lightweight way, saving the consideration of Font-Awesome for further down the line.
