### PR TITLE
Add font-awesome icons in some other spots

### DIFF
--- a/assets/css/_buttons.scss
+++ b/assets/css/_buttons.scss
@@ -57,6 +57,10 @@ a.button-like {
   text-decoration: none;
   -webkit-align-items: flex-start !important;
 
+  &:not([disabled]) .svg-inline--fa {
+    color: #231f20;
+  }
+
   &:hover {
     background-color: mix($ui-colour, white, 70%);
   }
@@ -69,6 +73,7 @@ a.button-like {
     border-top-color: desaturate($ui-colour, 100%);
     border-bottom-color: desaturate($ui-colour, 100%);
     background-color: desaturate(fade-out($ui-colour, 0.7), 100%);
+    color: #999 !important;
     cursor: auto;
 
     &:hover {

--- a/assets/css/_buttons.scss
+++ b/assets/css/_buttons.scss
@@ -6,6 +6,7 @@ button.scroll,
   top: 0;
   width: 25px;
   height: 40px;
+  padding: 0;
   cursor: pointer;
 
   &[disabled] {

--- a/assets/css/_info-bubble.scss
+++ b/assets/css/_info-bubble.scss
@@ -45,6 +45,16 @@
     fill: #231f20;
   }
 
+  .svg-inline--fa {
+    color: #231f20;
+    vertical-align: -0.1em;
+    height: 11px;
+  }
+
+  button[disabled] .svg-inline--fa {
+    color: #999;
+  }
+
   .variants {
     text-align: left;
     padding: 7px 8px 5px;

--- a/assets/css/_info-bubble.scss
+++ b/assets/css/_info-bubble.scss
@@ -46,13 +46,8 @@
   }
 
   .svg-inline--fa {
-    color: #231f20;
     vertical-align: -0.1em;
     height: 11px;
-  }
-
-  button[disabled] .svg-inline--fa {
-    color: #999;
   }
 
   .variants {

--- a/assets/css/_menus.scss
+++ b/assets/css/_menus.scss
@@ -59,12 +59,18 @@
     resize: none;
   }
 
-  .icon {
+  .icon,
+  .svg-inline--fa {
     position: absolute;
     top: 0.75em;
     left: 0.75em;
     width: 16px;
     height: 16px;
+
+    [dir='rtl'] {
+      left: auto;
+      right: 0.75em;
+    }
   }
 }
 
@@ -169,22 +175,22 @@ body.safari .menu {
     background: fade-out($ui-colour, 0.5);
   }
 
-  .svg-inline--fa {
+  .fa-check {
     display: none;
-  }
-
-  &.menu-item-selected .svg-inline--fa {
-    display: inline-block;
-    position: absolute;
-    margin-left: -16px;
-    margin-top: 2px;
-    font-size: 12px;
+    left: 1.25em;
+    margin-top: -1px;
+    width: 12px;
+    height: 12px;
     color: #1c99ce;
 
     [dir='rtl'] & {
-      margin-left: auto;
-      margin-right: -16px;
+      left: auto;
+      right: 1.25em;
     }
+  }
+
+  &.menu-item-selected .fa-check {
+    display: inline-block;
   }
 
   &.menu-item-loading::before {
@@ -233,9 +239,11 @@ body.safari .menu {
   line-height: 18px;
 }
 
-[dir='rtl'] {
-  .menu .icon {
-    left: auto;
-    right: 0.75em;
-  }
+.fa-facebook,
+.fa-facebook-square {
+  color: #3b5998;
+}
+
+.fa-twitter {
+  color: #1da1f2;
 }

--- a/assets/scripts/app/__tests__/NotificationBar.test.js
+++ b/assets/scripts/app/__tests__/NotificationBar.test.js
@@ -3,6 +3,7 @@ import React from 'react'
 import NotificationBar from '../NotificationBar'
 import { shallowWithIntl, mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
 import { mockIntl } from '../../../../test/__mocks__/react-intl'
+import { initIcons } from '../../ui/icons'
 
 const TEST_NOTIFICATION = {
   display: true,
@@ -13,6 +14,10 @@ const TEST_NOTIFICATION = {
 }
 
 describe('NotificationBar', () => {
+  beforeAll(() => {
+    initIcons()
+  })
+
   it('renders without crashing', () => {
     const wrapper = shallowWithIntl(<NotificationBar intl={mockIntl} notification={TEST_NOTIFICATION} />)
     expect(wrapper.exists()).toEqual(true)

--- a/assets/scripts/info_bubble/BuildingHeightControl.jsx
+++ b/assets/scripts/info_bubble/BuildingHeightControl.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { injectIntl, intlShape } from 'react-intl'
 import { debounce } from 'lodash'
 import { MAX_BUILDING_HEIGHT, BUILDINGS, calculateRealHeightNumber } from '../segments/buildings'
@@ -265,7 +266,7 @@ class BuildingHeightControl extends React.Component {
           onClick={this.onClickIncrement}
           disabled={isNotFloored || (this.props.value >= MAX_BUILDING_HEIGHT)}
         >
-          +
+          <FontAwesomeIcon icon="plus" />
         </button>
         {inputEl}
         <button
@@ -275,7 +276,7 @@ class BuildingHeightControl extends React.Component {
           onClick={this.onClickDecrement}
           disabled={isNotFloored || (this.props.value <= 1)}
         >
-          –
+          <FontAwesomeIcon icon="minus" />
         </button>
       </div>
     )

--- a/assets/scripts/info_bubble/WidthControl.jsx
+++ b/assets/scripts/info_bubble/WidthControl.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { injectIntl, intlShape } from 'react-intl'
 import { debounce } from 'lodash'
 import { trackEvent } from '../app/event_tracking'
@@ -265,7 +266,7 @@ class WidthControl extends React.Component {
           onClick={this.onClickDecrement}
           disabled={this.props.value <= MIN_SEGMENT_WIDTH}
         >
-          –
+          <FontAwesomeIcon icon="minus" />
         </button>
         {inputEl}
         <button
@@ -275,7 +276,7 @@ class WidthControl extends React.Component {
           onClick={this.onClickIncrement}
           disabled={this.props.value >= MAX_SEGMENT_WIDTH}
         >
-          +
+          <FontAwesomeIcon icon="plus" />
         </button>
       </div>
     )

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -22,12 +22,8 @@ import './vendor/polyfills/Element.remove'
 // Redux
 import store from './store'
 
-// Font Awesome
-import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCheck, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons'
-import { fab } from '@fortawesome/free-brands-svg-icons'
-
 // Main object
+import { initIcons } from './ui/icons'
 import { initialize } from './app/initialization'
 import App from './app/App'
 
@@ -39,8 +35,8 @@ if (window.location.hostname === 'streetmix.net' || window.location.hostname ===
   }).install()
 }
 
-// Load Font-Awesome icons
-library.add(faCheck, faMinus, faPlus, fab)
+// Initialize Font-Awesome icons (this must be done before React component mounting.)
+initIcons()
 
 // Mount React components
 ReactDOM.render(

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -24,7 +24,7 @@ import store from './store'
 
 // Font Awesome
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { faCheck, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons'
 import { fab } from '@fortawesome/free-brands-svg-icons'
 
 // Main object
@@ -40,7 +40,7 @@ if (window.location.hostname === 'streetmix.net' || window.location.hostname ===
 }
 
 // Load Font-Awesome icons
-library.add(faCheck, fab)
+library.add(faCheck, faMinus, faPlus, fab)
 
 // Mount React components
 ReactDOM.render(

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -25,6 +25,7 @@ import store from './store'
 // Font Awesome
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
+import { fab } from '@fortawesome/free-brands-svg-icons'
 
 // Main object
 import { initialize } from './app/initialization'
@@ -39,7 +40,7 @@ if (window.location.hostname === 'streetmix.net' || window.location.hostname ===
 }
 
 // Load Font-Awesome icons
-library.add(faCheck)
+library.add(faCheck, fab)
 
 // Mount React components
 ReactDOM.render(

--- a/assets/scripts/menus/ContactMenu.jsx
+++ b/assets/scripts/menus/ContactMenu.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Menu from './Menu'
 
 export default class ContactMenu extends React.PureComponent {
@@ -13,9 +14,7 @@ export default class ContactMenu extends React.PureComponent {
           <FormattedMessage id="menu.contact.forums" defaultMessage="Discuss on the forums" />
         </a>
         <a href="https://twitter.com/intent/tweet?text=@streetmix" target="_blank" rel="noopener noreferrer">
-          <svg className="icon">
-            <use xlinkHref="#icon-twitter" />
-          </svg>
+          <FontAwesomeIcon icon={['fab', 'twitter']} />
           <FormattedMessage id="menu.contact.twitter" defaultMessage="Send a tweet to @streetmix" />
         </a>
         <a href="http://streetmix-slack.herokuapp.com/" target="_blank" rel="noopener noreferrer">

--- a/assets/scripts/menus/ContactMenu.jsx
+++ b/assets/scripts/menus/ContactMenu.jsx
@@ -2,15 +2,14 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Menu from './Menu'
+import Icon from '../ui/Icon'
 
 export default class ContactMenu extends React.PureComponent {
   render () {
     return (
       <Menu {...this.props}>
         <a href="http://forums.streetmix.net/" target="_blank">
-          <svg className="icon">
-            <use xlinkHref="#icon-forums" />
-          </svg>
+          <Icon icon="forums" />
           <FormattedMessage id="menu.contact.forums" defaultMessage="Discuss on the forums" />
         </a>
         <a href="https://twitter.com/intent/tweet?text=@streetmix" target="_blank" rel="noopener noreferrer">
@@ -18,9 +17,7 @@ export default class ContactMenu extends React.PureComponent {
           <FormattedMessage id="menu.contact.twitter" defaultMessage="Send a tweet to @streetmix" />
         </a>
         <a href="http://streetmix-slack.herokuapp.com/" target="_blank" rel="noopener noreferrer">
-          <svg className="icon">
-            <use xlinkHref="#icon-slack" />
-          </svg>
+          <Icon icon="slack" />
           <FormattedMessage id="menu.contact.slack" defaultMessage="Join Slack chat" />
         </a>
         <a href="http://blog.streetmix.net" target="_blank">

--- a/assets/scripts/menus/ContributeMenu.jsx
+++ b/assets/scripts/menus/ContributeMenu.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Menu from './Menu'
 import { trackEvent } from '../app/event_tracking'
 
@@ -20,9 +21,7 @@ export default class ContributeMenu extends React.PureComponent {
     return (
       <Menu {...this.props}>
         <a href="https://github.com/streetmix/streetmix/" target="_blank" rel="noopener noreferrer" onClick={this.onClickGitHub}>
-          <svg className="icon">
-            <use xlinkHref="#icon-github" />
-          </svg>
+          <FontAwesomeIcon icon={['fab', 'github']} />
           <FormattedMessage id="menu.contribute.opensource" defaultMessage="Contribute to open source" />
         </a>
         <a href="https://opencollective.com/streetmix/" target="_blank" rel="noopener noreferrer" onClick={this.onClickDonate}>

--- a/assets/scripts/menus/LocaleSelect.jsx
+++ b/assets/scripts/menus/LocaleSelect.jsx
@@ -35,7 +35,7 @@ export default class LocaleSelect extends React.Component {
 
       return (
         <li className={classNames.join(' ')} key={locale.value} onClick={(event) => this.props.selectLocale(locale.value)}>
-          <FontAwesomeIcon icon="check" />
+          {(locale.value === actuallySelectedLocale) && <FontAwesomeIcon icon="check" />}
           {/* &#x200E; prevents trailing parentheses from going in the wrong place in rtl languages */}
           <span>{locale.label}&#x200E;</span>
           <span className="menu-item-subtext">

--- a/assets/scripts/menus/SettingsMenu.jsx
+++ b/assets/scripts/menus/SettingsMenu.jsx
@@ -64,12 +64,12 @@ export class SettingsMenu extends React.PureComponent {
         </h2>
         <ul className="menu-item-group">
           <li className={`menu-item ${(this.props.units === SETTINGS_UNITS_METRIC) ? 'menu-item-selected' : ''}`} onClick={this.selectMetric}>
-            <FontAwesomeIcon icon="check" />
+            {(this.props.units === SETTINGS_UNITS_METRIC) && <FontAwesomeIcon icon="check" />}
             {/* &#x200E; prevents trailing parentheses from going in the wrong place in rtl languages */}
             <FormattedMessage id="settings.units.metric" defaultMessage="Metric units (meters)" />&#x200E;
           </li>
           <li className={`menu-item ${(this.props.units === SETTINGS_UNITS_IMPERIAL) ? 'menu-item-selected' : ''}`} onClick={this.selectImperial}>
-            <FontAwesomeIcon icon="check" />
+            {(this.props.units === SETTINGS_UNITS_IMPERIAL) && <FontAwesomeIcon icon="check" />}
             <FormattedMessage id="settings.units.imperial" defaultMessage="Imperial units (feet)" />&#x200E;
           </li>
         </ul>

--- a/assets/scripts/menus/ShareMenu.jsx
+++ b/assets/scripts/menus/ShareMenu.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Menu from './Menu'
 
 import { FACEBOOK_APP_ID } from '../app/config'
@@ -169,9 +170,7 @@ export class ShareMenu extends React.Component {
           rel="noopener noreferrer"
           onClick={this.onClickShareViaTwitter}
         >
-          <svg className="icon">
-            <use xlinkHref="#icon-twitter" />
-          </svg>
+          <FontAwesomeIcon icon={['fab', 'twitter']} />
           <FormattedMessage id="menu.share.twitter" defaultMessage="Share using Twitter" />
         </a>
         <a
@@ -181,9 +180,7 @@ export class ShareMenu extends React.Component {
           rel="noopener noreferrer"
           onClick={this.onClickShareViaFacebook}
         >
-          <svg className="icon">
-            <use xlinkHref="#icon-facebook" />
-          </svg>
+          <FontAwesomeIcon icon={['fab', 'facebook-square']} />
           <FormattedMessage id="menu.share.facebook" defaultMessage="Share using Facebook" />
         </a>
         <a href="#" onClick={printImage}>

--- a/assets/scripts/ui/CloseButton.jsx
+++ b/assets/scripts/ui/CloseButton.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { injectIntl, intlShape } from 'react-intl'
 
 class CloseButton extends React.Component {
@@ -26,7 +27,7 @@ class CloseButton extends React.Component {
         onClick={this.props.onClick}
         title={title}
       >
-        ×
+        <FontAwesomeIcon icon={['far', 'times-circle']} />
       </button>
     )
   }

--- a/assets/scripts/ui/Icon.jsx
+++ b/assets/scripts/ui/Icon.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class Icon extends React.Component {
+  static propTypes = {
+    icon: PropTypes.string.isRequired
+  }
+
+  render () {
+    return (
+      <svg className="icon">
+        <use xlinkHref={`#icon-${this.props.icon}`} />
+      </svg>
+    )
+  }
+}

--- a/assets/scripts/ui/Scrollable.jsx
+++ b/assets/scripts/ui/Scrollable.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react'
 import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { animate } from '../util/helpers'
 
 export default class Scrollable extends React.PureComponent {
@@ -102,14 +103,14 @@ export default class Scrollable extends React.PureComponent {
           onClick={this.onClickLeft}
           ref={(ref) => { this.leftButton = ref }}
         >
-          «
+          <FontAwesomeIcon icon="chevron-left" />
         </button>
         <button
           className="scrollable scroll-right"
           onClick={this.onClickRight}
           ref={(ref) => { this.rightButton = ref }}
         >
-          »
+          <FontAwesomeIcon icon="chevron-right" />
         </button>
       </div>
     )

--- a/assets/scripts/ui/__tests__/CloseButton.test.js
+++ b/assets/scripts/ui/__tests__/CloseButton.test.js
@@ -3,10 +3,15 @@ import React from 'react'
 import CloseButton from '../CloseButton'
 import { mockIntl } from '../../../../test/__mocks__/react-intl'
 import { mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
+import { initIcons } from '../../ui/icons'
 
 const onClick = jest.fn()
 
 describe('CloseButton', () => {
+  beforeAll(() => {
+    initIcons()
+  })
+
   it('should renders without crashing', () => {
     const wrapper = mountWithIntl(<CloseButton onClick={onClick} />)
     expect(wrapper.find('button').length).toEqual(1)

--- a/assets/scripts/ui/icons.js
+++ b/assets/scripts/ui/icons.js
@@ -1,9 +1,15 @@
 // Font Awesome
 import { library } from '@fortawesome/fontawesome-svg-core'
-import { faCheck, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons'
+import {
+  faCheck,
+  faMinus,
+  faPlus,
+  faChevronRight,
+  faChevronLeft
+} from '@fortawesome/free-solid-svg-icons'
 import { fab } from '@fortawesome/free-brands-svg-icons'
 
 // Load Font-Awesome icons
 export function initIcons () {
-  library.add(faCheck, faMinus, faPlus, fab)
+  library.add(faCheck, faMinus, faPlus, faChevronRight, faChevronLeft, fab)
 }

--- a/assets/scripts/ui/icons.js
+++ b/assets/scripts/ui/icons.js
@@ -1,0 +1,9 @@
+// Font Awesome
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCheck, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+
+// Load Font-Awesome icons
+export function initIcons () {
+  library.add(faCheck, faMinus, faPlus, fab)
+}

--- a/assets/scripts/ui/icons.js
+++ b/assets/scripts/ui/icons.js
@@ -7,9 +7,10 @@ import {
   faChevronRight,
   faChevronLeft
 } from '@fortawesome/free-solid-svg-icons'
+import { faTimesCircle } from '@fortawesome/free-regular-svg-icons'
 import { fab } from '@fortawesome/free-brands-svg-icons'
 
 // Load Font-Awesome icons
 export function initIcons () {
-  library.add(faCheck, faMinus, faPlus, faChevronRight, faChevronLeft, fab)
+  library.add(faCheck, faMinus, faPlus, faChevronRight, faChevronLeft, faTimesCircle, fab)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,14 @@
         "@fortawesome/fontawesome-common-types": "^0.2.0"
       }
     },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.1.0.tgz",
+      "integrity": "sha512-VKkfgrEjso9Dsc4TgV5UKqtgxs7bv2sgIsulf6X2rwsVDQqIKOxTZ2tcftGSa4wvRPIJ3lNcrmEMLwDWub593w==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.0"
+      }
+    },
     "@fortawesome/free-solid-svg-icons": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,14 @@
         "@fortawesome/fontawesome-common-types": "^0.2.0-9"
       }
     },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.1.0.tgz",
+      "integrity": "sha512-ILEJHR7Wiz9kJMtMgRh3EXNZmxUZW6z+3JQEN1TL02+aME7q+sHn3H8oOClti9XuIx5HckmbfevpBrl+fzeWCw==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.0"
+      }
+    },
     "@fortawesome/free-solid-svg-icons": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.0-14",
+    "@fortawesome/free-brands-svg-icons": "5.1.0",
     "@fortawesome/free-solid-svg-icons": "5.1.0",
     "@fortawesome/react-fontawesome": "0.1.0",
     "@sendgrid/mail": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.0-14",
     "@fortawesome/free-brands-svg-icons": "5.1.0",
+    "@fortawesome/free-regular-svg-icons": "5.1.0",
     "@fortawesome/free-solid-svg-icons": "5.1.0",
     "@fortawesome/react-fontawesome": "0.1.0",
     "@sendgrid/mail": "6.3.1",


### PR DESCRIPTION
- Brand icons for Twitter, Facebook, and GitHub.
- Custom icons (e.g. multicolor ones) that do not come from FontAwesome are now in a individual `<Icon/>` component. (It's possible to export these icons directly as SVG as well so as to not pollute the segment icon package (this is a future todo))
- Plus/Minus icons on buttons improves visibility over using default font (note: harder to do on the map; we would have to write custom zoom controls to do this)
- Left/right arrow icons on Scrollable component (again, for improved visibility)
- Close button (x) is now an icon as well.
- Refactors the checkmarks so that the elements are rendered (instead of hidden) only if menu item is actually selected
- All disabled buttons will be grayed out by default.