### PR TITLE
withinCanvas

### DIFF
--- a/assets/css/_street-name.scss
+++ b/assets/css/_street-name.scss
@@ -107,6 +107,10 @@ body.windows .street-name-text {
   }
 }
 
+body.segment-move-dragging #street-name {
+  pointer-events: none;
+}
+
 #street-name {
   @include tap-highlight-color(transparent);
 

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -110,7 +110,7 @@ class StreetEditable extends React.Component {
 
     mainLeft = (mainLeft * TILE_SIZE) / 2
 
-    if (this.state.withinCanvas && draggingState) {
+    if (draggingState && this.state.withinCanvas) {
       mainLeft -= DRAGGING_MOVE_HOLE_WIDTH
       const spaceBetweenSegments = makeSpaceBetweenSegments(dataNo, draggingState)
       return Math.round(mainLeft + currPos + spaceBetweenSegments)

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -51,7 +51,7 @@ class StreetEditable extends React.Component {
       cancelSegmentResizeTransitions()
     }
 
-    const dragEvents = ['drag', 'touchmove']
+    const dragEvents = ['dragover', 'touchmove']
     if (!prevProps.draggingState && draggingState) {
       dragEvents.map((type) => { window.addEventListener(type, this.updateWithinCanvas) })
     } else if (prevProps.draggingState && !draggingState) {

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -51,12 +51,11 @@ class StreetEditable extends React.Component {
       cancelSegmentResizeTransitions()
     }
 
+    const dragEvents = ['drag', 'touchmove']
     if (!prevProps.draggingState && draggingState) {
-      window.addEventListener('drag', this.updateWithinCanvas)
-      window.addEventListener('touchmove', this.updateWithinCanvas)
+      dragEvents.map((type) => { window.addEventListener(type, this.updateWithinCanvas) })
     } else if (prevProps.draggingState && !draggingState) {
-      window.removeEventListener('drag', this.updateWithinCanvas)
-      window.removeEventListener('touchmove', this.updateWithinCanvas)
+      dragEvents.map((type) => { window.removeEventListener(type, this.updateWithinCanvas) })
     }
   }
 

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -53,8 +53,10 @@ class StreetEditable extends React.Component {
 
     if (!prevProps.draggingState && draggingState) {
       window.addEventListener('drag', this.updateWithinCanvas)
+      window.addEventListener('touchmove', this.updateWithinCanvas)
     } else if (prevProps.draggingState && !draggingState) {
       window.removeEventListener('drag', this.updateWithinCanvas)
+      window.removeEventListener('touchmove', this.updateWithinCanvas)
     }
   }
 

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -71,6 +71,7 @@ class Segment extends React.Component {
 
     this.oldSegmentCanvas = React.createRef()
     this.newSegmentCanvas = React.createRef()
+    this.initialRender = true
 
     this.state = {
       switchSegments: false,
@@ -90,8 +91,9 @@ class Segment extends React.Component {
     // the active segment should be shown. The following IF statement checks to see if a removal
     // or drag action occurred previously to this segment and displays the infoBubble for the
     // segment if it is equal to the activeSegment and no infoBubble was shown already.
-    const wasDragging = (prevProps.isDragging && !this.props.isDragging)
+    const wasDragging = (prevProps.isDragging && !this.props.isDragging) || (this.initialRender && this.props.activeSegment)
     const mouseEnterSuppressed = (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter)
+    this.initialRender = false
 
     if ((wasDragging || mouseEnterSuppressed) && this.props.activeSegment === this.props.dataNo) {
       infoBubble.considerShowing(false, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -91,7 +91,8 @@ class Segment extends React.Component {
     // the active segment should be shown. The following IF statement checks to see if a removal
     // or drag action occurred previously to this segment and displays the infoBubble for the
     // segment if it is equal to the activeSegment and no infoBubble was shown already.
-    const wasDragging = (prevProps.isDragging && !this.props.isDragging) || (this.initialRender && this.props.activeSegment)
+    const wasDragging = (prevProps.isDragging && !this.props.isDragging) ||
+      (this.initialRender && (this.props.activeSegment || this.props.activeSegment === 0))
     const mouseEnterSuppressed = (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter)
     this.initialRender = false
 

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -90,7 +90,10 @@ class Segment extends React.Component {
     // the active segment should be shown. The following IF statement checks to see if a removal
     // or drag action occurred previously to this segment and displays the infoBubble for the
     // segment if it is equal to the activeSegment and no infoBubble was shown already.
-    if (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter && this.props.activeSegment === this.props.dataNo) {
+    const wasDragging = (prevProps.isDragging && !this.props.isDragging)
+    const mouseEnterSuppressed = (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter)
+
+    if ((wasDragging || mouseEnterSuppressed) && this.props.activeSegment === this.props.dataNo) {
       infoBubble.considerShowing(false, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)
     }
 

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -221,7 +221,22 @@ export function onBodyMouseDown (event) {
 
 export function isSegmentWithinCanvas (event, canvasEl) {
   const { remainingWidth } = store.getState().street
-  const { x, y } = event
+
+  let x, y
+  if (event.touches && event.touches[0]) {
+    x = event.touches[0].pageX
+    y = event.touches[0].pageY
+  } else {
+    x = event.x
+    y = event.y
+  }
+
+  // For some reason, the last drag event of a palette segment causes x and
+  // y to be reset to 0 despite the last mouse position not being (0,0). The
+  // code below returns true if the second to last drag event was within canvas.
+  // TODO - find reason why last drag event resets x, y
+  if (x === 0 && y === 0 && oldDraggingState.withinCanvas) return true
+
   const { top, bottom, left, right } = canvasEl.getBoundingClientRect()
 
   const withinCanvasY = (y >= top && y <= bottom)
@@ -236,6 +251,7 @@ export function isSegmentWithinCanvas (event, canvasEl) {
   }
 
   const withinCanvas = (withinCanvasX && withinCanvasY)
+
   if (oldDraggingState) {
     oldDraggingState.withinCanvas = withinCanvas
   }

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -699,8 +699,6 @@ export const canvasTarget = {
 
 export function collectDropTarget (connect, monitor) {
   return {
-    connectDropTarget: connect.dropTarget(),
-    isOver: monitor.isOver(),
-    isOverCurrent: monitor.isOver({ shallow: true })
+    connectDropTarget: connect.dropTarget()
   }
 }

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -231,11 +231,12 @@ export function isSegmentWithinCanvas (event, canvasEl) {
     y = event.y
   }
 
+  const prevWithinCanvas = (oldDraggingState && oldDraggingState.withinCanvas)
   // For some reason, the last drag event of a palette segment causes x and
   // y to be reset to 0 despite the last mouse position not being (0,0). The
   // code below returns true if the second to last drag event was within canvas.
   // TODO - find reason why last drag event resets x, y
-  if (x === 0 && y === 0 && oldDraggingState.withinCanvas) return true
+  if (x === 0 && y === 0 && prevWithinCanvas) return true
 
   const { top, bottom, left, right } = canvasEl.getBoundingClientRect()
 

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -426,6 +426,14 @@ function handleSegmentDragStart () {
   hideControls()
 }
 
+function handleSegmentDragEnd () {
+  oldDraggingState = null
+  cancelSegmentResizeTransitions()
+  segmentsChanged(false)
+  document.body.classList.remove('segment-move-dragging')
+  document.body.classList.remove('not-within-canvas')
+}
+
 export const Types = {
   SEGMENT: 'SEGMENT',
   PALETTE_SEGMENT: 'PALETTE_SEGMENT'
@@ -468,11 +476,7 @@ export const segmentSource = {
       }
     }
 
-    oldDraggingState = null
-    cancelSegmentResizeTransitions()
-    segmentsChanged(false)
-    document.body.classList.remove('segment-move-dragging')
-    document.body.classList.remove('not-within-canvas')
+    handleSegmentDragEnd()
   }
 }
 
@@ -502,11 +506,7 @@ export const paletteSegmentSource = {
       handleSegmentCanvasDrop(monitor.getItem(), monitor.getItemType())
     }
 
-    oldDraggingState = null
-    cancelSegmentResizeTransitions()
-    segmentsChanged(false)
-    document.body.classList.remove('segment-move-dragging')
-    document.body.classList.remove('not-within-canvas')
+    handleSegmentDragEnd()
   }
 }
 

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -487,6 +487,9 @@ export const paletteSegmentSource = {
 
   beginDrag (props, monitor, component) {
     handleSegmentDragStart()
+    // Initialize an empty draggingState object in Redux for palette segments in order to
+    // add event listener in StreetEditable once dragging begins.
+    store.dispatch(updateDraggingState())
 
     const segmentInfo = getSegmentInfo(props.type)
 

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -421,7 +421,7 @@ export const segmentSource = {
   },
 
   isDragging (props, monitor) {
-    return monitor.getItem().dataNo === props.dataNo
+    return monitor.getItem().id === props.segment.id
   },
 
   beginDrag (props, monitor, component) {
@@ -432,7 +432,8 @@ export const segmentSource = {
       variantString: props.segment.variantString,
       type: props.segment.type,
       randSeed: props.segment.randSeed,
-      actualWidth: props.segment.width
+      actualWidth: props.segment.width,
+      id: props.segment.id
     }
   },
 
@@ -620,7 +621,8 @@ function handleSegmentCanvasDrop (draggedItem, type) {
     variantString: draggedItem.variantString,
     width: draggedItem.actualWidth,
     type: draggedItem.type,
-    randSeed: draggedItem.randSeed
+    randSeed: draggedItem.randSeed,
+    id: draggedItem.id
   }
 
   let newIndex = (segmentAfterEl !== undefined) ? (segmentAfterEl + 1) : segmentBeforeEl

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -458,7 +458,7 @@ export const segmentSource = {
 
     if (!monitor.didDrop()) {
       // if no object returned by a drop handler, check if it is still within the canvas
-      const { withinCanvas } = oldDraggingState
+      const withinCanvas = oldDraggingState && oldDraggingState.withinCanvas
       if (withinCanvas) {
         handleSegmentCanvasDrop(monitor.getItem(), monitor.getItemType())
       } else if (monitor.getItemType() === Types.SEGMENT) {
@@ -497,7 +497,7 @@ export const paletteSegmentSource = {
   endDrag (props, monitor, component) {
     store.dispatch(clearDraggingState())
 
-    const { withinCanvas } = oldDraggingState
+    const withinCanvas = oldDraggingState && oldDraggingState.withinCanvas
     if (!monitor.didDrop() && withinCanvas) {
       handleSegmentCanvasDrop(monitor.getItem(), monitor.getItemType())
     }

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -231,13 +231,6 @@ export function isSegmentWithinCanvas (event, canvasEl) {
     y = event.y
   }
 
-  const prevWithinCanvas = (oldDraggingState && oldDraggingState.withinCanvas)
-  // For some reason, the last drag event of a palette segment causes x and
-  // y to be reset to 0 despite the last mouse position not being (0,0). The
-  // code below returns true if the second to last drag event was within canvas.
-  // TODO - find reason why last drag event resets x, y
-  if (x === 0 && y === 0 && prevWithinCanvas) return true
-
   const { top, bottom, left, right } = canvasEl.getBoundingClientRect()
 
   const withinCanvasY = (y >= top && y <= bottom)


### PR DESCRIPTION
Resolves #1111 

Before in order to figure out whether or not a dragged/dropped segment was within the canvas we were using react-dnd's `isOver` prop passed to `<StreetEditable />` which would return true or false depending on whether or not the drag source was over the `<StreetEditable />` drop target. However, this prop was not reliable in that if another DOM element was over `<StreetEditable />` with a higher zindex then the `isOver` prop would return false. Also, for situations such as `street.occupiedWidth` being greater than `street.width` then technically if a dragged segment is hovering over a segment outside `<StreetEditable />` it should register as withinCanvas but it does not. 

Originally the idea for a solution was to increase the width of `<StreetEditable />` to equal `street.occupiedWidth` when `street.occupiedWidth > street.width`. However, this caused a lot of positioning errors for the street segments. The final solution was to attach an event listener when a segment is being dragged and remove it when the segment is no longer being dragged. The event is then passed to a function `isSegmentWithinCanvas` which returns true or false depending on if the dragged segment is withinCanvas. The value is also saved to `oldDraggingState` which will determine on react-dnd's `endDrag` method whether or not dropping the segment will remove the segment or add the segment. 

**Questions:**
- In order to make it work for both touch and mouse I've added event listeners for event types: 'drag' and 'touchmove'. Is there an event type that will listen to both types of actions? Is there a better way to do this?
- I added a comment about this within the code but it seems that when a palette segment is being dragged, the last drag event resets the x and y values to be 0 despite it not being dropped and (0, 0). This causes the function `isSegmentWithinCanvas` to always return false when a palette segment is being dropped. The solution to this was to ignore the last drag event if it returned (0,0) but the last drag event returned withinCanvas to be true. What is causing the drag event to reset and how can I fix this?