### PR TITLE
initialize state in constructor so warning no longer pops up in console

### DIFF
--- a/assets/scripts/info_bubble/Variants.jsx
+++ b/assets/scripts/info_bubble/Variants.jsx
@@ -28,6 +28,14 @@ class Variants extends React.Component {
     flags: PropTypes.object.isRequired
   }
 
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      variantSets: null
+    }
+  }
+
   static getDerivedStateFromProps (nextProps, prevState) {
     let variantSets = []
 


### PR DESCRIPTION
My previous change in `<Variants />` to use `getDerivedStateFromProps` also removed the constructor which initialized state.