### PR TITLE
Building flags

### DIFF
--- a/app/data/flags.json
+++ b/app/data/flags.json
@@ -11,8 +11,12 @@
     "label": "UI — Edit street name",
     "defaultValue": true
   },
-  "EDIT_BUILDINGS": {
-    "label": "UI — Edit buildings",
+  "EDIT_BUILDINGS_LEFT": {
+    "label": "UI — Edit left-side buildings",
+    "defaultValue": true
+  },
+  "EDIT_BUILDINGS_RIGHT": {
+    "label": "UI — Edit right-side buildings",
     "defaultValue": true
   },
   "SAVE_UNDO": {

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -14,13 +14,27 @@ import { addBuildingFloor, removeBuildingFloor } from '../store/actions/street'
 
 class Building extends React.Component {
   static propTypes = {
-    activeSegment: PropTypes.string,
+    // Provided by parent
     position: PropTypes.string.isRequired,
-    addBuildingFloor: PropTypes.func,
-    removeBuildingFloor: PropTypes.func,
-    street: PropTypes.object,
     buildingWidth: PropTypes.number,
-    updatePerspective: PropTypes.func
+    updatePerspective: PropTypes.func,
+
+    // Provided by Redux store
+    street: PropTypes.object,
+    activeSegment: PropTypes.string,
+    // eslint-disable-next-line react/no-unused-prop-types
+    leftBuildingEditable: PropTypes.bool,
+    // eslint-disable-next-line react/no-unused-prop-types
+    rightBuildingEditable: PropTypes.bool,
+
+    // Provided by Redux action dispatchers
+    addBuildingFloor: PropTypes.func,
+    removeBuildingFloor: PropTypes.func
+  }
+
+  static defaultProps = {
+    leftBuildingEditable: true,
+    rightBuildingEditable: true
   }
 
   constructor (props) {
@@ -31,7 +45,24 @@ class Building extends React.Component {
       height: (props.position === 'left') ? 'leftBuildingHeight' : 'rightBuildingHeight',
       oldBuildingEnter: true,
       newBuildingEnter: false,
-      switchBuildings: false
+      switchBuildings: false,
+      isEditable: true
+    }
+  }
+
+  static getDerivedStateFromProps (props, state) {
+    if (props.leftBuildingEditable === false && props.position === 'left') {
+      return {
+        isEditable: false
+      }
+    } else if (props.rightBuildingEditable === false && props.position === 'right') {
+      return {
+        isEditable: false
+      }
+    } else {
+      return {
+        isEditable: true
+      }
     }
   }
 
@@ -64,8 +95,12 @@ class Building extends React.Component {
   }
 
   onBuildingMouseEnter = (event) => {
+    if (!this.state.isEditable) return
+
     window.addEventListener('keydown', this.handleKeyDown)
+
     let type
+
     if (this.props.position === 'left') {
       type = INFO_BUBBLE_TYPE_LEFT_BUILDING
     } else if (this.props.position === 'right') {
@@ -77,13 +112,18 @@ class Building extends React.Component {
   }
 
   onBuildingMouseLeave = (event) => {
+    if (!this.state.isEditable) return
+
     window.removeEventListener('keydown', this.handleKeyDown)
+
     if (infoBubble.considerSegmentEl === this.streetSectionBuilding) {
       infoBubble.dontConsiderShowing()
     }
   }
 
   handleKeyDown = (event) => {
+    if (!this.state.isEditable) return
+
     const negative = (event.keyCode === KEYS.MINUS) ||
       (event.keyCode === KEYS.MINUS_ALT) ||
       (event.keyCode === KEYS.MINUS_KEYPAD)
@@ -200,7 +240,9 @@ class Building extends React.Component {
 function mapStateToProps (state) {
   return {
     street: state.street,
-    activeSegment: (typeof state.ui.activeSegment === 'string') ? state.ui.activeSegment : null
+    activeSegment: (typeof state.ui.activeSegment === 'string') ? state.ui.activeSegment : null,
+    leftBuildingEditable: state.flags.EDIT_BUILDINGS_LEFT.value,
+    rightBuildingEditable: state.flags.EDIT_BUILDINGS_RIGHT.value
   }
 }
 

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -13,10 +13,7 @@ import {
   createNewUndoIfNecessary,
   unifyUndoStack
 } from './undo_stack'
-import {
-  DEFAULT_STREET_WIDTH,
-  normalizeStreetWidth
-} from './width'
+import { normalizeStreetWidth } from './width'
 import { updateLastStreetInfo, scheduleSavingStreetToServer } from './xhr'
 import {
   updateStreetWidth,
@@ -35,6 +32,7 @@ const DEFAULT_BUILDING_VARIANT_LEFT = 'narrow'
 const DEFAULT_BUILDING_VARIANT_RIGHT = 'wide'
 const DEFAULT_BUILDING_HEIGHT_EMPTY = 1
 const DEFAULT_BUILDING_VARIANT_EMPTY = 'grass'
+const DEFAULT_STREET_WIDTH = 80
 
 let _lastStreet
 

--- a/assets/scripts/streets/width.js
+++ b/assets/scripts/streets/width.js
@@ -6,8 +6,6 @@ import {
 } from '../segments/constants'
 import store from '../store'
 
-export const DEFAULT_STREET_WIDTH = 80
-
 const MIN_CUSTOM_STREET_WIDTH = 10
 export const MAX_CUSTOM_STREET_WIDTH = 400
 


### PR DESCRIPTION
A couple of cleanup / tweaks.

- Move exported constant variable `DEFAULT_STREET_WIDTH` to `data_model.js`, the only module that actually uses it.
- We had a flag for building editability that was never actually used in the code. This makes the flag work as well as allows it to be granular (you can turn it on for either the left or right building). Note on building editability: this only prevents user UI from editing it; it does not prevent buildings from being edited via other means, like undo/redo.