### PR TITLE
Update gallery sign-in-prompt to remove Twitter

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -286,7 +286,8 @@
     "delete-street-tooltip": "Delete street",
     "street-count": "{count, plural, one {# street} other {# streets}}",
     "no-streets": "No streets yet",
-    "sign-in": "Sign in with Twitter for your personal street gallery"
+    "sign-in": "Sign in with Twitter for your personal street gallery",
+    "sign-in-prompt": "Sign in to see your personal street gallery"
   },
   "users": {
     "anonymous": "Anonymous",


### PR DESCRIPTION
Add a new version of the gallery's sign in string to not include Twitter (in preparation for new sign-in flow).