### PR TITLE
Add CodeCovc reporting to the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ script:
 
 # Send exit signal to node process
 after_script:
+  - bash <(curl -s https://codecov.io/bash)
   - pkill node
 
 after_failure:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:css": "stylelint ./assets/styles/**/*.scss",
     "lint:js": "eslint \"**/*.js\" \"**/*.jsx\"",
     "lint:json": "find assets -name '*.json' -exec jsonlint {} --quiet \\;",
-    "jest": "jest",
+    "jest": "jest --collectCoverage",
     "jest:watch": "jest --watch",
     "protractor:update": "./node_modules/protractor/bin/webdriver-manager update",
     "protractor:local": "protractor ./test/integration/local.conf.js",
@@ -51,6 +51,12 @@
     ],
     "setupFiles": [
       "./test/setup-jest.js"
+    ],
+    "collectCoverageFrom": [
+      "app.js",
+      "app/**/*.{js,jsx}",
+      "assets/scripts/**/*.{js,jsx}",
+      "!assets/scripts/vendor/**/*.{js,jsx}"
     ],
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|svg)$": "<rootDir>/test/__mocks__/fileMock.js",


### PR DESCRIPTION
## What does this PR do?

Add code coverage reporting and uploading to CodeCov to the repo. 
- Use jest configuration to whitelabel the important directories and exclude the vendor folder for the FE.
- Add collectCoverage to the jest script so that coverage report is collected for codecov to pick up on CI with the bash command in travis.yml after the script

This should send the coverage reports generated by jest to Codecov