### PR TITLE
When remixing a street, new street should have the correct namespaced ID.

### DIFF
--- a/assets/scripts/app/__tests__/page_url.js
+++ b/assets/scripts/app/__tests__/page_url.js
@@ -1,0 +1,44 @@
+/* eslint-env jest */
+import { getStreetUrl } from '../page_url'
+
+jest.mock('../routing', () => ({
+  // FIXME: redefining this manually to prevent failed import
+  RESERVED_URLS: ['reserved'],
+  URL_NO_USER: '-',
+  URL_RESERVED_PREFIX: '~'
+}))
+
+describe('getStreetUrl', () => {
+  it('returns a url for a user’s street', () => {
+    const url = getStreetUrl({
+      creatorId: 'foo',
+      namespacedId: 1
+    })
+    expect(url).toBe('/foo/1')
+  })
+
+  it('returns a url for an anonymous user’s street', () => {
+    const url = getStreetUrl({
+      creatorId: null,
+      namespacedId: 1000
+    })
+    expect(url).toBe('/-/1000')
+  })
+
+  it('returns a url for a user with a reserved name', () => {
+    const url = getStreetUrl({
+      creatorId: 'reserved',
+      namespacedId: 42
+    })
+    expect(url).toBe('/~reserved/42')
+  })
+
+  it('returns a url with a slug when street is named', () => {
+    const url = getStreetUrl({
+      name: 'Street Name',
+      creatorId: 'bar',
+      namespacedId: 1337
+    })
+    expect(url).toBe('/bar/1337/street-name')
+  })
+})

--- a/assets/scripts/app/page_url.js
+++ b/assets/scripts/app/page_url.js
@@ -1,5 +1,4 @@
 import { debug } from '../preinit/debug_settings'
-import { getStreetUrl } from '../streets/data_model'
 import { setMode, MODES } from './mode'
 import {
   URL_NEW_STREET,
@@ -8,8 +7,10 @@ import {
   URL_ERROR,
   URL_GLOBAL_GALLERY,
   URL_NO_USER,
-  URL_RESERVED_PREFIX
+  URL_RESERVED_PREFIX,
+  RESERVED_URLS
 } from './routing'
+import { normalizeSlug } from '../util/helpers'
 import { setGalleryUserId } from '../store/actions/gallery'
 import store from '../store'
 import { saveCreatorId, saveStreetId } from '../store/actions/street'
@@ -94,6 +95,32 @@ export function processUrl () {
   } else {
     setMode(MODES.NOT_FOUND)
   }
+}
+
+export function getStreetUrl (street) {
+  let url = '/'
+  if (street.creatorId) {
+    if (RESERVED_URLS.indexOf(street.creatorId) !== -1) {
+      url += URL_RESERVED_PREFIX
+    }
+
+    url += street.creatorId
+  } else {
+    url += URL_NO_USER
+  }
+
+  url += '/'
+
+  url += street.namespacedId
+
+  if (street.creatorId) {
+    const slug = normalizeSlug(street.name)
+    if (slug) {
+      url += '/' + window.encodeURIComponent(slug)
+    }
+  }
+
+  return url
 }
 
 export function updatePageUrl (forceGalleryUrl) {

--- a/assets/scripts/gallery/GalleryStreetItem.jsx
+++ b/assets/scripts/gallery/GalleryStreetItem.jsx
@@ -8,10 +8,10 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { injectIntl, intlShape } from 'react-intl'
 import StreetName from '../streets/StreetName'
+import { getStreetUrl } from '../app/page_url'
 import DateTimeRelative from '../app/DateTimeRelative'
 import CloseButton from '../ui/CloseButton'
 import { drawStreetThumbnail } from './thumbnail'
-import { getStreetUrl } from '../streets/data_model'
 
 const THUMBNAIL_WIDTH = 180
 const THUMBNAIL_HEIGHT = 110

--- a/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
+++ b/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
@@ -9,7 +9,7 @@ jest.mock('../thumbnail', () => {
     drawStreetThumbnail: jest.fn()
   }
 })
-jest.mock('../../streets/data_model', () => {
+jest.mock('../../app/page_url', () => {
   return {
     getStreetUrl: jest.fn()
   }

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -1,4 +1,3 @@
-import { URL_NO_USER, RESERVED_URLS, URL_RESERVED_PREFIX } from '../app/routing'
 import { DEFAULT_SEGMENTS } from '../segments/default'
 import { getSegmentInfo } from '../segments/info'
 import { normalizeAllSegmentWidths } from '../segments/resizing'
@@ -6,7 +5,6 @@ import { getVariantString, getVariantArray } from '../segments/variant_utils'
 import { segmentsChanged } from '../segments/view'
 import { getSignInData, isSignedIn } from '../users/authentication'
 import { getUnits, getLeftHandTraffic } from '../users/localization'
-import { normalizeSlug } from '../util/helpers'
 import { generateRandSeed } from '../util/random'
 import { DEFAULT_ENVIRONS } from './constants'
 import {
@@ -369,32 +367,6 @@ function fillDefaultSegments () {
 
   store.dispatch(updateSegments(segments))
   normalizeAllSegmentWidths()
-}
-
-export function getStreetUrl (street) {
-  var url = '/'
-  if (street.creatorId) {
-    if (RESERVED_URLS.indexOf(street.creatorId) !== -1) {
-      url += URL_RESERVED_PREFIX
-    }
-
-    url += street.creatorId
-  } else {
-    url += URL_NO_USER
-  }
-
-  url += '/'
-
-  url += street.namespacedId
-
-  if (street.creatorId) {
-    var slug = normalizeSlug(street.name)
-    if (slug) {
-      url += '/' + encodeURIComponent(slug)
-    }
-  }
-
-  return url
 }
 
 export function prepareDefaultStreet () {

--- a/assets/scripts/streets/name.js
+++ b/assets/scripts/streets/name.js
@@ -11,7 +11,8 @@ export function initStreetNameChangeListener () {
   // We create a string representation of the two values we need to compare
   const select = (state) => JSON.stringify({
     name: state.street.name,
-    creatorId: state.street.creatorId
+    creatorId: state.street.creatorId,
+    namespacedId: state.street.namespacedId
   })
 
   const onChange = (string) => {


### PR DESCRIPTION
Should fix #1228. This is probably a bug resulting from earlier work that updated the page URL in response to changing street data. The fix is in `assets/scripts/streets/name.js` where the subscriber now updates the page URL when the namespaced ID changes in the underlying data.

The rest of the work moves the function `getStreetUrl()` from `data_model.js` to `page_url.js`, which makes more sense.