### PR TITLE
Completely remove suppressMouseEnter

### DIFF
--- a/assets/scripts/app/StreetEditablePresentation.jsx
+++ b/assets/scripts/app/StreetEditablePresentation.jsx
@@ -12,14 +12,6 @@ class StreetEditablePresentation extends React.Component {
     calculateSegmentPos: PropTypes.func.isRequired
   }
 
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      suppressMouseEnter: false
-    }
-  }
-
   /**
    * A <Transition> callback fired immediately after the `exit` class is applied.
    *
@@ -31,17 +23,6 @@ class StreetEditablePresentation extends React.Component {
     el.style.left = el.savedLeft + 'px'
 
     this.props.updatePerspective(el)
-    this.setState({ suppressMouseEnter: true })
-  }
-
-  /**
-   * A <Transition> callback fired immediately after the 'exit' classes are
-   * removed and the `exit-done` class is added to the DOM node.
-   *
-   * @params {HtmlElement}
-   */
-  handleOnExited = (el) => {
-    this.setState({ suppressMouseEnter: false })
   }
 
   updateSegmentData = (ref, dataNo, segmentPos) => {
@@ -85,7 +66,6 @@ class StreetEditablePresentation extends React.Component {
           enter={false}
           exit={!(immediateRemoval)}
           onExit={this.handleOnExit}
-          onExited={this.handleOnExited}
           unmountOnExit
         >
           <Segment
@@ -95,7 +75,6 @@ class StreetEditablePresentation extends React.Component {
             actualWidth={segment.width}
             units={units}
             segmentPos={segmentPos}
-            suppressMouseEnter={this.state.suppressMouseEnter}
             updateSegmentData={this.updateSegmentData}
             updatePerspective={this.props.updatePerspective}
           />

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -25,7 +25,7 @@ import {
   collectDropTarget
 } from './drag_and_drop'
 import { getSegmentVariantInfo, getSegmentInfo } from './info'
-import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, suppressMouseEnter, incrementSegmentWidth } from './resizing'
+import { normalizeSegmentWidth, RESIZE_TYPE_INITIAL, incrementSegmentWidth } from './resizing'
 import { removeSegment, removeAllSegments } from './remove'
 import { SETTINGS_UNITS_METRIC } from '../users/constants'
 import { infoBubble } from '../info_bubble/info_bubble'
@@ -43,7 +43,6 @@ export class Segment extends React.Component {
     actualWidth: PropTypes.number.isRequired,
     units: PropTypes.number,
     segmentPos: PropTypes.number,
-    suppressMouseEnter: PropTypes.bool.isRequired,
     updateSegmentData: PropTypes.func,
     updatePerspective: PropTypes.func,
 
@@ -63,8 +62,7 @@ export class Segment extends React.Component {
   }
 
   static defaultProps = {
-    units: SETTINGS_UNITS_METRIC,
-    suppressMouseEnter: false
+    units: SETTINGS_UNITS_METRIC
   }
 
   constructor (props) {
@@ -95,10 +93,10 @@ export class Segment extends React.Component {
     // segment if it is equal to the activeSegment and no infoBubble was shown already.
     const wasDragging = (prevProps.isDragging && !this.props.isDragging) ||
       (this.initialRender && (this.props.activeSegment || this.props.activeSegment === 0))
-    const mouseEnterSuppressed = (prevProps.suppressMouseEnter && !this.props.suppressMouseEnter)
+
     this.initialRender = false
 
-    if ((wasDragging || mouseEnterSuppressed) && this.props.activeSegment === this.props.dataNo) {
+    if ((wasDragging) && this.props.activeSegment === this.props.dataNo) {
       infoBubble.considerShowing(false, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)
     }
 
@@ -134,11 +132,6 @@ export class Segment extends React.Component {
   }
 
   onSegmentMouseEnter = (event) => {
-    if (this.props.suppressMouseEnter || suppressMouseEnter()) {
-      this.props.setActiveSegment(this.props.dataNo)
-      return
-    }
-
     window.addEventListener('keydown', this.handleKeyDown)
     infoBubble.considerShowing(event, this.streetSegment, INFO_BUBBLE_TYPE_SEGMENT)
   }

--- a/assets/scripts/segments/__tests__/Segment.test.js
+++ b/assets/scripts/segments/__tests__/Segment.test.js
@@ -60,11 +60,6 @@ describe('Segment', () => {
       wrapper.setProps({ isDragging: false })
       expect(infoBubble.considerShowing).toHaveBeenCalledTimes(1)
     })
-    it('when the mouseEnter is suppressed', () => {
-      const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} suppressMouseEnter />)
-      wrapper.setProps({ suppressMouseEnter: false })
-      expect(infoBubble.considerShowing).toHaveBeenCalledTimes(2) // should probably only be 1
-    })
   })
   it('renders the units correctly', () => {
     const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} units={SETTINGS_UNITS_IMPERIAL} cssTransform={'transform'} segmentPos={1} />)

--- a/assets/scripts/segments/resizing.js
+++ b/assets/scripts/segments/resizing.js
@@ -31,12 +31,6 @@ const TOUCH_CONTROLS_FADEOUT_DELAY = 3000
 
 const NORMALIZE_PRECISION = 5
 
-let _suppressMouseEnter = false
-
-export function suppressMouseEnter () {
-  return _suppressMouseEnter
-}
-
 export function resizeSegment (dataNo, resizeType, width) {
   width = normalizeSegmentWidth(width, resizeType)
   cancelSegmentResizeTransitions()
@@ -120,11 +114,7 @@ export function handleSegmentResizeEnd (event) {
 
   scheduleControlsFadeout(draggingResize.segmentEl)
 
-  _suppressMouseEnter = true
   infoBubble.considerShowing(event, draggingResize.segmentEl, INFO_BUBBLE_TYPE_SEGMENT)
-  window.setTimeout(function () {
-    _suppressMouseEnter = false
-  }, 50)
 
   if (draggingResize.width && (draggingResize.originalWidth !== draggingResize.width)) {
     trackEvent('INTERACTION', 'CHANGE_WIDTH', 'DRAGGING', null, true)


### PR DESCRIPTION
The original `suppressMouseEnter` variable was used very simply. It was set to `true` when a segment resize action ended, so that if the `mouseenter` event fired it didn't try to show the info bubble twice. As we migrated code to React components, passing this state around has made it balloon in complexity. And there's a good chance we don't even need this now.