### PR TITLE
Added trash can icon to remove button

### DIFF
--- a/assets/css/_info-bubble.scss
+++ b/assets/css/_info-bubble.scss
@@ -168,6 +168,12 @@
   margin-top: 1px;
   margin-left: 1em;
   font-size: 11px;
+
+  .remove-icon {
+    width: 14px;
+    height: 14px;
+    margin-right: 4px;
+  }
 }
 
 .info-bubble-controls {

--- a/assets/scripts/info_bubble/RemoveButton.jsx
+++ b/assets/scripts/info_bubble/RemoveButton.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl'
 import { trackEvent } from '../app/event_tracking'
 import { removeSegment, removeAllSegments } from '../segments/remove'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 class RemoveButton extends React.PureComponent {
   static propTypes = {
@@ -40,6 +41,10 @@ class RemoveButton extends React.PureComponent {
         title={this.props.intl.formatMessage({ id: 'tooltip.remove-segment', defaultMessage: 'Remove segment' })}
         onClick={this.onClick}
       >
+        <FontAwesomeIcon
+          icon="trash-alt"
+          className="remove-icon"
+          title={this.props.intl.formatMessage({ id: 'btn.remove', defaultMessage: 'Remove' })} />
         <FormattedMessage id="btn.remove" defaultMessage="Remove" />
       </button>
     )

--- a/assets/scripts/info_bubble/RemoveButton.jsx
+++ b/assets/scripts/info_bubble/RemoveButton.jsx
@@ -44,7 +44,7 @@ class RemoveButton extends React.PureComponent {
         <FontAwesomeIcon
           icon="trash-alt"
           className="remove-icon"
-          title={this.props.intl.formatMessage({ id: 'btn.remove', defaultMessage: 'Remove' })} />
+        />
         <FormattedMessage id="btn.remove" defaultMessage="Remove" />
       </button>
     )

--- a/assets/scripts/ui/icons.js
+++ b/assets/scripts/ui/icons.js
@@ -10,7 +10,8 @@ import {
   faArrowLeft,
   faTimes,
   faUndo,
-  faRedo
+  faRedo,
+  faTrashAlt
 } from '@fortawesome/free-solid-svg-icons'
 import { faTimesCircle } from '@fortawesome/free-regular-svg-icons'
 import { fab } from '@fortawesome/free-brands-svg-icons'
@@ -22,6 +23,6 @@ export function initIcons () {
     faChevronRight, faChevronLeft,
     faArrowRight, faArrowLeft,
     faTimes, faTimesCircle, fab,
-    faUndo, faRedo
+    faUndo, faRedo, faTrashAlt
   )
 }


### PR DESCRIPTION
I added a trash can icon to the remove button, in response to issue #1168.

Here is the popup/remove button with new trash can icon.
<img width="290" alt="screen shot 2018-11-13 at 4 59 57 pm" src="https://user-images.githubusercontent.com/212235/48452921-18968c00-e766-11e8-811c-4c1dfbe82392.png">

I considered putting the icon [on the left](https://user-images.githubusercontent.com/212235/48453139-01a46980-e767-11e8-9b3d-547fdcd2757b.png), which didn't feel correct.

I also looked at it without the 'Remove' text.

<img width="386" alt="screen shot 2018-11-13 at 3 41 00 pm" src="https://user-images.githubusercontent.com/212235/48452994-601d1800-e766-11e8-8867-c7ef1c9150e5.png">

I think the button could work without the label, but it bugs my eye that the button is a hair wider than the plus button that is immediately below it in most contexts. It feels that they are close enough to me that they should be the same width. Making the icon small enough that the buttons are the same width makes the trash can icon too small. It could be possible to rework the buttons below or the placement of the remove button to resolve. Perhaps part of a future discussion/solution?

Please review and let me know if there is any thing I can clean up from a code or styling point of view.

