### PR TITLE
Turns on Simplified Chinese & Traditional Chinese

### DIFF
--- a/app/data/locales.json
+++ b/app/data/locales.json
@@ -88,13 +88,13 @@
     "name": "Simplified Chinese",
     "value": "zh-Hans",
     "key": "i18n.lang.zh-hans",
-    "level": 2
+    "level": 3
   },
   {
     "label": "繁體中文",
     "name": "Traditional Chinese",
     "value": "zh-Hant",
     "key": "i18n.lang.zh-hant",
-    "level": 2
+    "level": 3
   }
 ]


### PR DESCRIPTION
When we are ready, this PR "flips the switch" and will make Simplified Chinese & Traditional Chinese level 3 languages. This will be ready to merge sometime this week. My best estimate as of right now for this is Wednesday.