### PR TITLE
Handles anonymously created streets and streets created by inactive users

### DIFF
--- a/app/resources/v1/__tests__/street_images.test.js
+++ b/app/resources/v1/__tests__/street_images.test.js
@@ -27,7 +27,7 @@ describe('POST api/v1/streets/images/:street_id', () => {
 
   cloudinary.v2.uploader.upload.mockResolvedValue('foo')
 
-  it('should respond with 200 Ok when a data url is sent', () => {
+  it('should respond with 201 Created when a data url is sent', () => {
     cloudinary.v2.api.resource.mockResolvedValueOnce('baz')
 
     return request(app)
@@ -36,11 +36,11 @@ describe('POST api/v1/streets/images/:street_id', () => {
       .type('text/plain')
       .send('bar')
       .then((response) => {
-        expect(response.statusCode).toEqual(200)
+        expect(response.statusCode).toEqual(201)
       })
   })
 
-  it('should respond with 200 Ok when street thumbnail does not exist', () => {
+  it('should respond with 201 Created when street thumbnail does not exist', () => {
     cloudinary.v2.api.resource.mockReturnValueOnce(null)
 
     return request(app)
@@ -48,11 +48,11 @@ describe('POST api/v1/streets/images/:street_id', () => {
       .type('text/plain')
       .send('bar')
       .then((response) => {
-        expect(response.statusCode).toEqual(200)
+        expect(response.statusCode).toEqual(201)
       })
   })
 
-  it('should respond with 404 when user is not owner of street', () => {
+  it('should respond with 403 Forbidden when user is not owner of street', () => {
     cloudinary.v2.api.resource.mockResolvedValueOnce('baz')
 
     return request(app)
@@ -61,7 +61,7 @@ describe('POST api/v1/streets/images/:street_id', () => {
       .type('text/plain')
       .send('bar')
       .then((response) => {
-        expect(response.statusCode).toEqual(404)
+        expect(response.statusCode).toEqual(403)
       })
   })
 })

--- a/app/resources/v1/__tests__/street_images.test.js
+++ b/app/resources/v1/__tests__/street_images.test.js
@@ -28,6 +28,8 @@ describe('POST api/v1/streets/images/:street_id', () => {
   cloudinary.v2.uploader.upload.mockResolvedValue('foo')
 
   it('should respond with 200 Ok when a data url is sent', () => {
+    cloudinary.v2.api.resource.mockResolvedValueOnce('baz')
+
     return request(app)
       .post(`/api/v1/streets/images/${street.id}`)
       .set('Authorization', 'Streetmix realm="" loginToken="xxxxxxxx-xxxx-xxxx-xxxx-1111111111111" userId="user1"')
@@ -38,7 +40,21 @@ describe('POST api/v1/streets/images/:street_id', () => {
       })
   })
 
+  it('should respond with 200 Ok when street thumbnail does not exist', () => {
+    cloudinary.v2.api.resource.mockReturnValueOnce(null)
+
+    return request(app)
+      .post(`/api/v1/streets/images/${street.id}`)
+      .type('text/plain')
+      .send('bar')
+      .then((response) => {
+        expect(response.statusCode).toEqual(200)
+      })
+  })
+
   it('should respond with 404 when user is not owner of street', () => {
+    cloudinary.v2.api.resource.mockResolvedValueOnce('baz')
+
     return request(app)
       .post(`/api/v1/streets/images/${street.id}`)
       .set('Authorization', 'Streetmix realm="" loginToken="xxxxxxxx-xxxx-xxxx-xxxx-2222222222222" userId="user2"')

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -62,7 +62,16 @@ exports.post = async function (req, res) {
       return
     }
 
-    res.status(200).json(resource)
+    const thumbnail = {
+      public_id: resource.public_id,
+      width: resource.width,
+      height: resource.height,
+      format: resource.format,
+      secure_url: resource.secure_url,
+      created_at: resource.created_at
+    }
+
+    res.status(200).json(thumbnail)
   }
 
   const handleFindStreetWithCreator = async function (street) {
@@ -86,8 +95,8 @@ exports.post = async function (req, res) {
       return
     }
 
-    if (street.creator_id !== user._id) {
-      res.status(404).send('User does not have right permissions to upload street thumbnail.')
+    if (street.creator_id.toString() !== user._id.toString()) {
+      res.status(404).send('User does not have the right permissions to upload street thumbnail.')
       return
     }
 
@@ -111,7 +120,7 @@ exports.post = async function (req, res) {
       .then(handleUploadStreetThumbnail)
       .catch(handleError)
   } else {
-    res.status(404).send('User does not have the right permissions to upload street thumbnail to Cloudinary.')
+    res.status(404).send('User does not have the right permissions to upload street thumbnail.')
   }
 }
 

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -97,7 +97,7 @@ exports.post = async function (req, res) {
 
   const handleError = function (error) {
     logger.error(error)
-    res.status(400).end()
+    res.status(500).end()
   }
 
   // 3a) If street thumbnail does not exist, upload to Cloudinary no matter the currently signed in user.

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -71,12 +71,12 @@ exports.post = async function (req, res) {
       created_at: resource.created_at
     }
 
-    res.status(200).json(thumbnail)
+    res.status(201).json(thumbnail)
   }
 
   const handleFindStreetWithCreator = async function (street) {
     if (!req.userId) {
-      res.status(404).send('Please provide a user ID.')
+      res.status(401).send('Please provide a user ID.')
       return
     }
 
@@ -91,12 +91,12 @@ exports.post = async function (req, res) {
     }
 
     if (!user) {
-      res.status(400).send('User not found.')
+      res.status(403).send('User not found.')
       return
     }
 
     if (street.creator_id.toString() !== user._id.toString()) {
-      res.status(404).send('User does not have the right permissions to upload street thumbnail.')
+      res.status(403).send('User does not have the right permissions to upload street thumbnail.')
       return
     }
 
@@ -120,7 +120,7 @@ exports.post = async function (req, res) {
       .then(handleUploadStreetThumbnail)
       .catch(handleError)
   } else {
-    res.status(404).send('User does not have the right permissions to upload street thumbnail.')
+    res.status(403).send('User does not have the right permissions to upload street thumbnail.')
   }
 }
 

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -111,7 +111,7 @@ exports.post = async function (req, res) {
       .then(handleUploadStreetThumbnail)
       .catch(handleError)
   } else {
-    res.status(400).send('User does not have the right permissions to upload street thumbnail to Cloudinary.')
+    res.status(404).send('User does not have the right permissions to upload street thumbnail to Cloudinary.')
   }
 }
 

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -4,7 +4,7 @@ const User = require('../../models/user.js')
 const Street = require('../../models/street.js')
 const logger = require('../../../lib/logger.js')()
 
-const ALLOW_ANON_STREET_THUMBNAILS = false
+const ALLOW_ANON_STREET_THUMBNAILS = true
 
 exports.post = async function (req, res) {
   const image = req.body

--- a/assets/scripts/streets/image.js
+++ b/assets/scripts/streets/image.js
@@ -100,8 +100,9 @@ export async function saveStreetThumbnail (street) {
     }
 
     const response = await window.fetch(url, options)
-
-    if (response.ok) {
+    if (!response.ok) {
+      throw response
+    } else {
       console.log('Updated street thumbnail.')
       _lastSavedTimestamp = Date.now()
       _savedThumbnail = true


### PR DESCRIPTION
Resolves #1226 and #1229 

- POST `/api/v1/streets/images` now returns an object in shape of `{ public_id, secure_url, width, height, format, created_at }` when successful.
- Set `ALLOW_ANON_STREET_THUMBNAILS` variable to true to allow anonymously created streets to be uploaded to Cloudinary.
- POST `/api/v1/streets/images` now checks if a street thumbnail already exists for the street in Cloudinary. If not, then the street thumbnail can be uploaded by any user. If it does exist, the POST request verifies that the user has the right permissions to upload the thumbnail to Cloudinary (user is the creator of the street or the street was created anonymously).
- Updated tests for `/api/v1/streets/images`