### PR TITLE
Canonical urls

### DIFF
--- a/app.js
+++ b/app.js
@@ -150,7 +150,12 @@ app.use((req, res, next) => {
     mixpanel: uuid()
   }
 
-  res.locals.STREETMIX_IMAGE = 'https://streetmix.net/images/thumbnail.png'
+  res.locals.STREETMIX_IMAGE = {
+    image: 'https://streetmix.net/images/thumbnail.png',
+    width: 1008,
+    height: 522
+  }
+
   res.locals.STREETMIX_TITLE = 'Streetmix'
   res.locals.STREETMIX_URL = config.restapi.protocol + config.app_host_port + '/'
 

--- a/app.js
+++ b/app.js
@@ -152,6 +152,7 @@ app.use((req, res, next) => {
 
   res.locals.STREETMIX_IMAGE = 'https://streetmix.net/images/thumbnail.png'
   res.locals.STREETMIX_TITLE = 'Streetmix'
+  res.locals.STREETMIX_URL = config.restapi.protocol + config.app_host_port + '/'
 
   next()
 })

--- a/app/resources/v1/__tests__/street_images.test.js
+++ b/app/resources/v1/__tests__/street_images.test.js
@@ -66,3 +66,19 @@ describe('DELETE api/v1/streets/images/:street_id', () => {
       })
   })
 })
+
+describe('GET api/v1/streets/images/:street_id', () => {
+  const app = setupMockServer((app) => {
+    app.get('/api/v1/streets/images/:street_id', images.get)
+  })
+
+  cloudinary.v2.api.resource.mockResolvedValue('foo')
+
+  it('should respond with 200 when street thumbnail is found', () => {
+    return request(app)
+      .get(`/api/v1/streets/images/${street.id}`)
+      .then((response) => {
+        expect(response.statusCode).toEqual(200)
+      })
+  })
+})

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -155,22 +155,21 @@ exports.get = async function (req, res) {
     return
   }
 
-  let thumbnail
+  let resource
 
   try {
     const publicId = `${config.env}/street_thumbnails/${req.params.street_id}`
-    const resource = await cloudinary.v2.api.resource(publicId)
-    thumbnail = resource && resource.secure_url
+    resource = await cloudinary.v2.api.resource(publicId)
   } catch (error) {
     logger.error(error)
     res.status(500).send('Error finding street thumbnail from cloudinary.')
     return
   }
 
-  if (!thumbnail) {
+  if (!resource) {
     res.status(400).send('Could not find street thumbnail from cloudinary.')
     return
   }
 
-  res.status(200).send({ image: thumbnail })
+  res.status(200).json(resource)
 }

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -11,14 +11,14 @@
     {{! Preview content for search engines, social media, chat apps }}
     {{! Open Graph / Facebook }}
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://streetmix.net/">
+    <meta property="og:url" content="{{STREETMIX_URL}}">
     <meta property="og:title" content="{{STREETMIX_TITLE}}">
     <meta property="og:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
     <meta property="og:image" content="{{STREETMIX_IMAGE}}">
 
     {{! Twitter }}
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://streetmix.net/">
+    <meta property="twitter:url" content="{{STREETMIX_URL}}">
     <meta property="twitter:title" content="{{STREETMIX_TITLE}}">
     <meta property="twitter:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
     <meta property="twitter:image" content="{{STREETMIX_IMAGE}}">

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -14,14 +14,16 @@
     <meta property="og:url" content="{{STREETMIX_URL}}">
     <meta property="og:title" content="{{STREETMIX_TITLE}}">
     <meta property="og:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
-    <meta property="og:image" content="{{STREETMIX_IMAGE}}">
+    <meta property="og:image" content="{{STREETMIX_IMAGE.image}}">
+    <meta property="og:image:width" content="{{STREETMIX_IMAGE.width}}">
+    <meta property="og:image:height" content="{{STREETMIX_IMAGE.height}}">
 
     {{! Twitter }}
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="{{STREETMIX_URL}}">
     <meta property="twitter:title" content="{{STREETMIX_TITLE}}">
     <meta property="twitter:description" content="A collaborative civic engagement platform for urban design. Design, remix, and share your neighborhood street with Streetmix.">
-    <meta property="twitter:image" content="{{STREETMIX_IMAGE}}">
+    <meta property="twitter:image" content="{{STREETMIX_IMAGE.image}}">
 
     {{! Display at 50% on mobile devices only; should not affect desktop browsers }}
     <meta name="viewport" content="width=device-width, initial-scale=.5, maximum-scale=.5">

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -37,6 +37,7 @@
     {{! Do not track parameter }}
     <meta name="twitter:dnt" content="on">
 
+    <link rel="canonical" href="{{STREETMIX_URL}}">
     <link href="/favicon.ico" rel="shortcut icon">
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic" rel="stylesheet">
     <link href="https://use.typekit.net/rtq2xbu.css" rel="stylesheet">

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -46,8 +46,12 @@ module.exports = async function (req, res, next) {
     } else {
       try {
         const results = JSON.parse(body)
-        if (results && results.image) {
-          res.locals.STREETMIX_IMAGE = results.image
+        if (results && results.secure_url) {
+          res.locals.STREETMIX_IMAGE = {
+            image: results.secure_url,
+            width: results.width,
+            height: results.height
+          }
         }
       } catch (error) {
         logger.error(error)

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -48,11 +48,6 @@ module.exports = async function (req, res, next) {
       throw new Error('Street not found.')
     }
 
-    const streetName = street.name || 'Unnamed Street'
-    const title = `${streetName} - Streetmix`
-
-    res.locals.STREETMIX_TITLE = title
-
     return street
   }
 

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -63,8 +63,7 @@ module.exports = async function (req, res, next) {
 
   const handleFindStreet = async function (street) {
     if (!street) {
-      res.status(400).send('Street not found.')
-      return
+      throw new Error('Street not found.')
     }
 
     const streetName = street.name || 'Unnamed Street'

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -4,6 +4,8 @@ const User = require('../../app/models/user')
 const Street = require('../../app/models/street')
 const logger = require('../../lib/logger')()
 
+const ANON_CREATOR = '-'
+
 module.exports = async function (req, res, next) {
   const userId = req.params.user_id
   const namespacedId = req.params.namespaced_id
@@ -12,13 +14,13 @@ module.exports = async function (req, res, next) {
     next()
   }
 
-  // 1) Find user using userId.
-  // 2) Find street using user._id and namespacedId.
-  // 3) Find street thumbnail using street.id
-  // 4a) Set res.locals.STREETMIX_TITLE if street found
-  // 4b) Set res.locals.STREETMIX_IMAGE if thumbnail found
+  // 1a) Find street using user._id and namespacedId.
+  // 1b) Find street using namespacedId (if anon creator).
+  // 2) Find street thumbnail using street.id
+  // 3) Set res.locals.STREETMIX_TITLE if street found
+  // 4) Set res.locals.STREETMIX_IMAGE if thumbnail found
 
-  const findUserById = async function (userId) {
+  const findStreetWithCreatorId = async function (userId) {
     let user
 
     try {
@@ -31,24 +33,11 @@ module.exports = async function (req, res, next) {
       throw new Error('User not found.')
     }
 
-    return user
+    return Street.findOne({ creator_id: user._id, namespaced_id: namespacedId })
   }
 
-  const findStreetByNamespacedId = async function (user) {
-    let street
-
-    try {
-      const creatorId = user._id.toString()
-      street = await Street.findOne({ creator_id: creatorId, namespaced_id: namespacedId })
-    } catch (error) {
-      throw new Error('Error finding street.')
-    }
-
-    if (!street) {
-      throw new Error('Street not found.')
-    }
-
-    return street
+  const findStreetWithNamespacedId = async function (namespacedId) {
+    return Street.findOne({ creator_id: null, namespaced_id: namespacedId })
   }
 
   const handleFindStreetThumbnail = function (error, response, body) {
@@ -69,6 +58,11 @@ module.exports = async function (req, res, next) {
   }
 
   const handleFindStreet = async function (street) {
+    if (!street) {
+      res.status(400).send('Street not found.')
+      return
+    }
+
     const streetName = street.name || 'Unnamed Street'
     const title = `${streetName} - Streetmix`
 
@@ -84,8 +78,13 @@ module.exports = async function (req, res, next) {
     next()
   }
 
-  findUserById(userId)
-    .then(findStreetByNamespacedId)
-    .then(handleFindStreet)
-    .catch(handleError)
+  if (userId === ANON_CREATOR) {
+    findStreetWithNamespacedId(namespacedId)
+      .then(handleFindStreet)
+      .catch(handleError)
+  } else {
+    findStreetWithCreatorId(userId)
+      .then(handleFindStreet)
+      .catch(handleError)
+  }
 }

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -78,6 +78,7 @@ module.exports = async function (req, res, next) {
     const title = `${streetName} - Streetmix`
 
     res.locals.STREETMIX_TITLE = title
+    res.locals.STREETMIX_URL += `${userId}/${namespacedId}/`
 
     const endpoint = config.restapi.protocol + config.app_host_port + config.restapi.baseuri + `/v1/streets/images/${street.id}`
     request.get(endpoint, handleFindStreetThumbnail)


### PR DESCRIPTION
Resolves #1225 

- Canonical urls meta tags are now set to original url instead of the homepage
- The metatags handler no longer throws an error for anonymously created streets (finding street is now separated into two ways: `findStreetWithCreatorId` and `findStreetWithNamespacedId`)
- GET `/api/v1/streets/images/:street_id` now returns the entire Cloudinary result instead of only the image url
- Test created for GET `/api/v1/streets/images/:street_id`
- `STREETMIX_IMAGE` is now an object in the shape of the following: `res.locals.STREETMIX_IMAGE = { image, width, height }` which is used to set the `og:image`, `og:image:width`, and `og:image:height`metatags (these are all necessary for facebook preview thumbnails to show the street thumbnail)
- Currently using the facebook media card validator, the following warning/error still shows up: "The following required properties are missing: fb:app_id" but it doesn't look like it affects the social media preview thumbnail. I am assuming that it is only necessary for fb to collect information regarding likes/shares from the link?
