### PR TITLE
Gallery: put back "escape" key to hide

### DIFF
--- a/assets/scripts/app/keyboard_commands.js
+++ b/assets/scripts/app/keyboard_commands.js
@@ -4,7 +4,6 @@ import USER_ROLES from '../../../app/data/user_roles'
 import { KEYS } from './keys'
 import { ENV } from './config'
 import { registerKeypress } from './keypress'
-import { showGallery, hideGallery } from '../gallery/view'
 import {
   draggingType,
   DRAGGING_TYPE_RESIZE,
@@ -26,10 +25,6 @@ export function onGlobalKeyDown (event) {
         handleSegmentResizeCancel()
       } else if (draggingType() === DRAGGING_TYPE_MOVE) {
         handleSegmentMoveCancel()
-      } else if (document.body.classList.contains('gallery-visible')) {
-        hideGallery(false)
-      } else if (isSignedIn()) {
-        showGallery(getSignInData().userId, false)
       } else {
         return
       }

--- a/assets/scripts/gallery/Gallery.jsx
+++ b/assets/scripts/gallery/Gallery.jsx
@@ -12,6 +12,7 @@ import Scrollable from '../ui/Scrollable'
 import Avatar from '../users/Avatar'
 import GalleryStreetItem from './GalleryStreetItem'
 import { switchGalleryStreet, repeatReceiveGalleryData, hideGallery } from './view'
+import { registerKeypress, deregisterKeypress } from '../app/keypress'
 import { sendDeleteStreetToServer } from '../streets/xhr'
 import { showError, ERRORS } from '../app/errors'
 import { URL_NEW_STREET, URL_NEW_STREET_COPY_LAST } from '../app/routing'
@@ -20,6 +21,7 @@ import { showDialog } from '../store/actions/dialogs'
 
 class Gallery extends React.Component {
   static propTypes = {
+    visible: PropTypes.bool,
     setGalleryMode: PropTypes.func,
     deleteGalleryStreet: PropTypes.func,
     showDialog: PropTypes.func,
@@ -45,14 +47,26 @@ class Gallery extends React.Component {
 
   componentDidMount () {
     this.scrollSelectedStreetIntoView()
+
+    registerKeypress('esc', this.hideGallery)
   }
 
   componentDidUpdate () {
     this.scrollSelectedStreetIntoView()
   }
 
+  componentWillUnmount () {
+    deregisterKeypress('esc', this.hideGallery)
+  }
+
   componentDidCatch () {
     this.props.setGalleryMode('ERROR')
+  }
+
+  hideGallery = (event) => {
+    if (this.props.visible) {
+      hideGallery()
+    }
   }
 
   selectStreet = (streetId) => {

--- a/assets/scripts/gallery/view.js
+++ b/assets/scripts/gallery/view.js
@@ -59,7 +59,7 @@ export function showGallery (userId, instant = false) {
   updatePageUrl(true)
 }
 
-export function hideGallery (instant) {
+export function hideGallery (instant = false) {
   // Do not hide the gallery if there is no street selected.
   if (galleryState.noStreetSelected === true) {
     return


### PR DESCRIPTION
A regression from way back where pressing `esc` key while the gallery is open is supposed to hide it. This puts it back by adding the listener to the `<Gallery />` component.

This was originally addressed as part of #1129 but it is not dependent on that, so I'm pulling it out into its own PR.