### PR TITLE
Cloudinary

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,10 +19,12 @@ const resources = require('./app/resources')
 const requestHandlers = require('./lib/request_handlers')
 const initRedisClient = require('./lib/redis')
 const initMongoDB = require('./lib/db')
+const initCloudinary = require('./lib/cloudinary')
 const exec = require('child_process').exec
 
 const client = initRedisClient()
 initMongoDB()
+initCloudinary()
 
 const app = module.exports = express()
 

--- a/app/resources/v1/user.js
+++ b/app/resources/v1/user.js
@@ -304,12 +304,6 @@ exports.delete = async function (req, res) {
     }
 
     // If successful in deleting user, delete user's profile image cached in cloudinary.
-    cloudinary.config({
-      cloud_name: 'streetmix',
-      api_key: config.cloudinary.api_key,
-      api_secret: config.cloudinary.api_secret
-    })
-
     const publicId = `${config.env}/profile_image/${targetUserId}`
 
     try {

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -125,7 +125,7 @@ exports.post = function (req, res) {
         profileImageUrl = response.secure_url
       } catch (error) {
         logger.error(error)
-        // If unable to cache image, simply return credentials profile image url.
+        // If unable to cache image, return credentials.profile_image_url.
         profileImageUrl = credentials.profile_image_url
       }
     }

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -1,6 +1,7 @@
 
 const config = require('config')
 const uuid = require('uuid')
+const cloudinary = require('cloudinary')
 const User = require('../../models/user.js')
 const { ERRORS } = require('../../../lib/util')
 const logger = require('../../../lib/logger.js')()
@@ -110,6 +111,37 @@ exports.post = function (req, res) {
     return nickname + '-' + id
   }
 
+  const handleUserProfileImage = async function (userId, credentials) {
+    const publicId = `${config.env}/profile_image/${userId}`
+
+    cloudinary.config({
+      cloud_name: 'streetmix',
+      api_key: config.cloudinary.api_key,
+      api_secret: config.cloudinary.api_secret
+    })
+
+    let response, profileImageUrl
+
+    try {
+      response = await cloudinary.v2.api.resource(publicId)
+      profileImageUrl = response.secure_url
+    } catch (error) {
+      logger.error(error)
+    }
+
+    if (!response) {
+      try {
+        response = await cloudinary.v2.uploader.upload(credentials.profile_image_url, { upload_preset: 'profile_image', public_id: publicId })
+        profileImageUrl = response.secure_url
+      } catch (error) {
+        logger.error(error)
+        profileImageUrl = credentials.profile_image_url
+      }
+    }
+
+    return profileImageUrl
+  }
+
   const handleAuth0SignIn = async function (credentials) {
     try {
       const user = await User.findOne({ auth0_id: credentials.auth0_id })
@@ -138,8 +170,10 @@ exports.post = function (req, res) {
           u.save(handleCreateUser)
         }
       } else {
+        const profileImageUrl = await handleUserProfileImage(user.id, credentials)
+
         user.auth0_id = credentials.auth0_id
-        user.profile_image_url = credentials.profile_image_url
+        user.profile_image_url = profileImageUrl
         user.email = credentials.email
         user.login_tokens.push(loginToken)
         user.save(handleUpdateUser)

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -116,7 +116,7 @@ exports.post = function (req, res) {
     let profileImageUrl
 
     // Check if user has profile image already cached in cloudinary
-    if (user.profile_image_url.includes(publicId)) {
+    if (user.profile_image_url && user.profile_image_url.includes(publicId)) {
       profileImageUrl = user.profile_image_url
     } else if (credentials.profile_image_url) {
       // If no profile image cached in cloudinary, cache image provided by credentials and return cloudinary url.

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -132,7 +132,7 @@ exports.post = function (req, res) {
 
     // If no cached image, upload image from credentials to cloudinary and return new cloudinary url.
     // If failed to cache image, use existing credentials profile image url.
-    if (!response) {
+    if (!response && credentials.profile_image_url) {
       try {
         response = await cloudinary.v2.uploader.upload(credentials.profile_image_url, { upload_preset: 'profile_image', public_id: publicId })
         profileImageUrl = response.secure_url

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -122,6 +122,7 @@ exports.post = function (req, res) {
 
     let response, profileImageUrl
 
+    // Check if user has profile image already cached in cloudinary
     try {
       response = await cloudinary.v2.api.resource(publicId)
       profileImageUrl = response.secure_url
@@ -129,6 +130,8 @@ exports.post = function (req, res) {
       logger.error(error)
     }
 
+    // If no cached image, upload image from credentials to cloudinary and return new cloudinary url.
+    // If failed to cache image, use existing credentials profile image url.
     if (!response) {
       try {
         response = await cloudinary.v2.uploader.upload(credentials.profile_image_url, { upload_preset: 'profile_image', public_id: publicId })

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -1,0 +1,10 @@
+const config = require('config')
+const cloudinary = require('cloudinary')
+
+module.exports = function () {
+  cloudinary.config({
+    cloud_name: 'streetmix',
+    api_key: config.cloudinary.api_key,
+    api_secret: config.cloudinary.api_secret
+  })
+}


### PR DESCRIPTION
- Initialized cloudinary config in `app.js` so we don't need to call `cloudinary.config()` each time we need to upload/delete images from cloudinary
- When a user logs in, the user's profile image url is checked to see if it was cached in cloudinary. If not, the image url given by credentials is uploaded to cloudinary and the new cloudinary url is returned. (This makes cloudinary the single source of truth for a user's profile image url. Previously even if a user changes their profile image through the admin dashboard, if the user signs out and then signs back in, the profile image is changed back to the one provided by the platform they used to sign in.)
- When a user is deleted through the admin dashboard, the profile image for the deleted user is removed from cloudinary.

**NOTE**: If the cloudinary methods to upload/delete fails, I have logged the error but I do not stop the api request. For example, if we failed to upload the `credentials.profile_image_url` to cloudinary, I log the error but simply allow streetmix to continue using `credentials.profile_image_url` instead of the cloudinary url. Similarly, if cloudinary fails to delete the profile image associated with the deleted user, I log the error but allow the request to end successfully since I do not think not being able to delete the user's profile image from cloudinary should cause the whole thing to fail. **Let me know if you think that I should fail the request if cloudinary fails!**
