### PR TITLE
Segment drag guides now use the "active segment" identifier

### DIFF
--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -204,7 +204,7 @@ body.segment-resize-dragging .drag-handle.floating,
   position: absolute;
   z-index: $z-07-segment-guide;
   top: -75px;
-  bottom: 75px;
+  bottom: 120px;
   left: 50%; /* Will be overridden by component */
   box-sizing: border-box;
   pointer-events: none;

--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -200,16 +200,21 @@ body.segment-resize-dragging .drag-handle.floating,
   transform: none;
 }
 
-.segment-guide {
+.segment-guides {
   position: absolute;
   z-index: $z-07-segment-guide;
-  left: 50%;
   top: 0;
   bottom: 45px;
-  border-left: 1px dashed fade-out(black, 0.6);
-  border-right: 1px dashed fade-out(black, 0.6);
+  left: 50%; /* Will be overridden by component */
   box-sizing: border-box;
   pointer-events: none;
+}
+
+.segment-guide {
+  position: absolute;
+  height: 100%;
+  border-left: 1px dashed fade-out(black, 0.6);
+  border-right: 1px dashed fade-out(black, 0.6);
 }
 
 .segment-guide-max-before,
@@ -218,8 +223,6 @@ body.segment-resize-dragging .drag-handle.floating,
 .segment-guide-min-after {
   width: 50px;
   position: absolute;
-  box-sizing: border-box;
-  pointer-events: none;
   bottom: 400px;
   font-size: 11px;
   color: fade-out(black, 0.4);

--- a/assets/css/_segment.scss
+++ b/assets/css/_segment.scss
@@ -203,8 +203,8 @@ body.segment-resize-dragging .drag-handle.floating,
 .segment-guides {
   position: absolute;
   z-index: $z-07-segment-guide;
-  top: 0;
-  bottom: 45px;
+  top: -75px;
+  bottom: 75px;
   left: 50%; /* Will be overridden by component */
   box-sizing: border-box;
   pointer-events: none;

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -13,6 +13,7 @@ import StreetEditable from './StreetEditable'
 import SkyBackground from './SkyBackground'
 import ScrollIndicators from './ScrollIndicators'
 import Building from '../segments/Building'
+import SegmentDragGuides from '../segments/SegmentDragGuides'
 import EmptySegmentContainer from '../segments/EmptySegmentContainer'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { animate, getElAbsolutePos } from '../util/helpers'
@@ -222,7 +223,10 @@ class StreetView extends React.Component {
                 key={this.props.locale.locale}
                 messages={this.props.locale.messages}
               >
-                <EmptySegmentContainer />
+                <React.Fragment>
+                  <SegmentDragGuides />
+                  <EmptySegmentContainer />
+                </React.Fragment>
               </IntlProvider>
               <section id="street-section-dirt" style={dirtStyle} />
             </section>

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -20,6 +20,7 @@ import { cancelFadeoutControls, resumeFadeoutControls } from '../segments/resizi
 // import { trackEvent } from '../app/event_tracking'
 import { BUILDINGS } from '../segments/buildings'
 import { getSegmentInfo, getSegmentVariantInfo } from '../segments/info'
+import { getSegmentEl } from '../segments/view'
 import { loseAnyFocus } from '../util/focus'
 import { getElAbsolutePos } from '../util/helpers'
 import { setInfoBubbleMouseInside, updateHoverPolygon } from '../store/actions/infoBubble'
@@ -57,7 +58,7 @@ class InfoBubble extends React.Component {
 
     // Stores a ref to the element
     this.el = React.createRef()
-    this.segmentEl = this.getSegmentEl(props.position)
+    this.segmentEl = getSegmentEl(props.position)
     this.streetOuterEl = null
 
     this.state = {
@@ -123,7 +124,7 @@ class InfoBubble extends React.Component {
   }
 
   componentDidUpdate (prevProps, prevState, snapshot) {
-    this.segmentEl = this.getSegmentEl(this.props.position)
+    this.segmentEl = getSegmentEl(this.props.position)
     this.setInfoBubblePosition()
 
     // If info bubble changes, wake this back up if it's fading out
@@ -296,21 +297,6 @@ class InfoBubble extends React.Component {
     }
 
     return hoverPolygon
-  }
-
-  getSegmentEl (position) {
-    if (!position && position !== 0) return
-
-    let segmentEl
-    if (position === 'left') {
-      segmentEl = document.querySelectorAll('.street-section-building')[0]
-    } else if (position === 'right') {
-      segmentEl = document.querySelectorAll('.street-section-building')[1]
-    } else {
-      const segments = document.getElementById('street-section-editable').querySelectorAll('.segment')
-      segmentEl = segments[position]
-    }
-    return segmentEl
   }
 
   /**

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -246,7 +246,7 @@ class Segment extends React.Component {
               key={this.props.locale}
               messages={this.props.localeMessages}
             >
-              <SegmentDragGuides width={width} type={this.props.type} variantString={this.props.variantString} dataNo={this.props.dataNo} />
+              <SegmentDragGuides position={this.props.dataNo} />
             </IntlProvider>
           </React.Fragment>
         }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { IntlProvider } from 'react-intl'
 import MeasurementText from '../ui/MeasurementText'
 import SegmentCanvas from './SegmentCanvas'
 import SegmentDragHandles from './SegmentDragHandles'
-import SegmentDragGuides from './SegmentDragGuides'
 import { CSSTransition } from 'react-transition-group'
 import { getSegmentVariantInfo, getSegmentInfo } from '../segments/info'
 import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter, incrementSegmentWidth } from './resizing'
@@ -241,13 +239,6 @@ class Segment extends React.Component {
             </span>
             <span className={'grid' + (this.props.units === SETTINGS_UNITS_METRIC ? ' units-metric' : ' units-imperial')} />
             <SegmentDragHandles width={width} />
-            <IntlProvider
-              locale={this.props.locale}
-              key={this.props.locale}
-              messages={this.props.localeMessages}
-            >
-              <SegmentDragGuides position={this.props.dataNo} />
-            </IntlProvider>
           </React.Fragment>
         }
         <CSSTransition

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 import { TILE_SIZE } from './constants'
 import { getSegmentVariantInfo } from '../segments/info'
+import { getSegmentEl } from '../segments/view'
 import { MIN_SEGMENT_WIDTH } from '../segments/resizing'
 
 export class SegmentDragGuides extends React.Component {
@@ -52,11 +53,13 @@ export class SegmentDragGuides extends React.Component {
     })
   }
 
-  getStyle = (width) => {
+  getStyle = (width, centerline) => {
     const pixelWidth = width * TILE_SIZE
+
     return {
       width: `${pixelWidth}px`,
-      marginLeft: (-pixelWidth / 2) + 'px'
+      marginLeft: (-pixelWidth / 2) + 'px',
+      left: `${centerline}px`
     }
   }
 
@@ -96,11 +99,15 @@ export class SegmentDragGuides extends React.Component {
       )
     }
 
+    // Get the center of the segment (its left offset plus half its width)
+    const el = getSegmentEl(this.props.activeSegment)
+    const centerline = el.offsetLeft + (el.cssTransformLeft || 0) + (el.offsetWidth / 2)
+
     return (
-      <React.Fragment>
+      <div className="segment-guides" style={{ left: centerline }}>
         {minGuide}
         {maxGuide}
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -9,11 +9,8 @@ import { MIN_SEGMENT_WIDTH } from '../segments/resizing'
 
 export class SegmentDragGuides extends React.Component {
   static propTypes = {
-    activeSegment: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
-    segments: PropTypes.array,
+    activeSegment: PropTypes.number,
+    segment: PropTypes.object,
     remainingWidth: PropTypes.number
   }
 
@@ -53,20 +50,19 @@ export class SegmentDragGuides extends React.Component {
     })
   }
 
-  getStyle = (width, centerline) => {
+  getStyle = (width) => {
     const pixelWidth = width * TILE_SIZE
 
     return {
       width: `${pixelWidth}px`,
-      marginLeft: (-pixelWidth / 2) + 'px',
-      left: `${centerline}px`
+      marginLeft: (-pixelWidth / 2) + 'px'
     }
   }
 
   render () {
-    if (!this.state.show || typeof this.props.activeSegment !== 'number') return null
+    if (!this.state.show || !this.props.segment) return null
 
-    const segment = this.props.segments[this.props.activeSegment]
+    const segment = this.props.segment
     const variantInfo = getSegmentVariantInfo(segment.type, segment.variantString)
     let minGuide, maxGuide
 
@@ -114,8 +110,8 @@ export class SegmentDragGuides extends React.Component {
 
 function mapStateToProps (state) {
   return {
-    activeSegment: state.ui.activeSegment,
-    segments: state.street.segments,
+    activeSegment: (typeof state.ui.activeSegment === 'number') ? state.ui.activeSegment : null,
+    segment: state.street.segments[state.ui.activeSegment] || null,
     remainingWidth: state.street.remainingWidth
   }
 }

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -95,9 +95,10 @@ export class SegmentDragGuides extends React.Component {
       )
     }
 
-    // Get the center of the segment (its left offset plus half its width)
+    // Calculate the centerline of the segment (its left offset plus half its width)
+    // Adjusting the centerline by 1px to the left seems to "look" better
     const el = getSegmentEl(this.props.activeSegment)
-    const centerline = el.offsetLeft + (el.cssTransformLeft || 0) + (el.offsetWidth / 2)
+    const centerline = el.offsetLeft + (el.cssTransformLeft || 0) + (el.offsetWidth / 2) - 1
 
     return (
       <div className="segment-guides" style={{ left: centerline }}>

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -8,10 +8,8 @@ import { MIN_SEGMENT_WIDTH } from '../segments/resizing'
 
 export class SegmentDragGuides extends React.Component {
   static propTypes = {
-    type: PropTypes.string.isRequired,
-    variantString: PropTypes.string.isRequired,
-    width: PropTypes.number,
-    dataNo: PropTypes.number,
+    position: PropTypes.number,
+    segments: PropTypes.array,
     remainingWidth: PropTypes.number
   }
 
@@ -40,7 +38,7 @@ export class SegmentDragGuides extends React.Component {
   }
 
   showGuides = (event) => {
-    if (event.detail.dataNo === this.props.dataNo) {
+    if (event.detail.dataNo === this.props.position) {
       this.setState({
         show: true
       })
@@ -64,7 +62,8 @@ export class SegmentDragGuides extends React.Component {
   render () {
     if (!this.state.show) return null
 
-    const variantInfo = getSegmentVariantInfo(this.props.type, this.props.variantString)
+    const segment = this.props.segments[this.props.position]
+    const variantInfo = getSegmentVariantInfo(segment.type, segment.variantString)
     let minGuide, maxGuide
 
     if (variantInfo.minWidth) {
@@ -76,7 +75,7 @@ export class SegmentDragGuides extends React.Component {
       )
     }
 
-    const remainingWidth = this.props.remainingWidth + (this.props.width / TILE_SIZE)
+    const remainingWidth = this.props.remainingWidth + segment.width
 
     if (remainingWidth &&
       (((!variantInfo.minWidth) && (remainingWidth >= MIN_SEGMENT_WIDTH)) || (remainingWidth >= variantInfo.minWidth)) &&
@@ -107,6 +106,7 @@ export class SegmentDragGuides extends React.Component {
 
 function mapStateToProps (state) {
   return {
+    segments: state.street.segments,
     remainingWidth: state.street.remainingWidth
   }
 }

--- a/assets/scripts/segments/SegmentDragGuides.jsx
+++ b/assets/scripts/segments/SegmentDragGuides.jsx
@@ -8,7 +8,10 @@ import { MIN_SEGMENT_WIDTH } from '../segments/resizing'
 
 export class SegmentDragGuides extends React.Component {
   static propTypes = {
-    position: PropTypes.number,
+    activeSegment: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
     segments: PropTypes.array,
     remainingWidth: PropTypes.number
   }
@@ -38,11 +41,9 @@ export class SegmentDragGuides extends React.Component {
   }
 
   showGuides = (event) => {
-    if (event.detail.dataNo === this.props.position) {
-      this.setState({
-        show: true
-      })
-    }
+    this.setState({
+      show: true
+    })
   }
 
   hideGuides = (event) => {
@@ -60,9 +61,9 @@ export class SegmentDragGuides extends React.Component {
   }
 
   render () {
-    if (!this.state.show) return null
+    if (!this.state.show || typeof this.props.activeSegment !== 'number') return null
 
-    const segment = this.props.segments[this.props.position]
+    const segment = this.props.segments[this.props.activeSegment]
     const variantInfo = getSegmentVariantInfo(segment.type, segment.variantString)
     let minGuide, maxGuide
 
@@ -106,6 +107,7 @@ export class SegmentDragGuides extends React.Component {
 
 function mapStateToProps (state) {
   return {
+    activeSegment: state.ui.activeSegment,
     segments: state.street.segments,
     remainingWidth: state.street.remainingWidth
   }

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -407,3 +407,26 @@ export function segmentsChanged (readDataFromDom = true, reassignElementRefs = f
 
   saveStreetToServerIfNecessary()
 }
+
+/**
+ * Given the position of a segment or building, retrieve a reference to its
+ * DOM element.
+ *
+ * @param {Number|string} position - either "left" or "right" for building,
+ *              or a number for the position of the segment. Should be
+ *              the `dataNo` or `position` variables.
+ */
+export function getSegmentEl (position) {
+  if (!position && position !== 0) return
+
+  let segmentEl
+  if (position === 'left') {
+    segmentEl = document.querySelectorAll('.street-section-building')[0]
+  } else if (position === 'right') {
+    segmentEl = document.querySelectorAll('.street-section-building')[1]
+  } else {
+    const segments = document.getElementById('street-section-editable').querySelectorAll('.segment')
+    segmentEl = segments[position]
+  }
+  return segmentEl
+}


### PR DESCRIPTION
Because we now have an "active segment" (#1083) we are refactoring active-segment-related UI to start using it. Drag guides were a recent port to React, and are view-only, so it's an easier step to take to give this pattern a try.

Instead of rendering invisible drag guides on every segment, and then selectively showing one when a segment handle is being dragged, we now render only one set of drag guides for the entire street. Because we already know the active segment during the drag action, this component knows what to render.

