### PR TITLE
Update street subscriber

### DIFF
--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -9,7 +9,6 @@ import { initLocale } from '../locales/locale'
 import { onNewStreetLastClick } from '../streets/creation'
 import {
   setLastStreet,
-  trimStreetData,
   setIgnoreStreetChanges
 } from '../streets/data_model'
 import { initStreetNameChangeListener } from '../streets/name'
@@ -121,7 +120,7 @@ function onEverythingLoaded () {
   segmentsChanged()
 
   setIgnoreStreetChanges(false)
-  setLastStreet(trimStreetData(store.getState().street))
+  setLastStreet()
   initStreetReduxTransitionSubscriber()
   initializeFlagSubscribers()
   initPersistedSettingsStoreObserver()

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -21,7 +21,7 @@ import { detectGeolocation } from '../users/geolocation'
 import { initPersistedSettingsStoreObserver } from '../users/settings'
 import { addEventListeners } from './event_listeners'
 import { getMode, setMode, MODES, processMode } from './mode'
-import { processUrl, updatePageUrl } from './page_url'
+import { processUrl } from './page_url'
 import { onResize } from './window_resize'
 import { startListening } from './keypress'
 import { registerKeypresses } from './keyboard_commands'
@@ -127,7 +127,6 @@ function onEverythingLoaded () {
   initStreetThumbnailSubscriber()
   initStreetNameChangeListener()
 
-  updatePageUrl()
   addEventListeners()
 
   store.dispatch(everythingLoaded())

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -12,8 +12,8 @@ import {
   setIgnoreStreetChanges
 } from '../streets/data_model'
 import { initStreetNameChangeListener } from '../streets/name'
-import { initStreetReduxTransitionSubscriber } from '../streets/street'
 import { initStreetThumbnailSubscriber } from '../streets/image'
+import { initStreetDataChangedListener } from '../streets/street'
 import { getPromoteStreet, remixStreet } from '../streets/remix'
 import { loadSignIn } from '../users/authentication'
 import { updateSettingsFromCountryCode } from '../users/localization'
@@ -121,7 +121,7 @@ function onEverythingLoaded () {
 
   setIgnoreStreetChanges(false)
   setLastStreet()
-  initStreetReduxTransitionSubscriber()
+  initStreetDataChangedListener()
   initializeFlagSubscribers()
   initPersistedSettingsStoreObserver()
   initStreetThumbnailSubscriber()

--- a/assets/scripts/gallery/fetch_street.js
+++ b/assets/scripts/gallery/fetch_street.js
@@ -3,7 +3,6 @@ import { API_URL } from '../app/config'
 import { hideError, showError, ERRORS } from '../app/errors'
 import {
   setLastStreet,
-  trimStreetData,
   setIgnoreStreetChanges
 } from '../streets/data_model'
 import { unpackServerStreetData } from '../streets/xhr'
@@ -64,7 +63,7 @@ function receiveGalleryStreet (transmission) {
   segmentsChanged()
 
   setIgnoreStreetChanges(false)
-  setLastStreet(trimStreetData(store.getState().street))
+  setLastStreet()
 
   // Save new street's thumbnail.
   saveStreetThumbnail(store.getState().street)

--- a/assets/scripts/streets/EnvironmentEditor.jsx
+++ b/assets/scripts/streets/EnvironmentEditor.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { CSSTransition } from 'react-transition-group'
-import { saveStreetToServerIfNecessary } from './data_model'
 import { getAllEnvirons } from './environs'
 import { DEFAULT_ENVIRONS } from './constants'
 import { setEnvironment } from '../store/actions/street'
@@ -22,7 +21,6 @@ class EnvironmentEditor extends Component {
 
   handleClick = (event, env) => {
     this.props.setEnvironment(env.id)
-    saveStreetToServerIfNecessary()
   }
 
   render () {

--- a/assets/scripts/streets/creation.js
+++ b/assets/scripts/streets/creation.js
@@ -3,13 +3,11 @@ import { setSettings } from '../users/settings'
 import {
   setLastStreet,
   setUpdateTimeToNow,
-  trimStreetData,
   prepareDefaultStreet,
   prepareEmptyStreet,
   setIgnoreStreetChanges
 } from './data_model'
 import { saveStreetToServer, fetchLastStreet } from './xhr'
-import store from '../store'
 
 export const NEW_STREET_DEFAULT = 1
 export const NEW_STREET_EMPTY = 2
@@ -22,7 +20,7 @@ export function makeDefaultStreet () {
   segmentsChanged()
 
   setIgnoreStreetChanges(false)
-  setLastStreet(trimStreetData(store.getState().street))
+  setLastStreet()
 
   saveStreetToServer(false)
 }
@@ -46,7 +44,7 @@ export function onNewStreetEmptyClick () {
   segmentsChanged()
 
   setIgnoreStreetChanges(false)
-  setLastStreet(trimStreetData(store.getState().street))
+  setLastStreet()
 
   saveStreetToServer(false)
 }

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -36,10 +36,6 @@ const DEFAULT_STREET_WIDTH = 80
 
 let _lastStreet
 
-export function getLastStreet () {
-  return _lastStreet
-}
-
 export function setLastStreet (value) {
   _lastStreet = value
 }

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -36,8 +36,8 @@ const DEFAULT_STREET_WIDTH = 80
 
 let _lastStreet
 
-export function setLastStreet (value) {
-  _lastStreet = value
+export function setLastStreet () {
+  _lastStreet = trimStreetData(store.getState().street)
 }
 
 const LATEST_SCHEMA_VERSION = 19
@@ -463,7 +463,8 @@ export function updateEverything (dontScroll, save = true) {
   // TODO Verify that we don't need to dispatch an update width event here
   segmentsChanged()
   setIgnoreStreetChanges(false)
-  _lastStreet = trimStreetData(store.getState().street)
+
+  setLastStreet()
 
   if (save === true) {
     scheduleSavingStreetToServer()

--- a/assets/scripts/streets/street.js
+++ b/assets/scripts/streets/street.js
@@ -1,70 +1,24 @@
-import store from '../store'
+import { observeStore } from '../store'
 import { saveStreetToServerIfNecessary } from './data_model'
 
-const street = store.getState().street
-let oldStreetName = street.name
-let oldStreetLocation = (street.location) ? street.location.wofId : null
-let oldLeftBuildingHeight = street.leftBuildingHeight
-let oldRightBuildingHeight = street.rightBuildingHeight
-let oldLeftBuildingVariant = street.leftBuildingVariant
-let oldRightBuildingVariant = street.rightBuildingVariant
-
-export function initStreetReduxTransitionSubscriber () {
-  store.subscribe(() => {
-    const state = store.getState().street
-    updateIfBuildingsChanged(state)
-    updateIfStreetNameChanged(state)
-    updateIfLocationChanged(state)
+/**
+ * Initializes a subscriber to changes in the street name,
+ * and updates various parts of the UI in response.
+ */
+export function initStreetDataChangedListener () {
+  // We create a string representation of the values we need to compare
+  const select = (state) => JSON.stringify({
+    leftBuildingHeight: state.street.leftBuildingHeight,
+    leftBuildingVariant: state.street.leftBuildingVariant,
+    rightBuildingHeight: state.street.rightBuildingHeight,
+    rightBuildingVariant: state.street.rightBuildingVariant,
+    name: state.street.name,
+    location: state.street.location
   })
-}
 
-function updateIfBuildingsChanged (state) {
-  let changed = false
-  // Checking building heights
-  if (state.leftBuildingHeight !== oldLeftBuildingHeight) {
-    oldLeftBuildingHeight = state.leftBuildingHeight
-    changed = true
-  }
-  if (state.rightBuildingHeight !== oldRightBuildingHeight) {
-    oldRightBuildingHeight = state.rightBuildingHeight
-    changed = true
-  }
-
-  // Checking building variants
-  if (state.leftBuildingVariant !== oldLeftBuildingVariant) {
-    oldLeftBuildingVariant = state.leftBuildingVariant
-    changed = true
-  }
-  if (state.rightBuildingVariant !== oldRightBuildingVariant) {
-    oldRightBuildingVariant = state.rightBuildingVariant
-    changed = true
-  }
-
-  if (changed) {
+  const onChange = () => {
     saveStreetToServerIfNecessary()
   }
-}
 
-function updateIfStreetNameChanged (state) {
-  if (state.name !== oldStreetName) {
-    oldStreetName = state.name
-    saveStreetToServerIfNecessary()
-  }
-}
-
-function updateIfLocationChanged (state) {
-  let changed = false
-  if (state.location && state.location.wofId !== oldStreetLocation) {
-    oldStreetLocation = state.location.wofId
-    changed = true
-  }
-  // If location was cleared
-  if (oldStreetLocation && !state.location) {
-    street.location = null
-    oldStreetLocation = null
-    changed = true
-  }
-  if (changed) {
-    saveStreetToServerIfNecessary()
-  }
+  return observeStore(select, onChange)
 }

--- a/assets/scripts/streets/street.js
+++ b/assets/scripts/streets/street.js
@@ -13,7 +13,8 @@ export function initStreetDataChangedListener () {
     rightBuildingHeight: state.street.rightBuildingHeight,
     rightBuildingVariant: state.street.rightBuildingVariant,
     name: state.street.name,
-    location: state.street.location
+    location: state.street.location,
+    environment: state.street.environment
   })
 
   const onChange = () => {

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -448,7 +448,7 @@ function receiveLastStreet (transmission) {
   segmentsChanged()
 
   setIgnoreStreetChanges(false)
-  setLastStreet(trimStreetData(store.getState().street))
+  setLastStreet()
 
   saveStreetToServer(false)
 }


### PR DESCRIPTION
Some ground work for #1217 and #1218 (alongside commit 40900538e8ae4d94939c422f801d6c43b6178302 yesterday): we eventually want to save streets to the server in _response_ to state changes, as opposed to calling a save functionally manually _when_ we change state. This PR does not make those changes right now, but it starts to get us there.

Here we look at the existing subscriber function in `assets/scripts/streets/street.js` and consolidates them using the `observeStore` pattern. I also move the save function in `EnvironmentEditor` into this.

I also make some easy refactoring to `setLastStreet`. Eventually, we want to remove it altogether.