### PR TITLE
Enable arbitrary building overhangs widths.

### DIFF
--- a/assets/css/_street-section.scss
+++ b/assets/css/_street-section.scss
@@ -87,7 +87,7 @@
 #street-section-dirt {
   position: absolute;
   left: 0;
-  right: 25px;
+  right: 0;
   top: $canvas-height - 80px;
   border-top: 45px solid $background-dirt-colour;
   background: $bottom-background;

--- a/assets/css/_street-section.scss
+++ b/assets/css/_street-section.scss
@@ -118,7 +118,6 @@
 
   canvas {
     position: absolute;
-    left: 0;
     bottom: 0;
   }
 }

--- a/assets/css/_street-section.scss
+++ b/assets/css/_street-section.scss
@@ -122,6 +122,14 @@
   }
 }
 
+.street-section-building-left canvas {
+  left: 0;
+}
+
+.street-segment-building-right canvas {
+  right: 0;
+}
+
 [dir='rtl'] {
   #street-section-outer,
   .street-scroll-indicator-left,

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -129,7 +129,7 @@ class StreetView extends React.Component {
       scrollLeft += deltaX
     } else {
       const streetWidth = this.props.street.width * TILE_SIZE
-      const currBuildingSpace = (this.state.buildingWidth) ? (this.state.buildingWidth - 25) : BUILDING_SPACE
+      const currBuildingSpace = (this.state.buildingWidth) ? (this.state.buildingWidth) : BUILDING_SPACE
       scrollLeft = (streetWidth + (currBuildingSpace * 2) - this.props.system.viewportWidth) / 2
     }
 
@@ -247,7 +247,7 @@ class StreetView extends React.Component {
   setBuildingWidth = (el) => {
     const pos = getElAbsolutePos(el)
 
-    let width = pos[0] + 25
+    let width = pos[0]
     if (width < 0) {
       width = 0
     }

--- a/assets/scripts/gallery/thumbnail.js
+++ b/assets/scripts/gallery/thumbnail.js
@@ -97,7 +97,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const leftBuilding = BUILDINGS[street.leftBuildingVariant]
   const leftOverhang = (typeof leftBuilding.overhangWidth === 'number') ? leftBuilding.overhangWidth : 0
   drawBuilding(ctx, street,
-    true, buildingWidth, groundLevel,
+    'left', buildingWidth, groundLevel,
     x1 - ((buildingWidth - leftOverhang) * multiplier),
     multiplier, dpi)
 
@@ -106,7 +106,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const rightBuilding = BUILDINGS[street.rightBuildingVariant]
   const rightOverhang = (typeof rightBuilding.overhangWidth === 'number') ? rightBuilding.overhangWidth : 0
   drawBuilding(ctx, street,
-    false, buildingWidth, groundLevel,
+    'right', buildingWidth, groundLevel,
     x2 - (rightOverhang * multiplier),
     multiplier, dpi)
 

--- a/assets/scripts/gallery/thumbnail.js
+++ b/assets/scripts/gallery/thumbnail.js
@@ -4,7 +4,6 @@ import { prettifyWidth } from '../util/width_units'
 import { SAVE_AS_IMAGE_NAMES_WIDTHS_PADDING } from '../streets/image'
 import {
   BUILDINGS,
-  BUILDING_DESTINATION_THUMBNAIL,
   GROUND_BASELINE_HEIGHT,
   drawBuilding
 } from '../segments/buildings'
@@ -97,7 +96,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const x1 = (thumbnailWidth / 2) - (street.width * TILE_SIZE * multiplier / 2)
   const leftBuilding = BUILDINGS[street.leftBuildingVariant]
   const leftOverhang = (typeof leftBuilding.overhangWidth === 'number') ? leftBuilding.overhangWidth : 0
-  drawBuilding(ctx, BUILDING_DESTINATION_THUMBNAIL, street,
+  drawBuilding(ctx, street,
     true, buildingWidth, groundLevel,
     x1 - ((buildingWidth - leftOverhang) * multiplier),
     multiplier, dpi)
@@ -106,7 +105,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const x2 = (thumbnailWidth / 2) + (street.width * TILE_SIZE * multiplier / 2)
   const rightBuilding = BUILDINGS[street.rightBuildingVariant]
   const rightOverhang = (typeof rightBuilding.overhangWidth === 'number') ? rightBuilding.overhangWidth : 0
-  drawBuilding(ctx, BUILDING_DESTINATION_THUMBNAIL, street,
+  drawBuilding(ctx, street,
     false, buildingWidth, groundLevel,
     x2 - (rightOverhang * multiplier),
     multiplier, dpi)

--- a/assets/scripts/gallery/thumbnail.js
+++ b/assets/scripts/gallery/thumbnail.js
@@ -96,7 +96,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const x1 = (thumbnailWidth / 2) - (street.width * TILE_SIZE * multiplier / 2)
   const leftBuilding = BUILDINGS[street.leftBuildingVariant]
   const leftOverhang = (typeof leftBuilding.overhangWidth === 'number') ? leftBuilding.overhangWidth : 0
-  drawBuilding(ctx, street,
+  drawBuilding(ctx, street.leftBuildingVariant, street,
     'left', buildingWidth, groundLevel,
     x1 - ((buildingWidth - leftOverhang) * multiplier),
     multiplier, dpi)
@@ -105,7 +105,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const x2 = (thumbnailWidth / 2) + (street.width * TILE_SIZE * multiplier / 2)
   const rightBuilding = BUILDINGS[street.rightBuildingVariant]
   const rightOverhang = (typeof rightBuilding.overhangWidth === 'number') ? rightBuilding.overhangWidth : 0
-  drawBuilding(ctx, street,
+  drawBuilding(ctx, street.rightBuildingVariant, street,
     'right', buildingWidth, groundLevel,
     x2 - (rightOverhang * multiplier),
     multiplier, dpi)

--- a/assets/scripts/gallery/thumbnail.js
+++ b/assets/scripts/gallery/thumbnail.js
@@ -3,6 +3,7 @@ import { drawLine } from '../util/canvas_drawing'
 import { prettifyWidth } from '../util/width_units'
 import { SAVE_AS_IMAGE_NAMES_WIDTHS_PADDING } from '../streets/image'
 import {
+  BUILDINGS,
   BUILDING_DESTINATION_THUMBNAIL,
   GROUND_BASELINE_HEIGHT,
   drawBuilding
@@ -92,16 +93,22 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
 
   const buildingWidth = buildingOffsetLeft / multiplier
 
+  // Left building
   const x1 = (thumbnailWidth / 2) - (street.width * TILE_SIZE * multiplier / 2)
+  const leftBuilding = BUILDINGS[street.leftBuildingVariant]
+  const leftOverhang = (typeof leftBuilding.overhangWidth === 'number') ? leftBuilding.overhangWidth : 0
   drawBuilding(ctx, BUILDING_DESTINATION_THUMBNAIL, street,
     true, buildingWidth, groundLevel,
-    x1 - ((buildingWidth - 25) * multiplier),
+    x1 - ((buildingWidth - leftOverhang) * multiplier),
     multiplier, dpi)
 
+  // Right building
   const x2 = (thumbnailWidth / 2) + (street.width * TILE_SIZE * multiplier / 2)
+  const rightBuilding = BUILDINGS[street.rightBuildingVariant]
+  const rightOverhang = (typeof rightBuilding.overhangWidth === 'number') ? rightBuilding.overhangWidth : 0
   drawBuilding(ctx, BUILDING_DESTINATION_THUMBNAIL, street,
     false, buildingWidth, groundLevel,
-    x2 - (25 * multiplier),
+    x2 - (rightOverhang * multiplier),
     multiplier, dpi)
 
   // Segments

--- a/assets/scripts/gallery/thumbnail.js
+++ b/assets/scripts/gallery/thumbnail.js
@@ -96,7 +96,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const x1 = (thumbnailWidth / 2) - (street.width * TILE_SIZE * multiplier / 2)
   const leftBuilding = BUILDINGS[street.leftBuildingVariant]
   const leftOverhang = (typeof leftBuilding.overhangWidth === 'number') ? leftBuilding.overhangWidth : 0
-  drawBuilding(ctx, street.leftBuildingVariant, street,
+  drawBuilding(ctx, street.leftBuildingVariant, street.leftBuildingHeight,
     'left', buildingWidth, groundLevel,
     x1 - ((buildingWidth - leftOverhang) * multiplier),
     multiplier, dpi)
@@ -105,7 +105,7 @@ export function drawStreetThumbnail (ctx, street, thumbnailWidth, thumbnailHeigh
   const x2 = (thumbnailWidth / 2) + (street.width * TILE_SIZE * multiplier / 2)
   const rightBuilding = BUILDINGS[street.rightBuildingVariant]
   const rightOverhang = (typeof rightBuilding.overhangWidth === 'number') ? rightBuilding.overhangWidth : 0
-  drawBuilding(ctx, street.rightBuildingVariant, street,
+  drawBuilding(ctx, street.rightBuildingVariant, street.rightBuildingHeight,
     'right', buildingWidth, groundLevel,
     x2 - (rightOverhang * multiplier),
     multiplier, dpi)

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -76,21 +76,21 @@ class Building extends React.Component {
     if (prevProps.street[height] !== street[height] ||
         lastOverflow !== streetOverflow ||
         (street[variant] && prevProps.buildingWidth !== buildingWidth)) {
-      createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
+      createBuilding(this.streetSectionBuilding, street[variant], position, street[height], streetOverflow)
     }
 
     if (prevProps.street[variant] && prevProps.street[variant] !== street[variant]) {
       if (this.shouldBuildingAnimate(prevProps.street, street)) {
         this.switchBuildings()
       } else {
-        createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
+        createBuilding(this.streetSectionBuilding, street[variant], position, street[height], streetOverflow)
       }
     }
 
     if (prevState.switchBuildings !== this.state.switchBuildings) {
       this.props.updatePerspective(this.oldStreetSectionBuilding)
       this.props.updatePerspective(this.streetSectionBuilding)
-      createBuilding(this.streetSectionBuilding, street[variant], position, street[height], street)
+      createBuilding(this.streetSectionBuilding, street[variant], position, street[height], streetOverflow)
     }
   }
 
@@ -184,6 +184,10 @@ class Building extends React.Component {
     }
 
     const classNames = ['street-section-building']
+
+    // Add a class name for building position
+    classNames.push(`street-segment-building-${this.props.position}`)
+
     if (isOldBuilding && this.props.activeSegment === this.props.position) {
       classNames.push('hover')
     }

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -179,15 +179,8 @@ class Building extends React.Component {
     const isOldBuilding = (building === 'old')
 
     const style = {
-      [this.props.position]: (-this.props.buildingWidth + 25) + 'px',
+      [this.props.position]: `-${this.props.buildingWidth}px`,
       width: this.props.buildingWidth + 'px'
-    }
-
-    const hoverStyle = {}
-    if (this.props.position === 'left') {
-      hoverStyle.right = '25px'
-    } else {
-      hoverStyle.left = '25px'
     }
 
     const classNames = ['street-section-building']
@@ -203,7 +196,7 @@ class Building extends React.Component {
         onMouseLeave={this.onBuildingMouseLeave}
         style={style}
       >
-        <div className="hover-bk" style={hoverStyle} />
+        <div className="hover-bk" />
       </section>
     )
   }

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -181,9 +181,7 @@ export function prettifyHeight (variant, position, floors, units, formatMessage)
   return text
 }
 
-export function drawBuilding (ctx, variant, street, position, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
-  const floors = (position === 'left') ? street.leftBuildingHeight : street.rightBuildingHeight
-
+export function drawBuilding (ctx, variant, floors, position, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
   const building = BUILDINGS[variant]
 
   const spriteId = getSpriteId(variant, position)
@@ -352,7 +350,7 @@ export function createBuilding (el, variant, position, floors, street) {
   const ctx = canvasEl.getContext('2d')
   const shadeIn = street.remainingWidth < 0
 
-  drawBuilding(ctx, variant, street,
+  drawBuilding(ctx, variant, floors,
     position, width, height,
     0,
     1.0, dpi, shadeIn)

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -181,6 +181,20 @@ export function prettifyHeight (variant, position, floors, units, formatMessage)
   return text
 }
 
+/**
+ * Draws the building on a canvas
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {string} variant - building
+ * @param {Number} floors - number of floors, if building as floors
+ * @param {string} position - left or right
+ * @param {Number} totalWidth - canvas width area to draw on
+ * @param {Number} totalHeight - canvas height area to draw on
+ * @param {Number} offsetLeft - left-position shift
+ * @param {Number} multiplier - scale of image
+ * @param {Number} dpi - pixel density of screen
+ * @param {Boolean} shadeIn - if true, add red colored overlay
+ */
 export function drawBuilding (ctx, variant, floors, position, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
   const building = BUILDINGS[variant]
 
@@ -315,16 +329,28 @@ function shadeInContext (ctx) {
   ctx.restore()
 }
 
-export function createBuilding (el, variant, position, floors, street) {
+/**
+ * Creates building canvas element to draw on
+ *
+ * @param {HTMLElement} el - wrapping element for canvas
+ * @param {string} variant
+ * @param {string} position
+ * @param {Number} floors
+ * @param {Boolean} shadeIn - colors the building with a red overlay
+ */
+export function createBuilding (el, variant, position, floors, shadeIn) {
   const elementWidth = el.offsetWidth
 
+  // Determine building dimensions
   const building = BUILDINGS[variant]
   const overhangWidth = (typeof building.overhangWidth === 'number') ? building.overhangWidth : 0
   const buildingHeight = getBuildingImageHeight(variant, position, floors)
 
+  // Determine canvas dimensions from building dimensions
   const width = elementWidth + overhangWidth
   const height = Math.min(MAX_CANVAS_HEIGHT, buildingHeight)
 
+  // Create canvas
   const canvasEl = document.createElement('canvas')
   const oldCanvasEl = el.querySelector('canvas')
   const dpi = store.getState().system.devicePixelRatio
@@ -334,12 +360,6 @@ export function createBuilding (el, variant, position, floors, street) {
   canvasEl.style.width = width + 'px'
   canvasEl.style.height = height + GROUND_BASELINE_HEIGHT + 'px'
 
-  if (position === 'left') {
-    canvasEl.style.left = '0'
-  } else {
-    canvasEl.style.right = '0'
-  }
-
   // Replace previous canvas if present, otherwise append a new one
   if (oldCanvasEl) {
     el.replaceChild(canvasEl, oldCanvasEl)
@@ -348,7 +368,6 @@ export function createBuilding (el, variant, position, floors, street) {
   }
 
   const ctx = canvasEl.getContext('2d')
-  const shadeIn = street.remainingWidth < 0
 
   drawBuilding(ctx, variant, floors,
     position, width, height,

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -181,10 +181,9 @@ export function prettifyHeight (variant, position, floors, units, formatMessage)
   return text
 }
 
-export function drawBuilding (ctx, street, left, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
-  const variant = left ? street.leftBuildingVariant : street.rightBuildingVariant
-  const floors = left ? street.leftBuildingHeight : street.rightBuildingHeight
-  const position = left ? 'left' : 'right'
+export function drawBuilding (ctx, street, position, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
+  const variant = (position === 'left') ? street.leftBuildingVariant : street.rightBuildingVariant
+  const floors = (position === 'left') ? street.leftBuildingHeight : street.rightBuildingHeight
 
   const building = BUILDINGS[variant]
 
@@ -355,7 +354,7 @@ export function createBuilding (el, variant, position, floors, street) {
   const shadeIn = street.remainingWidth < 0
 
   drawBuilding(ctx, street,
-    position === 'left', width, height,
+    position, width, height,
     0,
     1.0, dpi, shadeIn)
 }

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -181,8 +181,7 @@ export function prettifyHeight (variant, position, floors, units, formatMessage)
   return text
 }
 
-export function drawBuilding (ctx, street, position, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
-  const variant = (position === 'left') ? street.leftBuildingVariant : street.rightBuildingVariant
+export function drawBuilding (ctx, variant, street, position, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
   const floors = (position === 'left') ? street.leftBuildingHeight : street.rightBuildingHeight
 
   const building = BUILDINGS[variant]
@@ -353,7 +352,7 @@ export function createBuilding (el, variant, position, floors, street) {
   const ctx = canvasEl.getContext('2d')
   const shadeIn = street.remainingWidth < 0
 
-  drawBuilding(ctx, street,
+  drawBuilding(ctx, variant, street,
     position, width, height,
     0,
     1.0, dpi, shadeIn)

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -16,8 +16,7 @@ export const MAX_BUILDING_HEIGHT = 20
 
 export const GROUND_BASELINE_HEIGHT = 44
 
-// TODO: default overhang should just be 0
-const OVERHANG_WIDTH = 25
+const OVERHANG_WIDTH = 0
 
 /**
  * Define buildings here. Properties:

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -7,9 +7,6 @@ import store from '../store'
 
 const MAX_CANVAS_HEIGHT = 2048
 
-const BUILDING_DESTINATION_SCREEN = 1
-export const BUILDING_DESTINATION_THUMBNAIL = 2
-
 export const BUILDING_SPACE = 360
 
 export const MAX_BUILDING_HEIGHT = 20
@@ -184,7 +181,7 @@ export function prettifyHeight (variant, position, floors, units, formatMessage)
   return text
 }
 
-export function drawBuilding (ctx, destination, street, left, totalWidth, totalHeight, offsetLeft, multiplier, dpi) {
+export function drawBuilding (ctx, street, left, totalWidth, totalHeight, offsetLeft, multiplier, dpi, shadeIn = false) {
   const variant = left ? street.leftBuildingVariant : street.rightBuildingVariant
   const floors = left ? street.leftBuildingHeight : street.rightBuildingHeight
   const position = left ? 'left' : 'right'
@@ -303,7 +300,7 @@ export function drawBuilding (ctx, destination, street, left, totalWidth, totalH
   // If street width is exceeded, fade buildings
   // Note: it would make sense to also fade out buildings when drawing large canvases but that would
   // shade in the entire background erroneously
-  if ((street.remainingWidth < 0) && (destination === BUILDING_DESTINATION_SCREEN)) {
+  if (shadeIn === true) {
     shadeInContext(ctx)
   }
 }
@@ -355,8 +352,10 @@ export function createBuilding (el, variant, position, floors, street) {
   }
 
   const ctx = canvasEl.getContext('2d')
-  drawBuilding(ctx, BUILDING_DESTINATION_SCREEN, street,
+  const shadeIn = street.remainingWidth < 0
+
+  drawBuilding(ctx, street,
     position === 'left', width, height,
     0,
-    1.0, dpi)
+    1.0, dpi, shadeIn)
 }


### PR DESCRIPTION
## Enable arbitrary building overhang widths.

Some of our buildings have a bit of an overhang, for instance, this green canopy overlooking the sidewalk:

<img width="295" alt="screenshot 2018-11-03 07 28 11" src="https://user-images.githubusercontent.com/2553268/47951662-151b2d80-df3a-11e8-83d8-ced5345bd057.png">

This overhang is currently set to a fixed number of pixels. You'll see it in the code as the `OVERHANG_WIDTH` constant (equal to `25`), as well as various other places in the code where the number `25` is hardcoded to adjust for this fixed overhang.

This presents two problems:

1. We are incapable of having overhanging bits of buildings greater than 25 pixels. This would make it impossible to support canopies that might overhang the entire width of a sidewalk, as suggested in issue https://github.com/streetmix/streetmix/issues/400.
2. Because the overhang is hardcoded, all buildings are technically overhanging the sidewalk by default. For buildings that have no visual overhanging artifacts (like grass, for instance), the image itself must be offset by 25 pixels to align with the edge of the street's available right-of-way. As a result, defining the overhang value is counter-intuitive, as "grass" has an overhang value of `25` while the buildings with canopies have overhang values of `9` or `16`, which is calculated as `25 ` minus `the number of pixels to overhang by`.

The main goal of this PR (the first two commits) removes the hard-coded building overhang quantity entirely. Now, building components with no visual overhanging artifacts have a much more intuitive overhang value of `0`. For buildings with overhangs, the overhang value is simply the number of pixels to overhang by.

Rendering building canvases and thumbnails have been adjusted accordingly. This not only streamlines the logic for rendering buildings by removing the magic number of `25` throughout the code, but makes it possible to support buildings with extended overhangs.

## Additional refactoring of the building rendering process.

Furthermore, a number of improvements were made to the building rendering process.

- Added JSDoc headers to `drawBuilding()` and `createBuilding()` functions.
- As the `<Building />` component already conditionally renders buildings due to whether or not the street has remaining width, this value is passed all the way through to `drawBuilding()`. This allows us to remove specialized logic for shading in the buildings:
    - The constants `BUILDING_DESTINATION_SCREEN` and `BUILDING_DESTINATION_THUMBNAIL` can be completely removed. `BUILDING_DESTINATION_THUMBNAIL` was not actually used anymore, and `BUILDING_DESTINATION_SCREEN` was only used to determine whether or not a building should be shaded in, a situation we can alternatively address when calling `drawBuilding()` from a screen-rendering component by passing in a new parameter, `shadeIn`, a boolean value that shades in the building when equal to `true`.
- We refactor `drawBuilding()` to be more consistent with the `position` argument, and it no longer needs access to the entire `street` object.
    - `position` is now `left` or `right`, which is clearer, rather than a Boolean value.
    - `variant` and `floors` are now passed in explicitly when calling this function. 

