### PR TITLE
Small changes to POST /api/v1/streets/images/:street_id

### DIFF
--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -56,12 +56,6 @@ exports.post = async function (req, res) {
     edit_count: editCount
   }
 
-  if (event !== SAVE_THUMBNAIL_EVENTS.INITIAL && event !== SAVE_THUMBNAIL_EVENTS.TEST) {
-    logger.info({ event, ...details }, 'Uploading street thumbnail.')
-    res.status(501).json({ status: 501, msg: 'Only saving initial street rendered thumbnail.' })
-    return
-  }
-
   // 2) Check if street thumbnail exists.
   let resource
 
@@ -72,6 +66,22 @@ exports.post = async function (req, res) {
     if (err.error.http_code !== 404) {
       logger.error(err)
     }
+  }
+
+  // 3a) If street is a DEFAULT_STREET or EMPTY_STREET and thumbnail exists, return existing street thumbnail.
+  // 3b) If nothing changed since the last street thumbnail upload (based on editCount), return existing street thumbnail.
+  const tag = resource && resource.tags && resource.tags[0]
+  const thumbnailSaved = (streetType && resource) || (tag && editCount && parseInt(tag, 10) === editCount)
+
+  // Currently only uploading street thumbnails for initial street render. If not initial street render, only log details.
+  if (event !== SAVE_THUMBNAIL_EVENTS.INITIAL && event !== SAVE_THUMBNAIL_EVENTS.TEST) {
+    // If thumbnailSaved === true, then no upload would have been made.
+    if (!thumbnailSaved) {
+      logger.info({ event, ...details }, 'Uploading street thumbnail.')
+    }
+
+    res.status(501).json({ status: 501, msg: 'Only saving initial street rendered thumbnail.' })
+    return
   }
 
   const handleUploadSuccess = function (resource) {
@@ -143,12 +153,6 @@ exports.post = async function (req, res) {
     logger.error(error)
     res.status(500).end()
   }
-
-  const tag = resource && resource.tags && resource.tags[0]
-
-  // 3a) If street is a DEFAULT_STREET or EMPTY_STREET and thumbnail exists, return existing street thumbnail.
-  // 3b) If nothing changed since the last street thumbnail upload (based on editCount), return existing street thumbnail.
-  const thumbnailSaved = (streetType && resource) || (tag && editCount && parseInt(tag, 10) === editCount)
 
   if (thumbnailSaved) {
     handleUploadSuccess(resource)

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -20,7 +20,7 @@ exports.post = async function (req, res) {
     return
   }
 
-  const { image, event, streetType } = json
+  const { image, event, streetType, editCount, creatorId } = json
 
   if (!image) {
     res.status(400).json({ status: 400, msg: 'Image data not specified.' })
@@ -47,14 +47,13 @@ exports.post = async function (req, res) {
     return
   }
 
-  const editCount = street.data && street.data.street && street.data.street.editCount
   const publicId = `${config.env}/street_thumbnails/` + (streetType || req.params.street_id)
 
   const details = {
     public_id: publicId,
     street_type: streetType,
-    creator_id: street.creator_id,
-    edit_count: editCount && editCount.toString()
+    creator_id: creatorId,
+    edit_count: editCount
   }
 
   if (event !== SAVE_THUMBNAIL_EVENTS.INITIAL && event !== SAVE_THUMBNAIL_EVENTS.TEST) {
@@ -149,7 +148,7 @@ exports.post = async function (req, res) {
 
   // 3a) If street is a DEFAULT_STREET or EMPTY_STREET and thumbnail exists, return existing street thumbnail.
   // 3b) If nothing changed since the last street thumbnail upload (based on editCount), return existing street thumbnail.
-  const thumbnailSaved = (streetType && resource) || (tag && details.editCount && tag === details.editCount)
+  const thumbnailSaved = (streetType && resource) || (tag && editCount && parseInt(tag, 10) === editCount)
 
   if (thumbnailSaved) {
     handleUploadSuccess(resource)

--- a/assets/scripts/menus/ShareMenu.jsx
+++ b/assets/scripts/menus/ShareMenu.jsx
@@ -93,9 +93,6 @@ class ShareMenu extends React.Component {
   }
 
   onShow = () => {
-    // Save street thumbnail when share menu is active
-    saveStreetThumbnail(this.props.street, SAVE_THUMBNAIL_EVENTS.SHARE)
-
     // Make sure links are updated when the menu is opened
     this.updateLinks()
 
@@ -107,10 +104,12 @@ class ShareMenu extends React.Component {
   }
 
   onClickShareViaTwitter () {
+    saveStreetThumbnail(this.props.street, SAVE_THUMBNAIL_EVENTS.SHARE)
     trackEvent('SHARING', 'TWITTER', null, null, false)
   }
 
   onClickShareViaFacebook () {
+    saveStreetThumbnail(this.props.street, SAVE_THUMBNAIL_EVENTS.SHARE)
     trackEvent('SHARING', 'FACEBOOK', null, null, false)
   }
 
@@ -179,6 +178,7 @@ class ShareMenu extends React.Component {
             className="share-via-link"
             type="text"
             value={this.state.shareUrl}
+            onCopy={() => { saveStreetThumbnail(this.props.street, SAVE_THUMBNAIL_EVENTS.SHARE) }}
             spellCheck="false"
             ref={(ref) => { this.shareViaLinkInput = ref }}
             readOnly

--- a/assets/scripts/streets/image.js
+++ b/assets/scripts/streets/image.js
@@ -103,8 +103,11 @@ export async function saveStreetThumbnail (street, event) {
     const details = { image: dataUrl, event }
 
     // Check if street is default or empty street.
-    if (street.editCount === 0) {
+    // If a signed-in user adopts an existing street, the editCount is set to 0 even if it isn't a DEFAULT or EMPTY street.
+    // Only if the street has an editCount = 0 and has no originalStreetId, should we set the streetType.
+    if (street.editCount === 0 && !street.originalStreetId) {
       const streetType = (street.segments.length) ? 'DEFAULT_STREET' : 'EMPTY_STREET'
+
       details.streetType = streetType
     }
 

--- a/assets/scripts/streets/image.js
+++ b/assets/scripts/streets/image.js
@@ -100,14 +100,18 @@ export async function saveStreetThumbnail (street, event) {
   try {
     // .toDataURL is not available on IE11 when SVGs are part of the canvas.
     const dataUrl = thumbnail.toDataURL('image/png')
-    const details = { image: dataUrl, event }
+    const details = {
+      image: dataUrl,
+      event,
+      editCount: street.editCount,
+      creatorId: street.creatorId
+    }
 
     // Check if street is default or empty street.
     // If a signed-in user adopts an existing street, the editCount is set to 0 even if it isn't a DEFAULT or EMPTY street.
     // Only if the street has an editCount = 0 and has no originalStreetId, should we set the streetType.
     if (street.editCount === 0 && !street.originalStreetId) {
       const streetType = (street.segments.length) ? 'DEFAULT_STREET' : 'EMPTY_STREET'
-
       details.streetType = streetType
     }
 


### PR DESCRIPTION
- Solved a problem where remixed streets or anon created streets adopted by a signed in user had an `editCount = 0` and led to either a `DEFAULT_STREET` or `EMPTY_STREET` thumbnail being returned due to the original assumption that any street with `editCount === 0` is either a `DEFAULT_STREET` or `EMPTY_STREET`. The updated assumption/conditional statement is now if the `editCount === 0` and the street does not have an `originalStreetId`.
- Added a single tag to street thumbnails being updated equal to the street's `editCount`. Before uploading the street thumbnail to Cloudinary, if a street thumbnail already exists for that street the tag is checked against the current street's `editCount` and if it is equal we do not upload the thumbnail again since nothing should have changed (This hopefully reduces the number of `INITIAL` street thumbnail uploads if a user is refreshing the page). 
- No longer logging the error of `Resource not found` when we check to see if the street thumbnail exists since the street thumbnail not existing is dealt with further in the code in the conditional statement and is not really an error.