### PR TITLE
express: enable CORS for all pre-flight requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -179,16 +179,15 @@ app.get(config.twitter.oauth_callback_uri, controllers.twitter_sign_in_callback.
 // Auth0
 app.get(config.auth0.callback_uri, controllers.auth0_sign_in_callback.get)
 
-app.options('/api/v1/users', cors())
+// Enable CORS for all OPTIONs "pre-flight" requests
+app.options('/api/*', cors())
+
 app.post('/api/v1/users', cors(), resources.v1.users.post)
 app.get('/api/v1/users', cors(), resources.v1.users.get)
-app.options('/api/v1/users/:user_id', cors()) // Enable pre-flight request for authorized PUT request
 app.get('/api/v1/users/:user_id', cors(), resources.v1.user.get)
 app.put('/api/v1/users/:user_id', cors(), resources.v1.user.put)
 app.delete('/api/v1/users/:user_id', cors(), resources.v1.user.delete)
-app.options('/api/v1/users/:user_id/login-token', cors())
 app.delete('/api/v1/users/:user_id/login-token', cors(), resources.v1.user_session.delete)
-app.options('/api/v1/users/:user_id/streets', cors())
 app.delete('/api/v1/users/:user_id/streets', cors(), resources.v1.users_streets.delete)
 app.get('/api/v1/users/:user_id/streets', cors(), resources.v1.users_streets.get)
 


### PR DESCRIPTION
We have to set up `cors()` on enough routes with `OPTIONS` that it might be worthwhile to just set a catch-all one across all OPTIONS routes.

(This isn't `cors()` on _all_ HTTP verbs, although at some point in the future we may need to do that, too.)