### PR TITLE
Add Facebook app ID metatag

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,13 +143,15 @@ app.use(requestHandlers.login_token_parser)
 app.use(requestHandlers.request_log)
 app.use(requestHandlers.request_id_echo)
 
-// Generate nonces for inline scripts
+// Set variables for use in view templates
 app.use((req, res, next) => {
+  // Generate nonces for inline scripts
   res.locals.nonce = {
     google_analytics: uuid(),
     mixpanel: uuid()
   }
 
+  // Set default metatag information for social sharing cards
   res.locals.STREETMIX_IMAGE = {
     image: 'https://streetmix.net/images/thumbnail.png',
     width: 1008,
@@ -158,6 +160,9 @@ app.use((req, res, next) => {
 
   res.locals.STREETMIX_TITLE = 'Streetmix'
   res.locals.STREETMIX_URL = config.restapi.protocol + config.app_host_port + '/'
+
+  // Make required Facebook app ID available to metatags
+  res.locals.FACEBOOK_APP_ID = config.facebook_app_id
 
   next()
 })
@@ -255,6 +260,4 @@ if (config.env !== 'production') {
 app.get(['/:user_id/:namespaced_id', '/:user_id/:namespaced_id/:street_name'], requestHandlers.metatags)
 
 // Catch-all
-app.use((req, res) => res.render('main', {
-  FACEBOOK_APP_ID: config.facebook_app_id
-}))
+app.use((req, res) => res.render('main'))

--- a/app.js
+++ b/app.js
@@ -255,4 +255,6 @@ if (config.env !== 'production') {
 app.get(['/:user_id/:namespaced_id', '/:user_id/:namespaced_id/:street_name'], requestHandlers.metatags)
 
 // Catch-all
-app.use((req, res) => res.render('main'))
+app.use((req, res) => res.render('main', {
+  FACEBOOK_APP_ID: config.facebook_app_id
+}))

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -18,6 +18,9 @@
     <meta property="og:image:width" content="{{STREETMIX_IMAGE.width}}">
     <meta property="og:image:height" content="{{STREETMIX_IMAGE.height}}">
 
+    {{! Facebook }}
+    <meta property="fb:app_id" content="{{FACEBOOK_APP_ID}}" />
+
     {{! Twitter }}
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="{{STREETMIX_URL}}">


### PR DESCRIPTION
Resolves #1234.

I thought about moving the app ID to `.env` variables, but it's not technically a secret, which is primarily what we use the env variables for.