### PR TITLE
Make keyboard key a standalone UI component

### DIFF
--- a/assets/locales/ar/main.json
+++ b/assets/locales/ar/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "اختصارات لوحة المفاتيح:",
       "remove": "إزالة الجزء الذي تُشير إليه<br />(إضغط مفتاح <kbd class='key'>Shift</kbd> لإزالة الكل)",
       "move": "جولة حول الشارع<br />(اضغط على مفتاح <kbd class='key'>Shift</kbd> للانتقال إلى الحواف)",
-      "change": "تغيير عرض الجزء الذي تُشير إليه<br />(لمزيد من الدقة إضغط على المفتاح <kbd class='key'>Shift</kbd>)"
+      "change": "تغيير عرض الجزء الذي تُشير إليه<br />(لمزيد من الدقة إضغط على المفتاح <kbd class='key'>Shift</kbd>)",
+      "remove-instruction": "إزالة الجزء الذي تُشير إليه",
+      "remove-shift-instruction": "(إضغط مفتاح {shiftKey} لإزالة الكل)",
+      "move-instruction": "جولة حول الشارع",
+      "move-shift-instruction": "(اضغط على مفتاح {shiftKey} للانتقال إلى الحواف)",
+      "change-instruction": "تغيير عرض الجزء الذي تُشير إليه",
+      "change-shift-instruction": "(لمزيد من الدقة إضغط على المفتاح {shiftKey})"
     },
     "share": {
       "sign-in-twitter-link": "تسجيل الدخول",

--- a/assets/locales/de/main.json
+++ b/assets/locales/de/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Tastatur-Shortcuts:",
       "remove": "Entferne das Element, auf das du zeigst <br />(halte <kbd class='key'>Shift</kbd> gedrückt, um alle zu entfernen)",
       "move": "Bewege dich auf der Straße <br /> (halte <kbd class='key'>Shift</kbd> gedrückt, um zu den Kanten zu springen)",
-      "change": "Ändere die Breite des Elements, auf das du zeigst <br />(halte <kbd class='key'>Shift</kbd> gedrückt für eine höhere Genauigkeit)"
+      "change": "Ändere die Breite des Elements, auf das du zeigst <br />(halte <kbd class='key'>Shift</kbd> gedrückt für eine höhere Genauigkeit)",
+      "remove-instruction": "Entferne das Element, auf das du zeigst",
+      "remove-shift-instruction": "(halte {shiftKey} gedrückt, um alle zu entfernen)",
+      "move-instruction": "Bewege dich auf der Straße",
+      "move-shift-instruction": "(halte {shiftKey} gedrückt, um zu den Kanten zu springen)",
+      "change-instruction": "Ändere die Breite des Elements, auf das du zeigst",
+      "change-shift-instruction": "(halte {shiftKey} gedrückt für eine höhere Genauigkeit)"
     },
     "share": {
       "sign-in-twitter-link": "Anmelden",

--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Keyboard shortcuts:",
       "remove": "Remove a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> to remove all)",
       "move": "Move around the street<br />(hold <kbd class='key'>Shift</kbd> to jump to edges)",
-      "change": "Change width of a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> for more precision)"
+      "change": "Change width of a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> for more precision)",
+      "remove-instruction": "Remove a segment you’re pointing at",
+      "remove-shift-instruction": "(hold {shiftKey} to remove all)",
+      "move-instruction": "Move around the street",
+      "move-shift-instruction": "(hold {shiftKey} to jump to edges)",
+      "change-instruction": "Change width of a segment you’re pointing at",
+      "change-shift-instruction": "(hold {shiftKey} for more precision)"
     },
     "share": {
       "sign-in-twitter-link": "Sign in",

--- a/assets/locales/es-MX/main.json
+++ b/assets/locales/es-MX/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Atajos del teclado:",
       "remove": "Eliminar el segmento que estás apuntando<br />(mantén pulsado <kbd class='key'>Mayús</kbd> para eliminar todo)",
       "move": "Desplazarte por la calle<br /> (mantén presionada<kbd class='key'>Mayús</kbd> para brincar a los bordes)",
-      "change": "Cambiar el ancho del segmento al que estas apuntando<br />(deja pulsada <kbd class='key'>Mayús</kbd> para mayor precisión)"
+      "change": "Cambiar el ancho del segmento al que estas apuntando<br />(deja pulsada <kbd class='key'>Mayús</kbd> para mayor precisión)",
+      "remove-instruction": "Eliminar el segmento que estás apuntando",
+      "remove-shift-instruction": "(mantén pulsado {shiftKey} para eliminar todo)",
+      "move-instruction": "Desplazarte por la calle",
+      "move-shift-instruction": "(mantén presionada {shiftKey} para brincar a los bordes)",
+      "change-instruction": "Cambiar el ancho del segmento al que estas apuntando",
+      "change-shift-instruction": "(deja pulsada {shiftKey} para mayor precisión)"
     },
     "share": {
       "sign-in-twitter-link": "Ingresar",

--- a/assets/locales/es/main.json
+++ b/assets/locales/es/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Teclas de acceso rápido:",
       "remove": "Remover un segmento al que esté apuntando<br />(mantén presionada la tecla <kbd class='key'>Shift</kbd> para remover todo)",
       "move": "Moverse alrededor de la calle<br />(manten presionada la tecla  <kbd class='key'>Shift</kbd> para saltar a los bordes)",
-      "change": "Cambiar lo ancho de un segmento al que estés apuntando<br />(mantén presionada la tecla <kbd class='key'>Shift</kbd> para más precision)"
+      "change": "Cambiar lo ancho de un segmento al que estés apuntando<br />(mantén presionada la tecla <kbd class='key'>Shift</kbd> para más precision)",
+      "remove-instruction": "Remover un segmento al que esté apuntando",
+      "remove-shift-instruction": "(mantén presionada la tecla {shiftKey} para remover todo)",
+      "move-instruction": "Moverse alrededor de la calle",
+      "move-shift-instruction": "(manten presionada la tecla {shiftKey} para saltar a los bordes)",
+      "change-instruction": "Cambiar lo ancho de un segmento al que estés apuntando",
+      "change-shift-instruction": "(mantén presionada la tecla {shiftKey} para más precision)"
     },
     "share": {
       "sign-in-twitter-link": "Acceder",
@@ -268,7 +274,7 @@
   },
   "key": {
     "backspace": "Retrocerder",
-    "shift": "Mover",
+    "shift": "Mayús",
     "plus": "",
     "minus": "",
     "left-arrow": "",

--- a/assets/locales/fi/main.json
+++ b/assets/locales/fi/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Pikanäppäimet:",
       "remove": "Poista osoittimen alla oleva kohde<br />(poista kaikki pitämällä <kbd class='key'>Shift</kbd> pohjassa)",
       "move": "Siirry kadulla<br />(hyppää reunaan pitämällä <kbd class='key'>Shift</kbd> pohjassa)",
-      "change": "Muuta osoittimen alla oleva kohteen leveyttä<br /> (lisää tarkkuutta pitämällä <kbd class='key'>Shift</kbd> pohjassa)"
+      "change": "Muuta osoittimen alla oleva kohteen leveyttä<br /> (lisää tarkkuutta pitämällä <kbd class='key'>Shift</kbd> pohjassa)",
+      "remove-instruction": "Poista osoittimen alla oleva kohde",
+      "remove-shift-instruction": "(poista kaikki pitämällä {shiftKey} pohjassa)",
+      "move-instruction": "Siirry kadulla",
+      "move-shift-instruction": "(hyppää reunaan pitämällä {shiftKey} pohjassa)",
+      "change-instruction": "Muuta osoittimen alla oleva kohteen leveyttä",
+      "change-shift-instruction": "(lisää tarkkuutta pitämällä {shiftKey} pohjassa)"
     },
     "share": {
       "sign-in-twitter-link": "Kirjaudu sisään",

--- a/assets/locales/fr/main.json
+++ b/assets/locales/fr/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Raccourcis claviers :",
       "remove": "Enlever un élément de voirie que vous pointez<br /> (maintenir la touche <kbd class='key'>Shift</kbd> enfoncée pour tout enlever)",
       "move": "Passer d'un segment de rue à un autre<br />(maintenir <kbd class='key'>Shift</kbd> appuyé pour atteindre les extrémités)",
-      "change": "Changer la largeur d'un élément de voirie pointé<br />(maintenir <kbd class='key'>Shift</kbd>pour plus de précision)"
+      "change": "Changer la largeur d'un élément de voirie pointé<br />(maintenir <kbd class='key'>Shift</kbd>pour plus de précision)",
+      "remove-instruction": "Enlever un élément de voirie que vous pointez",
+      "remove-shift-instruction": "(maintenir la touche {shiftKey} enfoncée pour tout enlever)",
+      "move-instruction": "Passer d'un segment de rue à un autre",
+      "move-shift-instruction": "(maintenir {shiftKey} appuyé pour atteindre les extrémités)",
+      "change-instruction": "Changer la largeur d'un élément de voirie pointé",
+      "change-shift-instruction": "(maintenir {shiftKey}pour plus de précision)"
     },
     "share": {
       "sign-in-twitter-link": "Se connecter",
@@ -268,7 +274,7 @@
   },
   "key": {
     "backspace": "Backspace",
-    "shift": "Touche majuscule",
+    "shift": "Shift",
     "plus": "Plus",
     "minus": "Moins",
     "left-arrow": "Flèche de gauche",

--- a/assets/locales/ja/main.json
+++ b/assets/locales/ja/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "キーボードショートカット:",
       "remove": "選択中のセグメントを削除します<br />(<kbd class='key'>Shift</kbd>を押すと全削除)",
       "move": "ストリートを動かす<br />(<kbd class='key'>Shift</kbd> を押すと端に移動)",
-      "change": "選択中のセグメントの幅を変更<br />(<kbd class='key'>Shift</kbd>を押すと微調整可能)"
+      "change": "選択中のセグメントの幅を変更<br />(<kbd class='key'>Shift</kbd>を押すと微調整可能)",
+      "remove-instruction": "選択中のセグメントを削除します",
+      "remove-shift-instruction": "({shiftKey}を押すと全削除)",
+      "move-instruction": "ストリートを動かす",
+      "move-shift-instruction": "({shiftKey}を押すと端に移動)",
+      "change-instruction": "選択中のセグメントの幅を変更",
+      "change-shift-instruction": "({shiftKey}を押すと微調整可能)"
     },
     "share": {
       "sign-in-twitter-link": "サインイン",

--- a/assets/locales/pl/main.json
+++ b/assets/locales/pl/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Skróty klawiszowe:",
       "remove": "Usuń wskazany segment<br />(przytrzymaj <kbd class='key'>Shift</kbd>, aby usunąć wszystko)",
       "move": "Przemieszczaj się po ulicy<br />(przytrzymaj <kbd class='key'>Shift</kbd> aby ustawić się na krawędzi)",
-      "change": "Zmień szerokość wskazanego segmentu<br />(przytrzymaj <kbd class='key'>Shift</kbd> dla zwiększenia precyzji)"
+      "change": "Zmień szerokość wskazanego segmentu<br />(przytrzymaj <kbd class='key'>Shift</kbd> dla zwiększenia precyzji)",
+      "remove-instruction": "Usuń wskazany segment",
+      "remove-shift-instruction": "(przytrzymaj {shiftKey}, aby usunąć wszystko)",
+      "move-instruction": "Przemieszczaj się po ulicy",
+      "move-shift-instruction": "(przytrzymaj {shiftKey} aby ustawić się na krawędzi)",
+      "change-instruction": "Zmień szerokość wskazanego segmentu",
+      "change-shift-instruction": "(przytrzymaj {shiftKey} dla zwiększenia precyzji)"
     },
     "share": {
       "sign-in-twitter-link": "Zaloguj się",
@@ -268,7 +274,7 @@
   },
   "key": {
     "backspace": "Backspace",
-    "shift": "Przesuń",
+    "shift": "Shift",
     "plus": "Plus",
     "minus": "Minus",
     "left-arrow": "Strzałka w lewo",

--- a/assets/locales/pt-BR/main.json
+++ b/assets/locales/pt-BR/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Teclas de atalho:",
       "remove": "Remover um segmento que você está apontando<br />(segure <kbd class='key'>Shift</kbd> para remover tudo)",
       "move": "Movimente-se pela rua<br />(segure <kbd class='key'>Shift</kbd> para saltar para as bordas)",
-      "change": "Mudar largura do segmento que você está apontando<br />(segure <kbd class='key'>Shift</kbd> para obter mais precisão)"
+      "change": "Mudar largura do segmento que você está apontando<br />(segure <kbd class='key'>Shift</kbd> para obter mais precisão)",
+      "remove-instruction": "Remover um segmento que você está apontando",
+      "remove-shift-instruction": "(segure {shiftKey} para remover tudo)",
+      "move-instruction": "Movimente-se pela rua",
+      "move-shift-instruction": "(segure {shiftKey} para saltar para as bordas)",
+      "change-instruction": "Mudar largura do segmento que você está apontando",
+      "change-shift-instruction": "(segure {shiftKey} para obter mais precisão)"
     },
     "share": {
       "sign-in-twitter-link": "Entrar",

--- a/assets/locales/ru/main.json
+++ b/assets/locales/ru/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Сочетания клавиш:",
       "remove": "Удалить сегмент, на который вы указываете<br />(зажмите <kbd class='key'>Shift</kbd> для удаления всех сегментов)",
       "move": "Передвинуться по улице<br />(зажмите <kbd class='key'>Shift</kbd> для перехода на грани)",
-      "change": "Изменить ширину сегмента, на который вы указываете<br />(зажмите <kbd class='key'>Shift</kbd> для более точного изменения)"
+      "change": "Изменить ширину сегмента, на который вы указываете<br />(зажмите <kbd class='key'>Shift</kbd> для более точного изменения)",
+      "remove-instruction": "Удалить сегмент, на который вы указываете",
+      "remove-shift-instruction": "(зажмите {shiftKey} для удаления всех сегментов)",
+      "move-instruction": "Передвинуться по улице",
+      "move-shift-instruction": "(зажмите {shiftKey} для перехода на грани)",
+      "change-instruction": "Изменить ширину сегмента, на который вы указываете",
+      "change-shift-instruction": "(зажмите {shiftKey} для более точного изменения)"
     },
     "share": {
       "sign-in-twitter-link": "Войти",

--- a/assets/locales/sv/main.json
+++ b/assets/locales/sv/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "Snabbkommandon:",
       "remove": "Ta bort ett segment du pekar på<br />(håll inne <kbd class='key'>Shift</kbd> för att ta bort alla)",
       "move": "",
-      "change": ""
+      "change": "",
+      "remove-instruction": "Ta bort ett segment du pekar på",
+      "remove-shift-instruction": "(håll inne {shiftKey} för att ta bort alla)",
+      "move-instruction": "",
+      "move-shift-instruction": "",
+      "change-instruction": "",
+      "change-shift-instruction": ""
     },
     "share": {
       "sign-in-twitter-link": "Logga in",

--- a/assets/locales/zh-Hans/main.json
+++ b/assets/locales/zh-Hans/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "快捷键：",
       "remove": "移除鼠标所指的部分<br />（长按<kbd class='key'>Shift</kbd>来移除所有的部分）",
       "move": "移动这一部分的街道<br /> （长按<kbd class='key'>Shift</kbd>来跳到边上）",
-      "change": "更改鼠标所指街道部分<br />的宽度（长按<kbd class='key'>Shift</kbd>来进行微调）"
+      "change": "更改鼠标所指街道部分<br />的宽度（长按<kbd class='key'>Shift</kbd>来进行微调）",
+      "remove-instruction": "移除鼠标所指的部分",
+      "remove-shift-instruction": "（长按{shiftKey}来移除所有的部分）",
+      "move-instruction": "移动这一部分的街道",
+      "move-shift-instruction": "（长按{shiftKey}来跳到边上）",
+      "change-instruction": "更改鼠标所指街道部分",
+      "change-shift-instruction": "的宽度（长按{shiftKey}来进行微调）"
     },
     "share": {
       "sign-in-twitter-link": "登陆",
@@ -268,7 +274,7 @@
   },
   "key": {
     "backspace": "退格键",
-    "shift": "Shift键",
+    "shift": "Shift",
     "plus": "",
     "minus": "",
     "left-arrow": "",

--- a/assets/locales/zh-Hant/main.json
+++ b/assets/locales/zh-Hant/main.json
@@ -17,7 +17,13 @@
       "keyboard-label": "快捷鍵：",
       "remove": "移除你現在所指的部分<br />（長按<kbd class='key'>Shift</kbd>來移除所有的部分）",
       "move": "移動這個部分<br /> （長按<kbd class='key'>Shift</kbd>來跳到邊上）",
-      "change": "更改你現在所指部分<br />的寬度（長按<kbd class='key'>Shift</kbd>來微調）"
+      "change": "更改你現在所指部分<br />的寬度（長按<kbd class='key'>Shift</kbd>來微調）",
+      "remove-instruction": "移除你現在所指的部分",
+      "remove-shift-instruction": "（長按<kbd class='key'>Shift</kbd>來移除所有的部分）",
+      "move-instruction": "移動這個部分",
+      "move-shift-instruction": "（長按<kbd class='key'>Shift</kbd>來跳到邊上）",
+      "change-instruction": "更改你現在所指部分",
+      "change-shift-instruction": "的寬度（長按<kbd class='key'>Shift</kbd>來微調）"
     },
     "share": {
       "sign-in-twitter-link": "登錄",
@@ -268,7 +274,7 @@
   },
   "key": {
     "backspace": "退位鍵",
-    "shift": "Shift鍵",
+    "shift": "Shift",
     "plus": "",
     "minus": "",
     "left-arrow": "",

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -2,8 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FormattedMessage, FormattedHTMLMessage, injectIntl, intlShape } from 'react-intl'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Menu from './Menu'
+import KeyboardKey from '../ui/KeyboardKey'
+import {
+  ICON_MINUS,
+  ICON_PLUS,
+  ICON_ARROW_RIGHT,
+  ICON_ARROW_LEFT
+} from '../ui/icons'
 import { registerKeypress } from '../app/keypress'
 import { trackEvent } from '../app/event_tracking'
 import { showDialog } from '../store/actions/dialogs'
@@ -48,7 +54,9 @@ class HelpMenu extends React.PureComponent {
             <tbody>
               <tr>
                 <td>
-                  <kbd className="key"><FormattedMessage id="key.backspace" defaultMessage="Backspace" /></kbd>
+                  <KeyboardKey>
+                    <FormattedMessage id="key.backspace" defaultMessage="Backspace" />
+                  </KeyboardKey>
                 </td>
                 <td>
                   <FormattedHTMLMessage
@@ -59,20 +67,17 @@ class HelpMenu extends React.PureComponent {
               </tr>
               <tr>
                 <td>
-                  <kbd
-                    className="key key-icon"
-                    title={this.props.intl.formatMessage({ id: 'key.minus', defaultMessage: 'Minus' })}
-                  >
-                    <FontAwesomeIcon icon="minus" />
-                  </kbd>
-                  <kbd
-                    className="key key-icon"
-                    title={this.props.intl.formatMessage({ id: 'key.plus', defaultMessage: 'Plus' })}
-                  >
-                    <FontAwesomeIcon icon="plus" />
-                  </kbd>
+                  {/* <FormattedMessage> used with render prop because we pass the translated
+                      text to <KeyboardKey> as a string, not as a component */}
+                  <FormattedMessage id="key.minus" defaultMessage="Minus">
+                    {(label) => <KeyboardKey icon={ICON_MINUS} label={label} />}
+                  </FormattedMessage>
+                  <FormattedMessage id="key.plus" defaultMessage="Plus">
+                    {(label) => <KeyboardKey icon={ICON_PLUS} label={label} />}
+                  </FormattedMessage>
                 </td>
                 <td>
+                  {/* Note: the keyboard keys are currently hard-coded into the translation text. */}
                   <FormattedHTMLMessage
                     id="menu.help.change"
                     defaultMessage="Move around the street<br />(hold <kbd class='key'>Shift</kbd> to jump to edges)"
@@ -81,18 +86,12 @@ class HelpMenu extends React.PureComponent {
               </tr>
               <tr>
                 <td>
-                  <kbd
-                    className="key key-icon"
-                    title={this.props.intl.formatMessage({ id: 'key.left-arrow', defaultMessage: 'Left arrow' })}
-                  >
-                    <FontAwesomeIcon icon="arrow-left" />
-                  </kbd>
-                  <kbd
-                    className="key key-icon"
-                    title={this.props.intl.formatMessage({ id: 'key.right-arrow', defaultMessage: 'Right arrow' })}
-                  >
-                    <FontAwesomeIcon icon="arrow-right" />
-                  </kbd>
+                  <FormattedMessage id="key.left-arrow" defaultMessage="Left arrow">
+                    {(label) => <KeyboardKey icon={ICON_ARROW_LEFT} label={label} />}
+                  </FormattedMessage>
+                  <FormattedMessage id="key.right-arrow" defaultMessage="Right arrow">
+                    {(label) => <KeyboardKey icon={ICON_ARROW_RIGHT} label={label} />}
+                  </FormattedMessage>
                 </td>
                 <td>
                   <FormattedHTMLMessage

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { FormattedMessage, FormattedHTMLMessage, injectIntl, intlShape } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import Menu from './Menu'
 import KeyboardKey from '../ui/KeyboardKey'
 import {
@@ -15,9 +15,8 @@ import { trackEvent } from '../app/event_tracking'
 import { showDialog } from '../store/actions/dialogs'
 import './HelpMenu.scss'
 
-class HelpMenu extends React.PureComponent {
+class HelpMenu extends Component {
   static propTypes = {
-    intl: intlShape.isRequired,
     showAboutDialog: PropTypes.func,
     showWhatsNewDialog: PropTypes.func
   }
@@ -32,21 +31,21 @@ class HelpMenu extends React.PureComponent {
   }
 
   render () {
+    const shiftKey = (
+      <KeyboardKey>
+        <FormattedMessage id="key.shift" defaultMessage="Shift" />
+      </KeyboardKey>
+    )
+
     return (
       <Menu onShow={this.onShow} {...this.props}>
-        <a
-          href="#"
-          onClick={this.props.showAboutDialog}
-        >
+        <a href="#" onClick={this.props.showAboutDialog}>
           <FormattedMessage id="menu.item.about" defaultMessage="About Streetmix…" />
         </a>
-        <a
-          href="#"
-          onClick={this.props.showWhatsNewDialog}
-        >
+        <a href="#" onClick={this.props.showWhatsNewDialog}>
           <FormattedMessage id="dialogs.whatsnew.heading" defaultMessage="What’s new in Streetmix? [en]&lrm;" />
         </a>
-        <div className="form non-touch-only help-menu-shortcuts">
+        <div className="help-menu-shortcuts non-touch-only">
           <p>
             <FormattedMessage id="menu.help.keyboard-label" defaultMessage="Keyboard shortcuts:" />
           </p>
@@ -59,9 +58,15 @@ class HelpMenu extends React.PureComponent {
                   </KeyboardKey>
                 </td>
                 <td>
-                  <FormattedHTMLMessage
-                    id="menu.help.remove"
-                    defaultMessage="Remove a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> to remove all)"
+                  <FormattedMessage
+                    id="menu.help.remove-instruction"
+                    defaultMessage="Remove a segment you’re pointing at"
+                  />
+                  <br />
+                  <FormattedMessage
+                    id="menu.help.remove-shift-instruction"
+                    defaultMessage="(hold {shiftKey} to remove all)&lrm;"
+                    values={{ shiftKey }}
                   />
                 </td>
               </tr>
@@ -77,10 +82,15 @@ class HelpMenu extends React.PureComponent {
                   </FormattedMessage>
                 </td>
                 <td>
-                  {/* Note: the keyboard keys are currently hard-coded into the translation text. */}
-                  <FormattedHTMLMessage
-                    id="menu.help.change"
-                    defaultMessage="Move around the street<br />(hold <kbd class='key'>Shift</kbd> to jump to edges)"
+                  <FormattedMessage
+                    id="menu.help.change-instruction"
+                    defaultMessage="Change width of a segment you’re pointing at"
+                  />
+                  <br />
+                  <FormattedMessage
+                    id="menu.help.change-shift-instruction"
+                    defaultMessage="(hold {shiftKey} for more precision)&lrm;"
+                    values={{ shiftKey }}
                   />
                 </td>
               </tr>
@@ -94,9 +104,15 @@ class HelpMenu extends React.PureComponent {
                   </FormattedMessage>
                 </td>
                 <td>
-                  <FormattedHTMLMessage
-                    id="menu.help.move"
-                    defaultMessage="Change width of a segment you’re pointing at<br />(hold <kbd class='key'>Shift</kbd> for more precision)"
+                  <FormattedMessage
+                    id="menu.help.move-instruction"
+                    defaultMessage="Move around the street"
+                  />
+                  <br />
+                  <FormattedMessage
+                    id="menu.help.move-shift-instruction"
+                    defaultMessage="(hold {shiftKey} to jump to edges)&lrm;"
+                    values={{ shiftKey }}
                   />
                 </td>
               </tr>
@@ -108,10 +124,6 @@ class HelpMenu extends React.PureComponent {
   }
 }
 
-// Inject Intl via a higher-order component provided by react-intl.
-// Exported so that this component can be tested.
-export const HelpMenuWithIntl = injectIntl(HelpMenu)
-
 function mapDispatchToProps (dispatch) {
   return {
     showAboutDialog: () => { dispatch(showDialog('ABOUT')) },
@@ -119,4 +131,4 @@ function mapDispatchToProps (dispatch) {
   }
 }
 
-export default connect(null, mapDispatchToProps)(HelpMenuWithIntl)
+export default connect(null, mapDispatchToProps)(HelpMenu)

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -71,7 +71,7 @@ class HelpMenu extends Component {
                 </td>
               </tr>
               <tr>
-                <td>
+                <td dir="ltr">
                   {/* <FormattedMessage> used with render prop because we pass the translated
                       text to <KeyboardKey> as a string, not as a component */}
                   <FormattedMessage id="key.minus" defaultMessage="Minus">
@@ -95,7 +95,7 @@ class HelpMenu extends Component {
                 </td>
               </tr>
               <tr>
-                <td>
+                <td dir="ltr">
                   <FormattedMessage id="key.left-arrow" defaultMessage="Left arrow">
                     {(label) => <KeyboardKey icon={ICON_ARROW_LEFT}>{label}</KeyboardKey>}
                   </FormattedMessage>

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -75,10 +75,10 @@ class HelpMenu extends Component {
                   {/* <FormattedMessage> used with render prop because we pass the translated
                       text to <KeyboardKey> as a string, not as a component */}
                   <FormattedMessage id="key.minus" defaultMessage="Minus">
-                    {(label) => <KeyboardKey icon={ICON_MINUS} label={label} />}
+                    {(label) => <KeyboardKey icon={ICON_MINUS}>{label}</KeyboardKey>}
                   </FormattedMessage>
                   <FormattedMessage id="key.plus" defaultMessage="Plus">
-                    {(label) => <KeyboardKey icon={ICON_PLUS} label={label} />}
+                    {(label) => <KeyboardKey icon={ICON_PLUS}>{label}</KeyboardKey>}
                   </FormattedMessage>
                 </td>
                 <td>
@@ -97,10 +97,10 @@ class HelpMenu extends Component {
               <tr>
                 <td>
                   <FormattedMessage id="key.left-arrow" defaultMessage="Left arrow">
-                    {(label) => <KeyboardKey icon={ICON_ARROW_LEFT} label={label} />}
+                    {(label) => <KeyboardKey icon={ICON_ARROW_LEFT}>{label}</KeyboardKey>}
                   </FormattedMessage>
                   <FormattedMessage id="key.right-arrow" defaultMessage="Right arrow">
-                    {(label) => <KeyboardKey icon={ICON_ARROW_RIGHT} label={label} />}
+                    {(label) => <KeyboardKey icon={ICON_ARROW_RIGHT}>{label}</KeyboardKey>}
                   </FormattedMessage>
                 </td>
                 <td>

--- a/assets/scripts/menus/HelpMenu.jsx
+++ b/assets/scripts/menus/HelpMenu.jsx
@@ -15,7 +15,7 @@ import { trackEvent } from '../app/event_tracking'
 import { showDialog } from '../store/actions/dialogs'
 import './HelpMenu.scss'
 
-class HelpMenu extends Component {
+export class HelpMenu extends Component {
   static propTypes = {
     showAboutDialog: PropTypes.func,
     showWhatsNewDialog: PropTypes.func

--- a/assets/scripts/menus/HelpMenu.scss
+++ b/assets/scripts/menus/HelpMenu.scss
@@ -3,6 +3,11 @@
   max-width: 400px;
   line-height: 18px;
 
+  [dir="rtl"] & {
+    padding-left: 1em;
+    padding-right: 2.5em;
+  }
+
   p:first-child {
     margin-top: 0;
   }

--- a/assets/scripts/menus/HelpMenu.scss
+++ b/assets/scripts/menus/HelpMenu.scss
@@ -1,4 +1,23 @@
 .help-menu-shortcuts {
+  padding: 0.5em 1em 1em 2.5em;
   max-width: 400px;
   line-height: 18px;
+
+  p:first-child {
+    margin-top: 0;
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: -5px;
+
+    td {
+      vertical-align: top;
+      padding: 5px;
+    }
+
+    td:first-child {
+      min-width: 60px;
+    }
+  }
 }

--- a/assets/scripts/menus/Menu.scss
+++ b/assets/scripts/menus/Menu.scss
@@ -86,28 +86,6 @@ body.safari .menu {
   }
 }
 
-.menu .form {
-  padding: 0.5em 1em 1em 2.5em;
-
-  p:first-child {
-    margin-top: 0;
-  }
-
-  table {
-    border-collapse: collapse;
-    margin: -5px;
-
-    td {
-      vertical-align: top;
-      padding: 5px;
-    }
-
-    td:first-child {
-      min-width: 60px;
-    }
-  }
-}
-
 .menu-header {
   font-weight: bold;
   margin: 0;

--- a/assets/scripts/menus/__tests__/HelpMenu.test.js
+++ b/assets/scripts/menus/__tests__/HelpMenu.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import { shallowWithIntl as shallow } from '../../../../test/helpers/intl-enzyme-test-helper.js'
-import { HelpMenuWithIntl as HelpMenu } from '../HelpMenu'
+import { shallow } from 'enzyme'
+import HelpMenu from '../HelpMenu'
 
 describe('HelpMenu', () => {
   it('renders without crashing', () => {

--- a/assets/scripts/menus/__tests__/HelpMenu.test.js
+++ b/assets/scripts/menus/__tests__/HelpMenu.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
 import { shallow } from 'enzyme'
-import HelpMenu from '../HelpMenu'
+import { HelpMenu } from '../HelpMenu'
 
 describe('HelpMenu', () => {
   it('renders without crashing', () => {

--- a/assets/scripts/palette/PaletteCommandsLeft.jsx
+++ b/assets/scripts/palette/PaletteCommandsLeft.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import CloseButton from '../ui/CloseButton'
-import { TOOLS_ICON } from '../ui/icons'
+import { ICON_TOOLS } from '../ui/icons'
 import { toggleToolbox } from '../store/actions/ui'
 import './PaletteCommandsLeft.scss'
 
@@ -53,7 +53,7 @@ class PaletteCommandsLeft extends Component {
         onClick={this.handleClickTools}
         title={'Toggle tools'}
       >
-        <FontAwesomeIcon icon={TOOLS_ICON} />
+        <FontAwesomeIcon icon={ICON_TOOLS} />
       </button>
     )
 

--- a/assets/scripts/palette/UndoRedo.jsx
+++ b/assets/scripts/palette/UndoRedo.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { UNDO_ICON, REDO_ICON } from '../ui/icons'
+import { ICON_UNDO, ICON_REDO } from '../ui/icons'
 import { undo, redo } from '../store/actions/undo'
 import { isUndoAvailable, isRedoAvailable } from '../streets/undo_stack'
 
@@ -29,7 +29,7 @@ export class UndoRedo extends React.Component {
               disabled={!isUndoAvailable()}
               title={title}
             >
-              <FontAwesomeIcon icon={UNDO_ICON} />
+              <FontAwesomeIcon icon={ICON_UNDO} />
             </button>
           )}
         </FormattedMessage>
@@ -40,7 +40,7 @@ export class UndoRedo extends React.Component {
               disabled={!isRedoAvailable()}
               title={title}
             >
-              <FontAwesomeIcon icon={REDO_ICON} />
+              <FontAwesomeIcon icon={ICON_REDO} />
             </button>
           )}
         </FormattedMessage>

--- a/assets/scripts/ui/KeyboardKey.jsx
+++ b/assets/scripts/ui/KeyboardKey.jsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import './KeyboardKey.scss'
+
+const KeyboardKey = (props) => {
+  if (props.icon && props.label) {
+    // The `title` property on <kbd> is suggested to provide
+    // accessible text for the icon being displayed.
+    return (
+      <kbd
+        className="key key-icon"
+        title={props.label}
+      >
+        <FontAwesomeIcon icon={props.icon} />
+      </kbd>
+    )
+  }
+
+  // A `title` property is not required here because the
+  // child elements provide their own text
+  return (
+    <kbd className="key">
+      {props.children}
+    </kbd>
+  )
+}
+
+KeyboardKey.propTypes = {
+  children: PropTypes.any,
+  label: PropTypes.string,
+  icon: PropTypes.string
+}
+
+export default KeyboardKey

--- a/assets/scripts/ui/KeyboardKey.jsx
+++ b/assets/scripts/ui/KeyboardKey.jsx
@@ -4,13 +4,16 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import './KeyboardKey.scss'
 
 const KeyboardKey = (props) => {
-  if (props.icon && props.label) {
+  if (props.icon && typeof props.children === 'string') {
     // The `title` property on <kbd> is suggested to provide
-    // accessible text for the icon being displayed.
+    // accessible text for the icon being displayed. In this
+    // case we use the `children` prop as the `title`, which
+    // means it's necessary for this to be a simple string content
+    // and not a React component
     return (
       <kbd
         className="key key-icon"
-        title={props.label}
+        title={props.children}
       >
         <FontAwesomeIcon icon={props.icon} />
       </kbd>
@@ -28,8 +31,7 @@ const KeyboardKey = (props) => {
 
 KeyboardKey.propTypes = {
   children: PropTypes.any,
-  label: PropTypes.string,
-  icon: PropTypes.string
+  icon: PropTypes.object
 }
 
 export default KeyboardKey

--- a/assets/scripts/ui/KeyboardKey.scss
+++ b/assets/scripts/ui/KeyboardKey.scss
@@ -1,0 +1,31 @@
+// Keyboard button
+.key {
+  position: relative;
+  display: inline-block;
+  padding: 0.2em 0.75em;
+  margin: 0 0.25em;
+  border: #ccc 1px solid;
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: bold;
+  // Mac OS X default monospace font has different sized left/right arrows, so use Menlo instead
+  font-family: 'Menlo', monospace;
+  background: #f4f4f4;
+  color: rgb(64, 64, 64);
+  text-shadow: #fff 0 1px 0;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 0 0 #fff inset;
+  white-space: nowrap;
+}
+
+.key-icon {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 24px;
+  height: 24px;
+
+  > svg.svg-inline--fa {
+    margin-left: 0.5px; /* adjust off-centering */
+    margin-top: 1px; /* adjust off-centering */
+  }
+}

--- a/assets/scripts/ui/__tests__/KeyboardKey.test.js
+++ b/assets/scripts/ui/__tests__/KeyboardKey.test.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import KeyboardKey from '../KeyboardKey'
+
+describe('KeyboardKey', () => {
+  it('renders a <kbd> element with string child', () => {
+    const wrapper = shallow(<KeyboardKey>foo</KeyboardKey>)
+    expect(wrapper.props().title).toBeUndefined()
+    expect(wrapper.debug()).toMatchSnapshot()
+  })
+
+  it('renders a <kbd> element with element child', () => {
+    const wrapper = shallow(<KeyboardKey><strong>foo</strong></KeyboardKey>)
+    expect(wrapper.props().title).toBeUndefined()
+    expect(wrapper.debug()).toMatchSnapshot()
+  })
+
+  it('renders a <kbd> element with icon and title', () => {
+    const wrapper = shallow(<KeyboardKey icon={{ prefix: 'fas', icon: 'minus' }}>foo</KeyboardKey>)
+    expect(wrapper.find('FontAwesomeIcon').length).toBe(1)
+    expect(wrapper.props().title).toBe('foo')
+    expect(wrapper.debug()).toMatchSnapshot()
+  })
+})

--- a/assets/scripts/ui/__tests__/__snapshots__/KeyboardKey.test.js.snap
+++ b/assets/scripts/ui/__tests__/__snapshots__/KeyboardKey.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`KeyboardKey renders a <kbd> element with element child 1`] = `
+"<kbd className=\\"key\\">
+  <strong>
+    foo
+  </strong>
+</kbd>"
+`;
+
+exports[`KeyboardKey renders a <kbd> element with icon and title 1`] = `
+"<kbd className=\\"key key-icon\\" title=\\"foo\\">
+  <FontAwesomeIcon icon={{...}} border={false} className=\\"\\" mask={{...}} fixedWidth={false} inverse={false} flip={{...}} listItem={false} pull={{...}} pulse={false} rotation={{...}} size={{...}} spin={false} symbol={false} title=\\"\\" transform={{...}} />
+</kbd>"
+`;
+
+exports[`KeyboardKey renders a <kbd> element with string child 1`] = `
+"<kbd className=\\"key\\">
+  foo
+</kbd>"
+`;

--- a/assets/scripts/ui/icons.js
+++ b/assets/scripts/ui/icons.js
@@ -23,9 +23,13 @@ import {
 } from '@fortawesome/free-brands-svg-icons'
 
 // Alternative icon reference, which can be mocked and tested
-export const UNDO_ICON = faUndo
-export const REDO_ICON = faRedo
-export const TOOLS_ICON = faTools
+export const ICON_UNDO = faUndo
+export const ICON_REDO = faRedo
+export const ICON_TOOLS = faTools
+export const ICON_MINUS = faMinus
+export const ICON_PLUS = faPlus
+export const ICON_ARROW_RIGHT = faArrowRight
+export const ICON_ARROW_LEFT = faArrowLeft
 
 export const ICON_TWITTER = faTwitter
 export const ICON_FACEBOOK = faFacebookSquare

--- a/assets/styles/_chrome.scss
+++ b/assets/styles/_chrome.scss
@@ -133,35 +133,3 @@ body.controls-fade-out .segment.hover .hover-bk {
   transition: opacity $touch-controls-fadeout-time !important;
   opacity: 0.01 !important;
 }
-
-// Keyboard button
-.key {
-  position: relative;
-  display: inline-block;
-  padding: 0.2em 0.75em;
-  margin: 0 0.25em;
-  border: #ccc 1px solid;
-  border-radius: 4px;
-  font-size: 0.8em;
-  font-weight: bold;
-  // Mac OS X default monospace font has different sized left/right arrows, so use Menlo instead
-  font-family: 'Menlo', monospace;
-  background: #f4f4f4;
-  color: rgb(64, 64, 64);
-  text-shadow: #fff 0 1px 0;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 1px 0 0 #fff inset;
-  white-space: nowrap;
-}
-
-.key-icon {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  width: 24px;
-  height: 24px;
-
-  > svg.svg-inline--fa {
-    margin-left: 0.5px; /* adjust off-centering */
-    margin-top: 1px; /* adjust off-centering */
-  }
-}


### PR DESCRIPTION
- Creates a new `<KeyboardKey />` UI component for the keyboard keys used in the Help menu.
- This allows the component to import its own styles.
- This also abstracts away the exact HTML syntax for these elements. (The class "key" is used on the `<kbd>` element to create the keyboard effect because we should not assume that the element will always be used to indicate a keyboard key.)
- We also remove the the need to hard-code this HTML syntax in the translation string.
- As a result we break up the translation string into two parts to remove all HTML and to allow substitution of React components into the translation string.
- This actually results in a refactor of `<HelpMenu />` that makes it simpler and easier to test.
- All locale files are manually updated here to support this change, and a follow up task is to make the same changes on the Transifex side so that future exports of locale data won't overwrite this change.