### PR TITLE
when dispatching updateStreetData (such as after undo/redo) do immedi…

### DIFF
--- a/assets/scripts/store/reducers/street.js
+++ b/assets/scripts/store/reducers/street.js
@@ -37,7 +37,8 @@ const street = (state = initialState, action) => {
     case REPLACE_STREET_DATA:
       return {
         ...state,
-        ...action.street
+        ...action.street,
+        immediateRemoval: true
       }
     case ADD_SEGMENT:
       return {


### PR DESCRIPTION
…ate removal if necessary - fixes issue #1144

We've been using the `immediateRemoval` in store to decide whether or not animations should be used and like @louh mentioned it appears that I forgot the case for when we are replacing the entire `street` object. 