### PR TITLE
Add Simplified Chinese + related updates

### DIFF
--- a/app/data/locales.json
+++ b/app/data/locales.json
@@ -7,11 +7,11 @@
     "level": 2
   },
   {
-    "label": "中文",
-    "name": "Chinese (Traditional)",
-    "value": "zh-Hant",
-    "key": "i18n.lang.zh-hant",
-    "level": 2
+    "label": "Deutsch",
+    "name": "German",
+    "value": "de",
+    "key": "i18n.lang.de",
+    "level": 1
   },
   {
     "label": "English",
@@ -19,6 +19,20 @@
     "value": "en",
     "key": "i18n.lang.en",
     "level": 4
+  },
+  {
+    "label": "Español",
+    "name": "Spanish",
+    "value": "es",
+    "key": "i18n.lang.es",
+    "level": 1
+  },
+  {
+    "label": "Español (México)",
+    "name": "Spanish (Mexico)",
+    "value": "es-MX",
+    "key": "i18n.lang.es-mx",
+    "level": 3
   },
   {
     "label": "Suomi",
@@ -33,13 +47,6 @@
     "value": "fr",
     "key": "i18n.lang.fr",
     "level": 3
-  },
-  {
-    "label": "Deutsch",
-    "name": "German",
-    "value": "de",
-    "key": "i18n.lang.de",
-    "level": 1
   },
   {
     "label": "日本語",
@@ -70,24 +77,24 @@
     "level": 2
   },
   {
-    "label": "Español",
-    "name": "Spanish",
-    "value": "es",
-    "key": "i18n.lang.es",
-    "level": 1
-  },
-  {
-    "label": "Español (México)",
-    "name": "Spanish (Mexico)",
-    "value": "es-MX",
-    "key": "i18n.lang.es-mx",
-    "level": 3
-  },
-  {
     "label": "Svenska",
     "name": "Swedish",
     "value": "sv",
     "key": "i18n.lang.sv",
     "level": 1
+  },
+  {
+    "label": "简体中文",
+    "name": "Simplified Chinese",
+    "value": "zh-Hans",
+    "key": "i18n.lang.zh-hans",
+    "level": 2
+  },
+  {
+    "label": "繁體中文",
+    "name": "Traditional Chinese",
+    "value": "zh-Hant",
+    "key": "i18n.lang.zh-hant",
+    "level": 2
   }
 ]

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -309,7 +309,8 @@
       "pt-br": "Portuguese (Brazil)",
       "ru": "Russian",
       "sv": "Swedish",
-      "zh-hant": "Chinese (Traditional)"
+      "zh-hans": "Simplified Chinese",
+      "zh-hant": "Traditional Chinese"
     }
   }
 }

--- a/assets/scripts/locales/locale.js
+++ b/assets/scripts/locales/locale.js
@@ -23,6 +23,7 @@ import fr from 'react-intl/locale-data/fr'
 import ja from 'react-intl/locale-data/ja'
 import pl from 'react-intl/locale-data/pl'
 import pt from 'react-intl/locale-data/pt'
+import ru from 'react-intl/locale-data/ru'
 import sv from 'react-intl/locale-data/sv'
 import zh from 'react-intl/locale-data/zh'
 
@@ -31,7 +32,7 @@ import zh from 'react-intl/locale-data/zh'
  */
 export async function initLocale () {
   // Add react-intl locale data
-  addLocaleData([...ar, ...es, ...de, ...fi, ...fr, ...ja, ...pl, ...pt, ...sv, ...zh])
+  addLocaleData([...ar, ...es, ...de, ...fi, ...fr, ...ja, ...pl, ...pt, ...ru, ...sv, ...zh])
 
   // Default language is set by browser, or is English if undetermined
   const defaultLocale = navigator.language || DEFAULT_LOCALE


### PR DESCRIPTION
Our Chinese translation has evolved since it was originally created. We now will be launching a Traditional and Simplified Chinese translation of Streetmix.

This PR adds Simplified as a language option and adjusts labels to fit having two versions. A Chinese translator (Crystal) was consulted on these labels, and she recommended not using parentheses for our context. This also updates the new translation strings for this in `main.json`.

The PR also re-orders the list in locales.json to be by 2 letter language code (this is just to set up a way to keep the file organized moving forward; it does not affect how the languages are displayed in the UI). Currently, it looks like languages are being automatically sorted in the UI by Unicode character codes in the native language's spelling (e.g. Suomi (Finnish) goes after Polish (Polski), and 日本語 (Japanese) comes next as its script comes afterwards in Unicode). This is a good way of sorting, and it makes sense for us to keep this way for now.
_Note: there are multiple approaches to sorting languages. See https://ux.stackexchange.com/questions/17064/how-do-you-sort-a-list-of-languages and https://en.wikipedia.org/wiki/Wikipedia:Language_order_poll#General_order for perspectives on this._

Russian has also been added to `assets/scripts/locales/locale.js`, since we forgot to do that in #1085.