### PR TITLE
Metatags

### DIFF
--- a/app.js
+++ b/app.js
@@ -209,7 +209,11 @@ app.get('/api/v1/streets/:street_id', resources.v1.streets.get)
 app.put('/api/v1/streets/:street_id', resources.v1.streets.put)
 
 app.post('/api/v1/streets/images/:street_id', bodyParser.text({ limit: '3mb' }), resources.v1.street_images.post)
+<<<<<<< HEAD
 app.delete('/api/v1/streets/images/:street_id', resources.v1.street_images.delete)
+=======
+app.get('/api/v1/streets/images/:street_id', resources.v1.street_images.get)
+>>>>>>> created GET api request to fetch street thumbnail from cloudinary
 
 app.get('/api/v1/geo', cors(), resources.v1.geo.get)
 

--- a/app.js
+++ b/app.js
@@ -149,6 +149,10 @@ app.use((req, res, next) => {
     google_analytics: uuid(),
     mixpanel: uuid()
   }
+
+  res.locals.STREETMIX_IMAGE = 'https://streetmix.net/images/thumbnail.png'
+  res.locals.STREETMIX_TITLE = 'Streetmix'
+
   next()
 })
 
@@ -240,6 +244,8 @@ if (config.env !== 'production') {
   const runBundle = require('./app/bundle')
   runBundle(app)
 }
+
+app.get(['/:user_id/:namespaced_id', '/:user_id/:namespaced_id/:street_name'], requestHandlers.metatags)
 
 // Catch-all
 app.use((req, res) => res.render('main'))

--- a/app.js
+++ b/app.js
@@ -209,11 +209,8 @@ app.get('/api/v1/streets/:street_id', resources.v1.streets.get)
 app.put('/api/v1/streets/:street_id', resources.v1.streets.put)
 
 app.post('/api/v1/streets/images/:street_id', bodyParser.text({ limit: '3mb' }), resources.v1.street_images.post)
-<<<<<<< HEAD
 app.delete('/api/v1/streets/images/:street_id', resources.v1.street_images.delete)
-=======
 app.get('/api/v1/streets/images/:street_id', resources.v1.street_images.get)
->>>>>>> created GET api request to fetch street thumbnail from cloudinary
 
 app.get('/api/v1/geo', cors(), resources.v1.geo.get)
 

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -148,3 +148,29 @@ exports.delete = async function (req, res) {
     res.status(204).end()
   })
 }
+
+exports.get = async function (req, res) {
+  if (!req.params.street_id) {
+    res.status(400).send('Please provide a street id.')
+    return
+  }
+
+  let thumbnail
+
+  try {
+    const publicId = `${config.env}/street_thumbnails/${req.params.street_id}`
+    const resource = await cloudinary.v2.api.resource(publicId)
+    thumbnail = resource && resource.secure_url
+  } catch (error) {
+    logger.error(error)
+    res.status(500).send('Error finding street thumbnail from cloudinary.')
+    return
+  }
+
+  if (!thumbnail) {
+    res.status(400).send('Could not find street thumbnail from cloudinary.')
+    return
+  }
+
+  res.status(200).send({ image: thumbnail })
+}

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -12,16 +12,16 @@
     {{! Open Graph / Facebook }}
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://streetmix.net/">
-    <meta property="og:title" content="Streetmix">
+    <meta property="og:title" content={{STREETMIX_TITLE}}>
     <meta property="og:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
-    <meta property="og:image" content="https://streetmix.net/images/thumbnail.png">
+    <meta property="og:image" content={{STREETMIX_IMAGE}}>
 
     {{! Twitter }}
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://streetmix.net/">
-    <meta property="twitter:title" content="Streetmix">
+    <meta property="twitter:title" content={{STREETMIX_TITLE}}>
     <meta property="twitter:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
-    <meta property="twitter:image" content="https://streetmix.net/images/thumbnail.png">
+    <meta property="twitter:image" content={{STREETMIX_IMAGE}}>
 
     {{! Display at 50% on mobile devices only; should not affect desktop browsers }}
     <meta name="viewport" content="width=device-width, initial-scale=.5, maximum-scale=.5">

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -5,23 +5,23 @@
 
     <meta charset="utf-8">
     <meta http-equiv="Content-Language" content="en">
-    <meta name="title" content="Streetmix">
+    <meta name="title" content="{{STREETMIX_TITLE}}">
     <meta name="description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
 
     {{! Preview content for search engines, social media, chat apps }}
     {{! Open Graph / Facebook }}
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://streetmix.net/">
-    <meta property="og:title" content={{STREETMIX_TITLE}}>
+    <meta property="og:title" content="{{STREETMIX_TITLE}}">
     <meta property="og:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
-    <meta property="og:image" content={{STREETMIX_IMAGE}}>
+    <meta property="og:image" content="{{STREETMIX_IMAGE}}">
 
     {{! Twitter }}
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://streetmix.net/">
-    <meta property="twitter:title" content={{STREETMIX_TITLE}}>
+    <meta property="twitter:title" content="{{STREETMIX_TITLE}}">
     <meta property="twitter:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
-    <meta property="twitter:image" content={{STREETMIX_IMAGE}}>
+    <meta property="twitter:image" content="{{STREETMIX_IMAGE}}">
 
     {{! Display at 50% on mobile devices only; should not affect desktop browsers }}
     <meta name="viewport" content="width=device-width, initial-scale=.5, maximum-scale=.5">

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -3,26 +3,19 @@ const config = require('config')
 const User = require('../../app/models/user')
 const Street = require('../../app/models/street')
 
-module.exports = async function (req, res) {
-  // Default local variables set initially.
-  const DEFAULT_LOCALS = {
-    STREETMIX_TITLE: 'Streetmix',
-    STREETMIX_IMAGE: 'https://streetmix.net/images/thumbnail.png'
-  }
-
-  // Attempt retrieving street thumbnail if url is in shape of `/:user_id/:namespaced_id`
-  const params = req.path && req.path.split('/').slice(1)
-  const userId = params && params[0]
-  const namespacedId = params && params[1]
+module.exports = async function (req, res, next) {
+  const userId = req.params.user_id
+  const namespacedId = req.params.namespaced_id
 
   if (!userId || !namespacedId) {
-    res.render('main', DEFAULT_LOCALS)
-    return
+    next()
   }
 
   // 1) Find user using userId.
   // 2) Find street using user._id and namespacedId.
   // 3) Find street thumbnail using street.id
+  // 4a) Set res.locals.STREETMIX_TITLE if street found
+  // 4b) Set res.locals.STREETMIX_IMAGE if thumbnail found
 
   const findUserById = async function (userId) {
     let user
@@ -30,7 +23,7 @@ module.exports = async function (req, res) {
     try {
       user = await User.findOne({ id: userId })
     } catch (error) {
-      throw new Error(error)
+      throw new Error('Error finding user.')
     }
 
     if (!user) {
@@ -47,52 +40,47 @@ module.exports = async function (req, res) {
       const creatorId = user._id.toString()
       street = await Street.findOne({ creator_id: creatorId, namespaced_id: namespacedId })
     } catch (error) {
-      throw new Error(error)
+      throw new Error('Error finding street.')
     }
 
     if (!street) {
       throw new Error('Street not found.')
     }
 
+    const streetName = street.name || 'Unnamed Street'
+    const title = `${streetName} - Streetmix`
+
+    res.locals.STREETMIX_TITLE = title
+
     return street
-  }
-
-  const findStreetThumbnail = async function (streetId) {
-    let streetThumbnail
-
-    try {
-      const response = await cloudinary.v2.api.resource(`${config.env}/street_thumbnails/${streetId}`)
-      streetThumbnail = response && response.secure_url
-    } catch (error) {
-      throw new Error(error.message)
-    }
-
-    if (!streetThumbnail) {
-      throw new Error('Street thumbnail not found.')
-    }
-
-    return streetThumbnail
-  }
-
-  const handleError = function (error) {
-    console.log('Metatag error:' + error.message)
-    res.render('main', DEFAULT_LOCALS)
   }
 
   const handleFindStreet = async function (street) {
     const streetName = street.name || 'Unnamed Street'
     const title = `${streetName} - Streetmix`
 
-    let thumbnail
+    res.locals.STREETMIX_TITLE = title
+
+    let streetThumbnail
 
     try {
-      thumbnail = await findStreetThumbnail(street.id)
+      const response = await cloudinary.v2.api.resource(`${config.env}/street_thumbnails/${street.id}`)
+      streetThumbnail = response && response.secure_url
     } catch (error) {
-      console.log(error, error.message)
-      thumbnail = DEFAULT_LOCALS.STREETMIX_IMAGE
+      console.log(error)
+      throw new Error('Error finding street thumbnail from cloudinary.')
     }
 
-    res.render('main', { STREETMIX_TITLE: title, STREETMIX_IMAGE: thumbnail })
+    if (streetThumbnail) {
+      res.locals.STREETMIX_IMAGE = streetThumbnail
+    }
+
+    next()
+  }
+
+  const handleError = function (error) {
+    console.log(error)
+    next()
   }
 
   findUserById(userId)

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -2,6 +2,7 @@ const request = require('request')
 const config = require('config')
 const User = require('../../app/models/user')
 const Street = require('../../app/models/street')
+const logger = require('../../lib/logger')()
 
 module.exports = async function (req, res, next) {
   const userId = req.params.user_id
@@ -57,7 +58,7 @@ module.exports = async function (req, res, next) {
 
   const handleFindStreetThumbnail = function (error, response, body) {
     if (error) {
-      console.log(error)
+      logger.error(error)
     }
 
     const results = JSON.parse(body)
@@ -79,7 +80,7 @@ module.exports = async function (req, res, next) {
   }
 
   const handleError = function (error) {
-    console.log(error)
+    logger.error(error)
     next()
   }
 

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -1,0 +1,102 @@
+const cloudinary = require('cloudinary')
+const config = require('config')
+const User = require('../../app/models/user')
+const Street = require('../../app/models/street')
+
+module.exports = async function (req, res) {
+  // Default local variables set initially.
+  const DEFAULT_LOCALS = {
+    STREETMIX_TITLE: 'Streetmix',
+    STREETMIX_IMAGE: 'https://streetmix.net/images/thumbnail.png'
+  }
+
+  // Attempt retrieving street thumbnail if url is in shape of `/:user_id/:namespaced_id`
+  const params = req.path && req.path.split('/').slice(1)
+  const userId = params && params[0]
+  const namespacedId = params && params[1]
+
+  if (!userId || !namespacedId) {
+    res.render('main', DEFAULT_LOCALS)
+    return
+  }
+
+  // 1) Find user using userId.
+  // 2) Find street using user._id and namespacedId.
+  // 3) Find street thumbnail using street.id
+
+  const findUserById = async function (userId) {
+    let user
+
+    try {
+      user = await User.findOne({ id: userId })
+    } catch (error) {
+      throw new Error(error)
+    }
+
+    if (!user) {
+      throw new Error('User not found.')
+    }
+
+    return user
+  }
+
+  const findStreetByNamespacedId = async function (user) {
+    let street
+
+    try {
+      const creatorId = user._id.toString()
+      street = await Street.findOne({ creator_id: creatorId, namespaced_id: namespacedId })
+    } catch (error) {
+      throw new Error(error)
+    }
+
+    if (!street) {
+      throw new Error('Street not found.')
+    }
+
+    return street
+  }
+
+  const findStreetThumbnail = async function (streetId) {
+    let streetThumbnail
+
+    try {
+      const response = await cloudinary.v2.api.resource(`${config.env}/street_thumbnails/${streetId}`)
+      streetThumbnail = response && response.secure_url
+    } catch (error) {
+      throw new Error(error.message)
+    }
+
+    if (!streetThumbnail) {
+      throw new Error('Street thumbnail not found.')
+    }
+
+    return streetThumbnail
+  }
+
+  const handleError = function (error) {
+    console.log('Metatag error:' + error.message)
+    res.render('main', DEFAULT_LOCALS)
+  }
+
+  const handleFindStreet = async function (street) {
+    const streetName = street.name || 'Unnamed Street'
+    const title = `${streetName} - Streetmix`
+
+    let thumbnail
+
+    try {
+      thumbnail = await findStreetThumbnail(street.id)
+    } catch (error) {
+      console.log(error, error.message)
+      thumbnail = DEFAULT_LOCALS.STREETMIX_IMAGE
+    }
+
+    res.render('main', { STREETMIX_TITLE: title, STREETMIX_IMAGE: thumbnail })
+  }
+
+  findUserById(userId)
+    .then(findStreetByNamespacedId)
+    .then(handleFindStreet)
+    .catch(handleError)
+}

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -1,4 +1,4 @@
-const cloudinary = require('cloudinary')
+const request = require('request')
 const config = require('config')
 const User = require('../../app/models/user')
 const Street = require('../../app/models/street')
@@ -55,27 +55,27 @@ module.exports = async function (req, res, next) {
     return street
   }
 
+  const handleFindStreetThumbnail = function (error, response, body) {
+    if (error) {
+      console.log(error)
+    }
+
+    const results = JSON.parse(body)
+    if (results && results.image) {
+      res.locals.STREETMIX_IMAGE = results.image
+    }
+
+    next()
+  }
+
   const handleFindStreet = async function (street) {
     const streetName = street.name || 'Unnamed Street'
     const title = `${streetName} - Streetmix`
 
     res.locals.STREETMIX_TITLE = title
 
-    let streetThumbnail
-
-    try {
-      const response = await cloudinary.v2.api.resource(`${config.env}/street_thumbnails/${street.id}`)
-      streetThumbnail = response && response.secure_url
-    } catch (error) {
-      console.log(error)
-      throw new Error('Error finding street thumbnail from cloudinary.')
-    }
-
-    if (streetThumbnail) {
-      res.locals.STREETMIX_IMAGE = streetThumbnail
-    }
-
-    next()
+    const endpoint = config.restapi.protocol + config.app_host_port + config.restapi.baseuri + `/v1/streets/images/${street.id}`
+    request.get(endpoint, handleFindStreetThumbnail)
   }
 
   const handleError = function (error) {


### PR DESCRIPTION
Working towards issue #1210 

Now that street thumbnails are being cached/saved on cloudinary, we can use the cached street thumbnails as preview thumbnails for social media. This PR processes URLs with either of the following structures, `/:user_id/:namespaced_id` or `/:user_id/:namespaced_id/:street_name`, and finds the corresponding street being previewed before retrieving the street thumbnail's url for that street to be used in the image metatag. Along with changing the image metatag, this PR also changes the title metatag by replacing "Streetmix" with the name of the street hyphen Streetmix. If a street has no street name then the title ends up being "Unnamed Street - Streetmix". 

Some notes:
- If the url does not have either of the previous listed structures then the default image is used as the preview thumbnail and the default title is used ("Streetmix").
- If no street thumbnail exists for the url, then the default image is used.
- The current names of the variables being used to replace the metatag title and image are: `STREETMIX_TITLE` and `STREETMIX_IMAGE`
- The new file/module for handling of setting the variables for the metatags is located in `lib/request_handlers/metatags.js`. I do not know if this is the correct place to put it.

This branch is currently deployed on staging and the metatags can be tested on metatags.io using the staging url.