### PR TITLE
Add unit tests for info bubble

### DIFF
--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -34,7 +34,7 @@ const DESCRIPTION_HOVER_POLYGON_MARGIN = 200
 const MIN_TOP_MARGIN_FROM_VIEWPORT = 120
 const MIN_SIDE_MARGIN_FROM_VIEWPORT = 50
 
-class InfoBubble extends React.Component {
+export class InfoBubble extends React.Component {
   static propTypes = {
     visible: PropTypes.bool.isRequired,
     descriptionVisible: PropTypes.bool,

--- a/assets/scripts/info_bubble/__tests__/InfoBubble.test.js
+++ b/assets/scripts/info_bubble/__tests__/InfoBubble.test.js
@@ -1,0 +1,98 @@
+/* eslint-env jest */
+import React from 'react'
+import { InfoBubble } from '../InfoBubble'
+import { shallow } from 'enzyme'
+
+jest.mock('../../streets/data_model', () => {})
+jest.mock('../../segments/view')
+
+describe('InfoBubble', () => {
+  it('renders', () => {
+    const segment = {}
+    const street = {
+      segments: [segment]
+    }
+    const locale = { locale: 'en' }
+    const wrapper = shallow(<InfoBubble locale={locale} street={street} position={0} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it('shows description', () => {
+    const street = {
+      segments: []
+    }
+    const locale = { locale: 'en' }
+    const wrapper = shallow(<InfoBubble locale={locale} street={street} position={'u'} descriptionVisible />)
+    expect(wrapper).toMatchSnapshot()
+  })
+  it('is visible', () => {
+    const street = {
+      segments: []
+    }
+    const locale = { locale: 'en' }
+    const wrapper = shallow(<InfoBubble locale={locale} street={street} position={'u'} visible />)
+    expect(wrapper).toMatchSnapshot()
+  })
+  it('shows building left info bubble', () => {
+    const street = {
+      segments: [],
+      leftBuildingVariant: 'grass'
+    }
+    const locale = { locale: 'en' }
+    const wrapper = shallow(<InfoBubble locale={locale} street={street} position={'left'} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+  it('shows building right info bubble', () => {
+    const street = {
+      segments: [],
+      rightBuildingVariant: 'grass'
+    }
+    const locale = { locale: 'en' }
+    const wrapper = shallow(<InfoBubble locale={locale} street={street} position={'right'} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+  it('updates hover polygon', () => {
+    const segment = {}
+    const street = {
+      segments: [segment]
+    }
+    const updateHoverPolygon = jest.fn()
+    const locale = { locale: 'en' }
+    const wrapper = shallow(<InfoBubble locale={locale} street={street} position={0} visible={false} updateHoverPolygon={updateHoverPolygon} />)
+    wrapper.setProps({ visible: true })
+    expect(updateHoverPolygon).toHaveBeenCalledTimes(1)
+  })
+  describe('interactions', () => {
+    it('set info bubble mouse inside', () => {
+      const street = {
+        segments: []
+      }
+      const locale = { locale: 'en' }
+      const setInfoBubbleMouseInside = jest.fn()
+      const updateHoverPolygon = jest.fn()
+      const wrapper = shallow(<InfoBubble locale={locale} street={street} position={0} visible={false} setInfoBubbleMouseInside={setInfoBubbleMouseInside} updateHoverPolygon={updateHoverPolygon} />)
+      wrapper.simulate('mouseenter')
+      expect(setInfoBubbleMouseInside).toHaveBeenCalledTimes(1)
+      expect(setInfoBubbleMouseInside).toHaveBeenCalledWith(true)
+    })
+    it('does not set info bubble mouse inside', () => {
+      const street = {
+        segments: []
+      }
+      const locale = { locale: 'en' }
+      const setInfoBubbleMouseInside = jest.fn()
+      const updateHoverPolygon = jest.fn()
+      const wrapper = shallow(<InfoBubble locale={locale} street={street} position={0} visible={false} setInfoBubbleMouseInside={setInfoBubbleMouseInside} updateHoverPolygon={updateHoverPolygon} />)
+      wrapper.simulate('mouseleave')
+      expect(setInfoBubbleMouseInside).toHaveBeenCalledTimes(1)
+      expect(setInfoBubbleMouseInside).toHaveBeenCalledWith(false)
+    })
+  })
+
+  /**
+   * test:
+   * onMouseEnter (setInfoBubbleMouse)
+   * onMouseLeave
+   * updateHoverPolygon
+   * **/
+})

--- a/assets/scripts/info_bubble/__tests__/InfoBubble.test.js
+++ b/assets/scripts/info_bubble/__tests__/InfoBubble.test.js
@@ -88,11 +88,4 @@ describe('InfoBubble', () => {
       expect(setInfoBubbleMouseInside).toHaveBeenCalledWith(false)
     })
   })
-
-  /**
-   * test:
-   * onMouseEnter (setInfoBubbleMouse)
-   * onMouseLeave
-   * updateHoverPolygon
-   * **/
 })

--- a/assets/scripts/info_bubble/__tests__/__snapshots__/InfoBubble.test.js.snap
+++ b/assets/scripts/info_bubble/__tests__/__snapshots__/InfoBubble.test.js.snap
@@ -1,0 +1,255 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InfoBubble is visible 1`] = `
+<div
+  className="info-bubble info-bubble-type-segment visible"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onTouchStart={[Function]}
+>
+  <Triangle
+    highlight={false}
+  />
+  <header>
+    <div
+      className="info-bubble-header-label"
+    />
+    <InjectIntl(RemoveButton)
+      segment="u"
+    />
+  </header>
+  <div
+    className="info-bubble-controls"
+  >
+    <IntlProvider
+      locale="en"
+    >
+      <InjectIntl(Connect(Variants))
+        position="u"
+        type={1}
+      />
+    </IntlProvider>
+    <InjectIntl(Connect(WidthControl))
+      position="u"
+    />
+  </div>
+  <Warnings
+    segment={Object {}}
+  />
+  <Connect(Description)
+    highlightTriangle={[Function]}
+    infoBubbleEl={null}
+    unhighlightTriangle={[Function]}
+    updateBubbleDimensions={[Function]}
+    updateHoverPolygon={[Function]}
+  />
+</div>
+`;
+
+exports[`InfoBubble renders 1`] = `
+<div
+  className="info-bubble info-bubble-type-segment"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onTouchStart={[Function]}
+>
+  <Triangle
+    highlight={false}
+  />
+  <header>
+    <div
+      className="info-bubble-header-label"
+    >
+      <IntlProvider
+        locale="en"
+      >
+        <FormattedMessage
+          defaultMessage="Unknown"
+          id="segments.undefined"
+          values={Object {}}
+        />
+      </IntlProvider>
+    </div>
+    <InjectIntl(RemoveButton)
+      segment={0}
+    />
+  </header>
+  <div
+    className="info-bubble-controls"
+  >
+    <IntlProvider
+      locale="en"
+    >
+      <InjectIntl(Connect(Variants))
+        position={0}
+        type={1}
+      />
+    </IntlProvider>
+    <InjectIntl(Connect(WidthControl))
+      position={0}
+    />
+  </div>
+  <Warnings
+    segment={Object {}}
+  />
+  <Connect(Description)
+    highlightTriangle={[Function]}
+    infoBubbleEl={null}
+    unhighlightTriangle={[Function]}
+    updateBubbleDimensions={[Function]}
+    updateHoverPolygon={[Function]}
+  />
+</div>
+`;
+
+exports[`InfoBubble shows building left info bubble 1`] = `
+<div
+  className="info-bubble info-bubble-type-building"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onTouchStart={[Function]}
+>
+  <Triangle
+    highlight={false}
+  />
+  <header>
+    <div
+      className="info-bubble-header-label"
+    >
+      <IntlProvider
+        locale="en"
+      >
+        <FormattedMessage
+          defaultMessage="Grass"
+          id="buildings.grass.name"
+          values={Object {}}
+        />
+      </IntlProvider>
+    </div>
+  </header>
+  <div
+    className="info-bubble-controls"
+  >
+    <IntlProvider
+      locale="en"
+    >
+      <InjectIntl(Connect(Variants))
+        position="left"
+        type={2}
+      />
+    </IntlProvider>
+    <InjectIntl(Connect(BuildingHeightControl))
+      position="left"
+    />
+  </div>
+  <Warnings
+    segment={Object {}}
+  />
+  <Connect(Description)
+    highlightTriangle={[Function]}
+    infoBubbleEl={null}
+    unhighlightTriangle={[Function]}
+    updateBubbleDimensions={[Function]}
+    updateHoverPolygon={[Function]}
+  />
+</div>
+`;
+
+exports[`InfoBubble shows building right info bubble 1`] = `
+<div
+  className="info-bubble info-bubble-type-building"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onTouchStart={[Function]}
+>
+  <Triangle
+    highlight={false}
+  />
+  <header>
+    <div
+      className="info-bubble-header-label"
+    >
+      <IntlProvider
+        locale="en"
+      >
+        <FormattedMessage
+          defaultMessage="Grass"
+          id="buildings.grass.name"
+          values={Object {}}
+        />
+      </IntlProvider>
+    </div>
+  </header>
+  <div
+    className="info-bubble-controls"
+  >
+    <IntlProvider
+      locale="en"
+    >
+      <InjectIntl(Connect(Variants))
+        position="right"
+        type={3}
+      />
+    </IntlProvider>
+    <InjectIntl(Connect(BuildingHeightControl))
+      position="right"
+    />
+  </div>
+  <Warnings
+    segment={Object {}}
+  />
+  <Connect(Description)
+    highlightTriangle={[Function]}
+    infoBubbleEl={null}
+    unhighlightTriangle={[Function]}
+    updateBubbleDimensions={[Function]}
+    updateHoverPolygon={[Function]}
+  />
+</div>
+`;
+
+exports[`InfoBubble shows description 1`] = `
+<div
+  className="info-bubble info-bubble-type-segment show-description"
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onTouchStart={[Function]}
+>
+  <Triangle
+    highlight={false}
+  />
+  <header>
+    <div
+      className="info-bubble-header-label"
+    />
+    <InjectIntl(RemoveButton)
+      segment="u"
+    />
+  </header>
+  <div
+    className="info-bubble-controls"
+  >
+    <IntlProvider
+      locale="en"
+    >
+      <InjectIntl(Connect(Variants))
+        position="u"
+        type={1}
+      />
+    </IntlProvider>
+    <InjectIntl(Connect(WidthControl))
+      position="u"
+    />
+  </div>
+  <Warnings
+    segment={Object {}}
+  />
+  <Connect(Description)
+    highlightTriangle={[Function]}
+    infoBubbleEl={null}
+    unhighlightTriangle={[Function]}
+    updateBubbleDimensions={[Function]}
+    updateHoverPolygon={[Function]}
+  />
+</div>
+`;


### PR DESCRIPTION
## What does this PR do?

It adds basic tests for component edges (prop functions) and difference in
rendering (different props).
basic interaction tests (mouseover, mouseleave)

### Next steps
- [ ] test `createHoverPolygon`
- [ ] test `setInfoBubblePosition`
- [ ] test `updateBubbleDimensions`