### PR TITLE
Save street thumbnails only on first street load

### DIFF
--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -4,7 +4,7 @@ const User = require('../../models/user.js')
 const Street = require('../../models/street.js')
 const logger = require('../../../lib/logger.js')()
 
-const ALLOW_ANON_STREET_THUMBNAILS = true
+const ALLOW_ANON_STREET_THUMBNAILS = false
 
 exports.post = async function (req, res) {
   const image = req.body

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -12,7 +12,7 @@ import {
   setIgnoreStreetChanges
 } from '../streets/data_model'
 import { initStreetNameChangeListener } from '../streets/name'
-import { initStreetThumbnailSubscriber } from '../streets/image'
+import { saveStreetThumbnail } from '../streets/image'
 import { initStreetDataChangedListener } from '../streets/street'
 import { getPromoteStreet, remixStreet } from '../streets/remix'
 import { loadSignIn } from '../users/authentication'
@@ -124,7 +124,9 @@ function onEverythingLoaded () {
   initStreetDataChangedListener()
   initializeFlagSubscribers()
   initPersistedSettingsStoreObserver()
-  initStreetThumbnailSubscriber()
+  // initStreetThumbnailSubscriber()
+  saveStreetThumbnail(store.getState().street)
+
   initStreetNameChangeListener()
 
   addEventListeners()

--- a/assets/scripts/gallery/view.js
+++ b/assets/scripts/gallery/view.js
@@ -7,7 +7,7 @@ import { hideStatusMessage } from '../app/status_message'
 import { app } from '../preinit/app_settings'
 import { hideControls } from '../segments/resizing'
 import { updateToLatestSchemaVersion } from '../streets/data_model'
-import { saveStreetThumbnail } from '../streets/image'
+// import { saveStreetThumbnail } from '../streets/image'
 import { fetchGalleryData } from './fetch_data'
 import { fetchGalleryStreet } from './fetch_street'
 
@@ -122,7 +122,7 @@ export function repeatReceiveGalleryData () {
 
 export function switchGalleryStreet (id) {
   // Save previous street's thumbnail before switching streets.
-  saveStreetThumbnail(store.getState().street)
+  // saveStreetThumbnail(store.getState().street)
 
   galleryState.noStreetSelected = false
 

--- a/assets/scripts/menus/ShareMenu.jsx
+++ b/assets/scripts/menus/ShareMenu.jsx
@@ -14,7 +14,7 @@ import { showDialog } from '../store/actions/dialogs'
 import { startPrinting } from '../store/actions/app'
 
 import './ShareMenu.scss'
-import { saveStreetThumbnail } from '../streets/image'
+// import { saveStreetThumbnail } from '../streets/image'
 
 class ShareMenu extends React.Component {
   static propTypes = {
@@ -94,7 +94,7 @@ class ShareMenu extends React.Component {
 
   onShow = () => {
     // Save street thumbnail when share menu is active
-    saveStreetThumbnail(this.props.street)
+    // saveStreetThumbnail(this.props.street)
 
     // Make sure links are updated when the menu is opened
     this.updateLinks()

--- a/assets/scripts/streets/image.js
+++ b/assets/scripts/streets/image.js
@@ -56,7 +56,8 @@ let _lastSavedTimestamp
 let _savedThumbnail
 
 export function isThumbnailSaved () {
-  return _savedThumbnail
+  // return _savedThumbnail
+  return true
 }
 
 export function initStreetThumbnailSubscriber () {

--- a/assets/scripts/util/fetch_nonblocking.js
+++ b/assets/scripts/util/fetch_nonblocking.js
@@ -2,7 +2,7 @@ import {
   getSaveStreetIncomplete,
   setSaveStreetIncomplete
 } from '../streets/xhr'
-import { saveStreetThumbnail, isThumbnailSaved } from '../streets/image'
+import { isThumbnailSaved } from '../streets/image'
 import store from '../store'
 import { showNoConnectionMessage } from '../store/actions/status'
 
@@ -185,7 +185,7 @@ function checkIfChangesSaved () {
   if (showWarning) {
     nonblockingAjaxRequestTimer = 0
     scheduleNextNonblockingAjaxRequest()
-    saveStreetThumbnail(store.getState().street)
+    // saveStreetThumbnail(store.getState().street)
     return 'Your changes have not been saved yet. Please return to the page, check your Internet connection, and wait a little while to allow the changes to be saved.'
   }
 }


### PR DESCRIPTION
- `ALLOW_ANON_STREET_THUMBNAILS` set to `false`
- No longer using subscriber to save street thumbnails every 30 minutes
- I commented out the use of `saveStreetThumbnails` when sharing, before unload, and when switching between streets instead of removing it all together