### PR TITLE
Default/Empty Street Thumbnails

### DIFF
--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -33,9 +33,9 @@ exports.post = async function (req, res) {
   }
 
   const publicId = `${config.env}/street_thumbnails/` + (streetType || req.params.street_id)
-  logger.info({ event, street_type: streetType, public_id: publicId }, 'Uploading street thumbnail.')
 
   if (event !== SAVE_THUMBNAIL_EVENTS.INITIAL && event !== SAVE_THUMBNAIL_EVENTS.TEST) {
+    logger.info({ event, street_type: streetType, public_id: publicId }, 'Uploading street thumbnail.')
     res.status(501).json({ status: 501, msg: 'Only saving initial street rendered thumbnail.' })
     return
   }
@@ -94,6 +94,7 @@ exports.post = async function (req, res) {
       return
     }
 
+    logger.info({ event, street_type: streetType, public_id: publicId }, 'Uploading street thumbnail.')
     return resource
   }
 

--- a/lib/request_handlers/metatags.js
+++ b/lib/request_handlers/metatags.js
@@ -72,7 +72,17 @@ module.exports = async function (req, res, next) {
     res.locals.STREETMIX_TITLE = title
     res.locals.STREETMIX_URL += `${userId}/${namespacedId}/`
 
-    const endpoint = config.restapi.protocol + config.app_host_port + config.restapi.baseuri + `/v1/streets/images/${street.id}`
+    let endpoint = config.restapi.protocol + config.app_host_port + config.restapi.baseuri + '/v1/streets/images/'
+
+    // If street is a DEFAULT_STREET or EMPTY_STREET, the public id for the street thumbnail is the street type, not the street id.
+    const streetData = street.data && street.data.street
+    if (streetData && streetData.editCount === 0) {
+      const streetType = (streetData.segments.length) ? 'DEFAULT_STREET' : 'EMPTY_STREET'
+      endpoint += streetType
+    } else {
+      endpoint += street.id
+    }
+
     request.get(endpoint, handleFindStreetThumbnail)
   }
 


### PR DESCRIPTION
Rather than uploading a new street thumbnail each time a new street based on the default street or simply an empty street is created, this PR checks if the `DEFAULT_STREET` or `EMPTY_STREET` thumbnail exists on Cloudinary and returns the thumbnail. The idea is to reduce the number of upload requests to Cloudinary since a default/empty street thumbnail will always be the same regardless of the creator. 