### PR TITLE
Improve palette tooltips, resolves #833

### DIFF
--- a/assets/css/_palette.scss
+++ b/assets/css/_palette.scss
@@ -13,11 +13,6 @@
   z-index: $z-02-palette;
   user-select: none;
   touch-action: none;
-
-  // Address a bug where switching building types
-  // will momentarily cause this element to disappear from view
-  // Only in Safari (observed in v8.0.2, still present in v9.1.2)
-  transform: rotateZ(0);
 }
 
 body.read-only .palette-container {

--- a/assets/css/_palette.tooltip.scss
+++ b/assets/css/_palette.tooltip.scss
@@ -1,0 +1,54 @@
+.palette-tooltip {
+  position: fixed;
+  background: white;
+  bottom: 84px;
+  padding: 0.75em 1.5em;
+  font-size: 13px;
+  border: 3px solid #85b7cc;
+  border-left: 0;
+  border-right: 0;
+  border-radius: 0;
+  text-align: center;
+  max-width: 100px;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 100ms, transform 100ms ease-in;
+  z-index: 2; // Positions this above hovered segment element
+  pointer-events: none;
+}
+
+.palette-tooltip-show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.palette-tooltip-contents {
+  max-height: 100px;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  hyphens: auto;
+}
+
+.palette-tooltip-pointer-container {
+  width: 40px;
+  position: absolute;
+  left: 50%;
+  margin-left: -20px;
+  overflow: hidden;
+  pointer-events: none;
+  bottom: -33px;
+  height: 33px;
+}
+
+.palette-tooltip-pointer {
+  position: absolute;
+  height: 30px;
+  width: 30px;
+  left: 50%;
+  bottom: 22px;
+  margin-left: -18px;
+  border: 3px solid #85b7cc;
+  transform: rotate(45deg);
+  background: #fff;
+  box-shadow: none;
+}

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -25,6 +25,7 @@
 @import 'segment';
 @import 'info-bubble';
 @import 'palette';
+@import 'palette.tooltip';
 @import 'status-message';
 @import 'welcome-panel';
 @import 'debug';

--- a/assets/scripts/app/Palette.jsx
+++ b/assets/scripts/app/Palette.jsx
@@ -70,7 +70,7 @@ class Palette extends React.Component {
    * @param {string} label - text to display inside the tooltip
    * @param {Object} rect - result of getBoundingClientRect() on segment element
    */
-  handleHover = (event, label, rect) => {
+  handlePointerOver = (event, label, rect) => {
     // x is the position right above the middle of the segment element to point at
     const x = rect.x + (rect.width / 2)
 
@@ -78,6 +78,12 @@ class Palette extends React.Component {
       tooltipLabel: label,
       tooltipVisible: true,
       tooltipPosition: { x }
+    })
+  }
+
+  handlePointerOut = (event) => {
+    this.setState({
+      tooltipVisible: false
     })
   }
 
@@ -101,7 +107,14 @@ class Palette extends React.Component {
         ? segment.paletteIcon
         : Object.keys(segment.details).shift()
 
-      return <SegmentForPalette key={segment.id} type={segment.id} variantString={variant} onHover={this.handleHover} />
+      return (
+        <SegmentForPalette
+          key={segment.id}
+          type={segment.id}
+          variantString={variant}
+          onPointerOver={this.handlePointerOver}
+        />
+      )
     })
   }
 
@@ -116,14 +129,16 @@ class Palette extends React.Component {
         <div className="palette-commands" ref={this.commandsEl}>
           <UndoRedo />
         </div>
-        <Scrollable className="palette" setRef={this.setScrollableRef} ref={this.scrollable}>
-          <IntlProvider
-            locale={this.props.locale.locale}
-            messages={this.props.locale.segmentInfo}
-          >
-            <React.Fragment>{this.props.everythingLoaded && this.renderPaletteItems()}</React.Fragment>
-          </IntlProvider>
-        </Scrollable>
+        <div onPointerOut={this.handlePointerOut}>
+          <Scrollable className="palette" setRef={this.setScrollableRef} ref={this.scrollable}>
+            <IntlProvider
+              locale={this.props.locale.locale}
+              messages={this.props.locale.segmentInfo}
+            >
+              <React.Fragment>{this.props.everythingLoaded && this.renderPaletteItems()}</React.Fragment>
+            </IntlProvider>
+          </Scrollable>
+        </div>
         <PaletteTooltips
           label={this.state.tooltipLabel}
           visible={this.state.tooltipVisible}

--- a/assets/scripts/app/Palette.jsx
+++ b/assets/scripts/app/Palette.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 import Scrollable from '../ui/Scrollable'
 import SegmentForPalette from '../segments/SegmentForPalette'
 import UndoRedo from './UndoRedo'
+import PaletteTooltips from '../palette/PaletteTooltips'
 import { getAllSegmentInfoArray } from '../segments/info'
 
 class Palette extends React.Component {
@@ -20,6 +21,12 @@ class Palette extends React.Component {
 
     this.commandsEl = React.createRef()
     this.scrollable = React.createRef()
+
+    this.state = {
+      tooltipLabel: null,
+      tooltipVisible: false,
+      tooltipPosition: {}
+    }
   }
 
   componentDidMount () {
@@ -55,6 +62,25 @@ class Palette extends React.Component {
     this.scrollable.current.checkButtonVisibilityState()
   }
 
+  /**
+   * Each segment in palette calls this function when the pointer hovers over it so we know
+   * what to display in the tooltip
+   *
+   * @param {Object} event - event handler object
+   * @param {string} label - text to display inside the tooltip
+   * @param {Object} rect - result of getBoundingClientRect() on segment element
+   */
+  handleHover = (event, label, rect) => {
+    // x is the position right above the middle of the segment element to point at
+    const x = rect.x + (rect.width / 2)
+
+    this.setState({
+      tooltipLabel: label,
+      tooltipVisible: true,
+      tooltipPosition: { x }
+    })
+  }
+
   renderPaletteItems = () => {
     const segments = getAllSegmentInfoArray()
 
@@ -75,7 +101,7 @@ class Palette extends React.Component {
         ? segment.paletteIcon
         : Object.keys(segment.details).shift()
 
-      return <SegmentForPalette key={segment.id} type={segment.id} variantString={variant} />
+      return <SegmentForPalette key={segment.id} type={segment.id} variantString={variant} onHover={this.handleHover} />
     })
   }
 
@@ -98,6 +124,11 @@ class Palette extends React.Component {
             <React.Fragment>{this.props.everythingLoaded && this.renderPaletteItems()}</React.Fragment>
           </IntlProvider>
         </Scrollable>
+        <PaletteTooltips
+          label={this.state.tooltipLabel}
+          visible={this.state.tooltipVisible}
+          pointAt={this.state.tooltipPosition}
+        />
       </div>
     )
   }

--- a/assets/scripts/app/Palette.jsx
+++ b/assets/scripts/app/Palette.jsx
@@ -81,7 +81,19 @@ class Palette extends React.Component {
     })
   }
 
+  /**
+   * When the pointer leaves the segment area, hide tooltip.
+   */
   handlePointerOut = (event) => {
+    this.setState({
+      tooltipVisible: false
+    })
+  }
+
+  /**
+   * When the segment area is being scrolled, hide tooltip.
+   */
+  handleScroll = (event) => {
     this.setState({
       tooltipVisible: false
     })
@@ -130,7 +142,7 @@ class Palette extends React.Component {
           <UndoRedo />
         </div>
         <div onPointerOut={this.handlePointerOut}>
-          <Scrollable className="palette" setRef={this.setScrollableRef} ref={this.scrollable}>
+          <Scrollable className="palette" setRef={this.setScrollableRef} ref={this.scrollable} onScroll={this.handleScroll}>
             <IntlProvider
               locale={this.props.locale.locale}
               messages={this.props.locale.segmentInfo}

--- a/assets/scripts/palette/PaletteTooltips.jsx
+++ b/assets/scripts/palette/PaletteTooltips.jsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default class PaletteTooltips extends React.Component {
+  static propTypes = {
+    label: PropTypes.string,
+    visible: PropTypes.bool,
+    pointAt: PropTypes.shape({
+      x: PropTypes.number,
+      y: PropTypes.number
+    })
+  }
+
+  static defaultProps = {
+    label: null,
+    visible: false
+  }
+
+  constructor (props) {
+    super(props)
+
+    this.el = React.createRef()
+  }
+
+  componentDidUpdate () {
+    // pointAt.y is not used right now. we are just hardcoding its
+    // vertical position inside the CSS for this component.
+    this.el.current.style.left = this.props.pointAt.x - (this.el.current.getBoundingClientRect().width / 2) + 'px'
+  }
+
+  render () {
+    const classNames = ['palette-tooltip']
+
+    if (this.props.visible) {
+      classNames.push('palette-tooltip-show')
+    }
+
+    return (
+      <div className="palette-tooltip-container">
+        <div className={classNames.join(' ')} ref={this.el}>
+          <div className="palette-tooltip-contents">
+            {this.props.label}
+          </div>
+          <div className="palette-tooltip-pointer-container">
+            <div className="palette-tooltip-pointer" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/assets/scripts/palette/PaletteTooltips.jsx
+++ b/assets/scripts/palette/PaletteTooltips.jsx
@@ -1,14 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 
-export default class PaletteTooltips extends React.Component {
+export class PaletteTooltips extends React.Component {
   static propTypes = {
     label: PropTypes.string,
     visible: PropTypes.bool,
     pointAt: PropTypes.shape({
       x: PropTypes.number,
-      y: PropTypes.number
-    })
+      y: PropTypes.number // Not used right now
+    }),
+
+    // Provided by Redux state
+    isDragging: PropTypes.bool
   }
 
   static defaultProps = {
@@ -31,7 +35,7 @@ export default class PaletteTooltips extends React.Component {
   render () {
     const classNames = ['palette-tooltip']
 
-    if (this.props.visible) {
+    if (this.props.visible && !this.props.isDragging) {
       classNames.push('palette-tooltip-show')
     }
 
@@ -49,3 +53,11 @@ export default class PaletteTooltips extends React.Component {
     )
   }
 }
+
+function mapStateToProps (state) {
+  return {
+    isDragging: !!state.ui.draggingState // Coerce to boolean
+  }
+}
+
+export default connect(mapStateToProps)(PaletteTooltips)

--- a/assets/scripts/segments/SegmentForPalette.jsx
+++ b/assets/scripts/segments/SegmentForPalette.jsx
@@ -16,29 +16,56 @@ const PALETTE_SEGMENT_MULTIPLIER = 1 / 3
 
 class SegmentForPalette extends React.Component {
   static propTypes = {
+    // Provided by react-intl
     intl: intlShape.isRequired,
+
+    // Provided by react-dnd
+    connectDragSource: PropTypes.func,
+    connectDragPreview: PropTypes.func,
+
+    // Provided by parent
     type: PropTypes.string.isRequired,
     variantString: PropTypes.string.isRequired,
-    connectDragSource: PropTypes.func,
-    connectDragPreview: PropTypes.func
+    onHover: PropTypes.func
   }
 
   componentDidMount = () => {
     this.props.connectDragPreview(getEmptyImage(), { captureDraggingState: true })
   }
 
-  render () {
+  handlePointerOver = (event) => {
+    const label = this.getLabel()
+    const rect = event.target.getBoundingClientRect()
+    this.props.onHover(event, label, rect)
+  }
+
+  getInfo = () => {
+    const segment = getSegmentInfo(this.props.type)
+    const variant = getSegmentVariantInfo(this.props.type, this.props.variantString)
+
+    return {
+      segment,
+      variant
+    }
+  }
+
+  getLabel = () => {
     // Get localized display names
-    const segmentInfo = getSegmentInfo(this.props.type)
-    const variantInfo = getSegmentVariantInfo(this.props.type, this.props.variantString)
-    const defaultMessage = variantInfo.name || segmentInfo.name
+    const info = this.getInfo()
+    const defaultMessage = info.variant.name || info.segment.name
+
+    return this.props.intl.formatMessage({ id: `segments.${info.segment.nameKey}`, defaultMessage })
+  }
+
+  render () {
+    const info = this.getInfo()
 
     // Determine width to render at
-    const dimensions = getVariantInfoDimensions(variantInfo)
+    const dimensions = getVariantInfoDimensions(info.variant)
 
     let actualWidth = dimensions.right - dimensions.left
     if (!actualWidth) {
-      actualWidth = segmentInfo.defaultWidth
+      actualWidth = info.segment.defaultWidth
     }
     actualWidth += PALETTE_SEGMENT_EXTRA_PADDING
 
@@ -46,7 +73,8 @@ class SegmentForPalette extends React.Component {
       <div
         style={{ width: (actualWidth * TILE_SIZE * PALETTE_SEGMENT_MULTIPLIER) + 'px' }}
         className="segment segment-in-palette"
-        title={this.props.intl.formatMessage({ id: `segments.${segmentInfo.nameKey}`, defaultMessage })}
+        onPointerOver={this.handlePointerOver}
+        onPointerOut={this.handlePointerOut}
       >
         <SegmentCanvas
           actualWidth={actualWidth}

--- a/assets/scripts/segments/SegmentForPalette.jsx
+++ b/assets/scripts/segments/SegmentForPalette.jsx
@@ -26,7 +26,7 @@ class SegmentForPalette extends React.Component {
     // Provided by parent
     type: PropTypes.string.isRequired,
     variantString: PropTypes.string.isRequired,
-    onHover: PropTypes.func
+    onPointerOver: PropTypes.func
   }
 
   componentDidMount = () => {
@@ -36,7 +36,7 @@ class SegmentForPalette extends React.Component {
   handlePointerOver = (event) => {
     const label = this.getLabel()
     const rect = event.target.getBoundingClientRect()
-    this.props.onHover(event, label, rect)
+    this.props.onPointerOver(event, label, rect)
   }
 
   getInfo = () => {

--- a/assets/scripts/ui/Scrollable.jsx
+++ b/assets/scripts/ui/Scrollable.jsx
@@ -12,11 +12,13 @@ export default class Scrollable extends React.PureComponent {
   static propTypes = {
     className: PropTypes.string,
     children: PropTypes.node,
-    setRef: PropTypes.func
+    setRef: PropTypes.func,
+    onScroll: PropTypes.func
   }
 
   static defaultProps = {
-    setRef: function noop () {}
+    setRef: () => {},
+    onScroll: () => {}
   }
 
   constructor (props) {
@@ -57,6 +59,9 @@ export default class Scrollable extends React.PureComponent {
 
   onScrollContainer = (event) => {
     this.checkButtonVisibilityState()
+
+    // If parent has provided its own onScroll handler function, call that now.
+    this.props.onScroll(event)
   }
 
   // Allows parent component to obtain a ref to the wrapping element created here.


### PR DESCRIPTION
Previously, each segment relied on native browser `title` attribute to provide a tooltip after a few seconds of hovering over an element. It was somewhat underwhelming and most users did not realize it was there. Case in point, issue #833 was filed after a public event in which a UX designer took note of this.

This PR replaces the `title` attribute with homegrown tooltip functionality which is much more responsive to user actions:

![aug-27-2018 14-28-30](https://user-images.githubusercontent.com/2553268/44678093-86ec6d80-aa05-11e8-93ef-f0f76a193027.gif)

Caveats:

- This hasn't been tested on touch devices; behavior is unknown.
- Label content has not been considered here. We merely reused the text in the previous labels. If the text is still not clear enough to describe each segment, this should be considered separately.
- Triggering a tooltip on the last (far-right) item if scrolling is active causes the right scroll button to appear. When that tooltip leaves, the scroll position is moved slightly to the left. Cause of this is unknown.

cc @manasvil