### PR TITLE
Add first snapshot test

### DIFF
--- a/assets/scripts/app/DebugInfo.jsx
+++ b/assets/scripts/app/DebugInfo.jsx
@@ -14,7 +14,7 @@ import { registerKeypress, deregisterKeypress } from './keypress'
 import { loseAnyFocus } from '../util/focus'
 import './DebugInfo.scss'
 
-class DebugInfo extends React.Component {
+export class DebugInfo extends React.Component {
   static propTypes = {
     settings: PropTypes.object.isRequired,
     street: PropTypes.object.isRequired,

--- a/assets/scripts/app/__tests__/DebugInfo.test.js
+++ b/assets/scripts/app/__tests__/DebugInfo.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+import React from 'react'
+import { shallow } from 'enzyme'
+import { DebugInfo } from '../DebugInfo'
+
+describe('DebugInfo', () => {
+  it('render correctly', () => {
+    const settings = { }
+    const street = { }
+    const flags = { }
+    const undo = { }
+    const wrapper = shallow(<DebugInfo settings={settings} street={street} flags={flags} undo={undo} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+  it('is visible when state visible is set', () => {
+    const settings = { }
+    const street = { }
+    const flags = { }
+    const undo = { }
+    const wrapper = shallow(<DebugInfo settings={settings} street={street} flags={flags} undo={undo} />)
+    wrapper.setState({ visible: true })
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/assets/scripts/app/__tests__/__snapshots__/DebugInfo.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/DebugInfo.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DebugInfo is visible when state visible is set 1`] = `
+<div
+  className="debug-info visible"
+>
+  <textarea
+    readOnly={true}
+    value=""
+  />
+</div>
+`;
+
+exports[`DebugInfo render correctly 1`] = `
+<div
+  className="debug-info"
+>
+  <textarea
+    readOnly={true}
+    value=""
+  />
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "setupFiles": [
       "./test/setup-jest.js"
     ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
     "collectCoverageFrom": [
       "app.js",
       "app/**/*.{js,jsx}",
@@ -167,6 +170,7 @@
     "babel-plugin-rewire": "1.2.0",
     "enzyme": "3.8.0",
     "enzyme-adapter-react-16": "1.9.1",
+    "enzyme-to-json": "3.3.5",
     "eslint": "5.13.0",
     "eslint-config-standard": "12.0.0",
     "eslint-config-standard-react": "7.0.2",


### PR DESCRIPTION
## What does this PR do?
It adds the first jest snapshot test to the project. To Show how this would be done. 

- Add enzyme helper to match snapshots (and reduce code duplication by
avoid calling toJSON) 
- Add first snapshot test for DebugInfo