### PR TITLE
Switches Portuguese (Brazil) to level 3

### DIFF
--- a/app/data/locales.json
+++ b/app/data/locales.json
@@ -60,7 +60,7 @@
     "name": "Portuguese (Brazil)",
     "value": "pt-BR",
     "key": "i18n.lang.pt-br",
-    "level": 2
+    "level": 3
   },
   {
     "label": "Español",


### PR DESCRIPTION
This switches Portuguese to "Level 3", meaning it will show up publicly in production Streetmix.

When we are ready to launch Portuguese, we can merge this.