### PR TITLE
flag overrides should ignore flags that no longer exist

### DIFF
--- a/assets/scripts/app/__tests__/flag_overrides.test.js
+++ b/assets/scripts/app/__tests__/flag_overrides.test.js
@@ -60,4 +60,21 @@ describe('applyFlagOverrides', () => {
       BAZ_BAR: { source: 'user', value: true }
     })
   })
+
+  it('does not apply flags that are not present in the application', () => {
+    // It is possible for a flag to be removed or deprecated from the application,
+    // but the value for the flag remains stored in user data or in localstorage.
+    // We do not want these "dead" flags to be in the final object.
+    const userOverrides = {
+      source: 'user',
+      flags: [
+        { flag: 'FOO_BAZ', value: false }
+      ],
+      priority: 1
+    }
+
+    const result = applyFlagOverrides(initialFlags, userOverrides)
+
+    expect(result).toEqual(initialFlags)
+  })
 })

--- a/assets/scripts/app/flag_utils.js
+++ b/assets/scripts/app/flag_utils.js
@@ -90,10 +90,12 @@ export function applyFlagOverrides (defaultFlags, ...flagOverrides) {
     updatedFlags = flags.reduce((obj, item) => {
       const { flag, value } = item
 
-      const prevFlagSource = obj[flag].source
-      const prevPriorityLevel = PRIORITY_LEVELS[prevFlagSource]
-      if (obj[flag].value !== value && prevPriorityLevel < priority) {
-        obj[flag] = { value, source }
+      if (obj[flag]) {
+        const prevFlagSource = obj[flag].source
+        const prevPriorityLevel = PRIORITY_LEVELS[prevFlagSource]
+        if (obj[flag].value !== value && prevPriorityLevel < priority) {
+          obj[flag] = { value, source }
+        }
       }
 
       return obj


### PR DESCRIPTION
Updates `applyFlagOverrides()` to address an edge case where a feature flag is set on the user side, but the feature flag is not present in `app/data/flags.json`. Previously, the script would crash because it attempts, and fails, to override the flag in the initial set of flags. In this PR, we skip flags that aren't in the initial flags.

There are a couple ways a "dead" flag can happen:

1. We are working on new feature flags in different branches, and then switch to another branch that does not have the same feature flags.
2. A feature flag is removed or deprecated from the application, but we haven't removed the flag from user data or local session data.

One possible solution is to pass through dead or unused flags as-is, which would be useful when testing different branches. However, this also encourages dead or unused flags to be never cleaned up in production, so for now, the behavior is to ignore flags that are not used.