### PR TITLE
Add Chinese reviewer and update Chinese language title in humans.txt

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -77,10 +77,11 @@
 
     Diana M. Alhaj, Arabic
     Zakaria Shekhreet, Arabic
-    Crystal Xing, Chinese (Traditional)
-    Ricky Tsui, Chinese (Traditional)
-    Summer Pan, Chinese (Traditional)
-    Wen Jing Jiang, Chinese (Traditional)
+    Crystal Xing, Chinese
+    Maggie Dong, Chinese
+    Ricky Tsui, Chinese
+    Summer Pan, Chinese
+    Wen Jing Jiang, Chinese
     Aleksi Kinnunen, Finnish
     Denis Devillé, French
     Jean-Louis Stanus, French


### PR DESCRIPTION
This adds Maggie, who just reviewed Chinese for us. It also changes "Chinese (Traditional)" to just "Chinese".

This second change was made for the following reasons:
- We recently changed how the language was written out to "Traditional Chinese" and "Simplified Chinese", so using the parentheses is inconsistent with that
- Several of our translators dabbed in both Traditional and Simplified Chinese, but we have so far only listed people once in this humans.txt file; this implementation lets us stay consistent with just listing people once
- Writing out the two fully would separate the two languages in the list, as Spanish falls between them in alphabetical order