### PR TITLE
Input controls

### DIFF
--- a/assets/scripts/info_bubble/WidthControl.jsx
+++ b/assets/scripts/info_bubble/WidthControl.jsx
@@ -42,6 +42,7 @@ class WidthControl extends React.Component {
 
     this.state = {
       isEditing: false,
+      isHovered: false,
       displayValue: null
     }
   }
@@ -53,7 +54,7 @@ class WidthControl extends React.Component {
    * @param {Object} nextProps
    */
   static getDerivedStateFromProps (nextProps, prevState) {
-    if (!prevState.isEditing) {
+    if (!prevState.isEditing && !prevState.isHovered) {
       return {
         displayValue: prettifyWidth(nextProps.value, nextProps.units)
       }
@@ -160,6 +161,7 @@ class WidthControl extends React.Component {
     if (this.state.isEditing) return
 
     this.setState({
+      isHovered: true,
       displayValue: stringifyMeasurementValue(this.props.value, this.props.units, this.props.locale)
     })
 
@@ -183,6 +185,7 @@ class WidthControl extends React.Component {
     if (this.state.isEditing) return
 
     this.setState({
+      isHovered: false,
       displayValue: prettifyWidth(this.props.value, this.props.units)
     })
 

--- a/assets/scripts/segments/__tests__/buildings.test.js
+++ b/assets/scripts/segments/__tests__/buildings.test.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+import { prettifyHeight } from '../buildings'
+import { SETTINGS_UNITS_METRIC, SETTINGS_UNITS_IMPERIAL } from '../../users/constants'
+
+jest.mock('../view', () => {})
+
+describe('prettifyHeight()', () => {
+  it('formats a building with floors with height (metric)', () => {
+    const formatMessage = () => '2 floors'
+    const text = prettifyHeight('wide', 'left', 2, SETTINGS_UNITS_METRIC, formatMessage)
+    expect(text).toBe('2 floors (7.65 m)')
+  })
+
+  it('formats a building with floors with height (metric)', () => {
+    const formatMessage = () => '3 floors'
+    const text = prettifyHeight('narrow', 'right', 3, SETTINGS_UNITS_IMPERIAL, formatMessage)
+    expect(text).toBe('3 floors (35½\')')
+  })
+})

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -1,4 +1,5 @@
 import { RandomGenerator } from '../util/random'
+import { prettifyWidth } from '../util/width_units'
 import { images } from '../app/load_resources'
 import { TILE_SIZE, TILESET_POINT_PER_PIXEL } from '../segments/constants'
 import { drawSegmentImage } from './view'
@@ -152,6 +153,38 @@ export function getBuildingImageHeight (variant, position, floors = 1) {
 export function calculateRealHeightNumber (variant, position, floors) {
   const CURB_HEIGHT = 6
   return (getBuildingImageHeight(variant, position, floors) - CURB_HEIGHT) / TILE_SIZE
+}
+
+/**
+ * Given a building, return a string showing number of floors and actual height measurement
+ * e.g. when height value is `4` return a string that looks like this:
+ *    "4 floors (45m)"
+ *
+ * This is only used in <BuildingHeightControl /> component, but moved here because of
+ * it's similar to width functionality, and its use in the component's static method
+ * `getDerivedStateFromProps()` means it cannot live on the component instance.
+ *
+ * @todo Localize return value
+ * @param {string} variant - what type of building is it
+ * @param {string} position - what side is it on (left or right)
+ * @param {Number} floors - number of floors
+ * @param {Number} units - units, either SETTINGS_UNITS_METRIC or SETTINGS_UNITS_IMPERIAL
+ * @param {Function} formatMessage - pass in intl.formatMessage()
+ */
+export function prettifyHeight (variant, position, floors, units, formatMessage) {
+  let text = formatMessage({
+    id: 'building.floors-count',
+    defaultMessage: '{count, plural, one {# floor} other {# floors}}'
+  }, {
+    count: floors
+  })
+
+  const realHeight = calculateRealHeightNumber(variant, position, floors)
+  const prettifiedHeight = prettifyWidth(realHeight, units)
+
+  text += ` (${prettifiedHeight})`
+
+  return text
 }
 
 export function drawBuilding (ctx, destination, street, left, totalWidth, totalHeight, offsetLeft, multiplier, dpi) {


### PR DESCRIPTION
Fixes an issue with the `<WidthControl />` component where the conversion to `getDerivedStateFromProps` caused a regression in the input hover state.

Also, I've moved `prettifyHeight` out of `<BuildingHeightControl />` which allows us to make the same `getDerivedStateFromProps` conversion. Also, `prettifyHeight` now has tests!

I have another branch coming after this one where the shared functionality between `<WidthControl />` and `<BuildingHeightControl />` will be consolidated into one generic component (but that's next).