### PR TITLE
Variants/WidthControl: port unsafe lifecycle methods

### DIFF
--- a/assets/scripts/info_bubble/Variants.jsx
+++ b/assets/scripts/info_bubble/Variants.jsx
@@ -28,26 +28,12 @@ class Variants extends React.Component {
     flags: PropTypes.object.isRequired
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      variantSets: this.getVariantSets(props) // should be an array or undefined
-    }
-  }
-
-  componentWillReceiveProps (nextProps) {
-    this.setState({
-      variantSets: this.getVariantSets(nextProps)
-    })
-  }
-
-  getVariantSets = (props) => {
+  static getDerivedStateFromProps (nextProps, prevState) {
     let variantSets = []
 
-    switch (props.type) {
+    switch (nextProps.type) {
       case INFO_BUBBLE_TYPE_SEGMENT:
-        const segmentInfo = getSegmentInfo(props.segmentType)
+        const segmentInfo = getSegmentInfo(nextProps.segmentType)
         if (segmentInfo) {
           variantSets = segmentInfo.variants
         }
@@ -61,7 +47,9 @@ class Variants extends React.Component {
     }
 
     // Return the array, removing any empty entries
-    return variantSets.filter((x) => x !== (undefined || null || ''))
+    return {
+      variantSets: variantSets.filter((x) => x !== (undefined || null || ''))
+    }
   }
 
   isVariantCurrentlySelected = (set, selection) => {

--- a/assets/scripts/info_bubble/WidthControl.jsx
+++ b/assets/scripts/info_bubble/WidthControl.jsx
@@ -42,7 +42,7 @@ class WidthControl extends React.Component {
 
     this.state = {
       isEditing: false,
-      displayValue: prettifyWidth(props.value, props.units)
+      displayValue: null
     }
   }
 
@@ -52,12 +52,14 @@ class WidthControl extends React.Component {
    *
    * @param {Object} nextProps
    */
-  componentWillReceiveProps (nextProps) {
-    if (!this.state.isEditing) {
-      this.setState({
+  static getDerivedStateFromProps (nextProps, prevState) {
+    if (!prevState.isEditing) {
+      return {
         displayValue: prettifyWidth(nextProps.value, nextProps.units)
-      })
+      }
     }
+
+    return null
   }
 
   /**


### PR DESCRIPTION
Working towards completion of issue #914. Previously used `componentWillReceiveProps` found in `<Variants />` and `<WidthControl />` have been updated to use `static getDerivedStateFromProps` in response to the removal of `componentWillReceiveProps` in React 17. 