### PR TITLE
Remove `system.cssTransform`

### DIFF
--- a/assets/scripts/app/SkyBackground.jsx
+++ b/assets/scripts/app/SkyBackground.jsx
@@ -36,8 +36,9 @@ class SkyBackground extends React.PureComponent {
     this.currentBackgroundEl.current.classList.add('sky-transition-in')
   }
 
-  updateStreetSkyBackground = (isFront, scrollPos) => {
+  transformSkyBackground = (isFront, scrollPos) => {
     let style = ''
+
     if (isFront) {
       const frontPos = -scrollPos * 0.5
       style = 'translateX(' + frontPos + 'px)'
@@ -45,7 +46,11 @@ class SkyBackground extends React.PureComponent {
       const rearPos = -scrollPos * 0.25
       style = 'translateX(' + rearPos + 'px)'
     }
-    return style
+
+    return {
+      WebkitTransform: style,
+      transform: style
+    }
   }
 
   render () {
@@ -57,11 +62,11 @@ class SkyBackground extends React.PureComponent {
       height: `${height}px`
     }
     const frontCloudStyle = {
-      transform: this.updateStreetSkyBackground(true, scrollPos),
+      ...this.transformSkyBackground(true, scrollPos),
       opacity: environs.cloudOpacity || null
     }
     const rearCloudStyle = {
-      transform: this.updateStreetSkyBackground(false, scrollPos),
+      ...this.transformSkyBackground(false, scrollPos),
       opacity: environs.cloudOpacity || null
     }
 

--- a/assets/scripts/app/SkyBackground.jsx
+++ b/assets/scripts/app/SkyBackground.jsx
@@ -9,7 +9,6 @@ class SkyBackground extends React.PureComponent {
   static propTypes = {
     scrollPos: PropTypes.number.isRequired,
     height: PropTypes.number.isRequired,
-    system: PropTypes.object.isRequired,
     environment: PropTypes.string.isRequired
   }
 
@@ -50,7 +49,7 @@ class SkyBackground extends React.PureComponent {
   }
 
   render () {
-    const { height, scrollPos, system, environment } = this.props
+    const { height, scrollPos, environment } = this.props
     const environs = getEnvirons(environment)
     const prevEnvirons = getEnvirons(this.state.prevEnvirons)
 
@@ -58,11 +57,11 @@ class SkyBackground extends React.PureComponent {
       height: `${height}px`
     }
     const frontCloudStyle = {
-      [system.cssTransform]: this.updateStreetSkyBackground(true, scrollPos),
+      transform: this.updateStreetSkyBackground(true, scrollPos),
       opacity: environs.cloudOpacity || null
     }
     const rearCloudStyle = {
-      [system.cssTransform]: this.updateStreetSkyBackground(false, scrollPos),
+      transform: this.updateStreetSkyBackground(false, scrollPos),
       opacity: environs.cloudOpacity || null
     }
 
@@ -102,7 +101,6 @@ class SkyBackground extends React.PureComponent {
 
 function mapStateToProps (state) {
   return {
-    system: state.system,
     environment: state.street.environment
   }
 }

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -234,13 +234,15 @@ export class Segment extends React.Component {
 
     const actualWidth = this.calculateSegmentWidths(RESIZE_TYPE_INITIAL)
     const elementWidth = actualWidth * TILE_SIZE
+    const translate = 'translateX(' + this.props.segmentPos + 'px)'
 
     const segmentStyle = {
       width: elementWidth + 'px',
       // In a street, certain segments have stacking priority over others (expressed as z-index).
       // Setting a z-index here will clobber a separate z-index (applied via CSS) when hovered by mouse pointer
       zIndex: (this.props.isDragging) ? 0 : segmentInfo.zIndex,
-      transform: 'translateX(' + this.props.segmentPos + 'px)'
+      WebkitTransform: translate,
+      transform: translate
     }
 
     const dataAttributes = {

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -47,7 +47,6 @@ export class Segment extends React.Component {
     updatePerspective: PropTypes.func,
 
     // Provided by store
-    cssTransform: PropTypes.string,
     locale: PropTypes.string,
     infoBubbleHovered: PropTypes.bool,
     descriptionVisible: PropTypes.bool,
@@ -241,7 +240,7 @@ export class Segment extends React.Component {
       // In a street, certain segments have stacking priority over others (expressed as z-index).
       // Setting a z-index here will clobber a separate z-index (applied via CSS) when hovered by mouse pointer
       zIndex: (this.props.isDragging) ? 0 : segmentInfo.zIndex,
-      [this.props.cssTransform]: 'translateX(' + this.props.segmentPos + 'px)'
+      transform: 'translateX(' + this.props.segmentPos + 'px)'
     }
 
     const dataAttributes = {
@@ -310,7 +309,6 @@ export class Segment extends React.Component {
 
 function mapStateToProps (state) {
   return {
-    cssTransform: state.system.cssTransform,
     locale: state.locale.locale,
     infoBubbleHovered: state.infoBubble.mouseInside,
     descriptionVisible: state.infoBubble.descriptionVisible,

--- a/assets/scripts/segments/__tests__/Segment.test.js
+++ b/assets/scripts/segments/__tests__/Segment.test.js
@@ -61,29 +61,29 @@ describe('Segment', () => {
     })
   })
   it('renders the units correctly', () => {
-    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} units={SETTINGS_UNITS_IMPERIAL} cssTransform={'transform'} segmentPos={1} />)
+    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} units={SETTINGS_UNITS_IMPERIAL} segmentPos={1} />)
     expect(wrapper).toMatchSnapshot()
   })
   it('renders active segment correctly', () => {
-    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} cssTransform={'transform'} segmentPos={1} />)
+    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} segmentPos={1} />)
     expect(wrapper).toMatchSnapshot()
   })
   it('renders segment warnings outside correctly', () => {
     segment.warnings = {}
     segment.warnings[SEGMENT_WARNING_OUTSIDE] = 'warning'
-    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} cssTransform={'transform'} segmentPos={1} />)
+    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} segmentPos={1} />)
     expect(wrapper).toMatchSnapshot()
   })
   it('renders segment warnings correctly', () => {
     segment.warnings = {}
     segment.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL] = 'warning'
-    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} cssTransform={'transform'} segmentPos={1} />)
+    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} segmentPos={1} />)
     expect(wrapper).toMatchSnapshot()
   })
   it('renders segment warnings width too large correctly', () => {
     segment.warnings = {}
     segment.warnings[SEGMENT_WARNING_WIDTH_TOO_LARGE] = 'warning'
-    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} cssTransform={'transform'} segmentPos={1} />)
+    const wrapper = shallow(<Segment connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} segment={segment} actualWidth={1} updateSegmentData={updateSegmentData} connectDragPreview={connectDragPreview} isDragging={false} dataNo={10} activeSegment={10} segmentPos={1} />)
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/assets/scripts/segments/__tests__/__snapshots__/Segment.test.js.snap
+++ b/assets/scripts/segments/__tests__/__snapshots__/Segment.test.js.snap
@@ -8,6 +8,7 @@ exports[`Segment renders active segment correctly 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
+      "WebkitTransform": "translateX(1px)",
       "transform": "translateX(1px)",
       "width": "12px",
       "zIndex": 1,
@@ -80,6 +81,7 @@ exports[`Segment renders segment warnings correctly 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
+      "WebkitTransform": "translateX(1px)",
       "transform": "translateX(1px)",
       "width": "12px",
       "zIndex": 1,
@@ -152,6 +154,7 @@ exports[`Segment renders segment warnings outside correctly 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
+      "WebkitTransform": "translateX(1px)",
       "transform": "translateX(1px)",
       "width": "12px",
       "zIndex": 1,
@@ -224,6 +227,7 @@ exports[`Segment renders segment warnings width too large correctly 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
+      "WebkitTransform": "translateX(1px)",
       "transform": "translateX(1px)",
       "width": "12px",
       "zIndex": 1,
@@ -296,6 +300,7 @@ exports[`Segment renders the units correctly 1`] = `
   onMouseLeave={[Function]}
   style={
     Object {
+      "WebkitTransform": "translateX(1px)",
       "transform": "translateX(1px)",
       "width": "12px",
       "zIndex": 1,

--- a/assets/scripts/store/reducers/system.js
+++ b/assets/scripts/store/reducers/system.js
@@ -12,8 +12,7 @@ const initialState = {
   noInternet: false,
   viewportWidth: window.innerWidth,
   viewportHeight: window.innerHeight,
-  devicePixelRatio: window.devicePixelRatio || 1.0,
-  cssTransform: (Modernizr && Modernizr.prefixed('transform')) || 'transform'
+  devicePixelRatio: window.devicePixelRatio || 1.0
 }
 
 const system = (state = initialState, action) => {


### PR DESCRIPTION
When Streetmix was originally written, the CSS `transform` property was still considered "experimental" and many browsers prefixed it (e.g. `-webkit-transform`, `-ms-transform`, etc.). Adding vendor-prefixed properties in CSS are still fine (Autoprefixer handles it for us), but in JavaScript, where our code might need to dynamically update an inline `transform` style, we relied on the Modernizr library to detect the correct vendor prefix, and then we stored that prefix in our `system` Redux state for later use. Thus, adding a transform style to a React component required connecting to Redux, reading the prefix, and then doing something like this:

```jsx
(props) => <MyComponent style={{ [props.system.cssTransform]: '0px' }} />
```

This meant adding complexity to our code and our tests. Here, I revisit this to see whether we can conceivably remove this from our code.

Browser support at this time suggests that it is now relatively safe to remove vendor prefixes (Sources: [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/transform#Browser_compatibility), [CanIUse](https://caniuse.com/#feat=transforms2d).) That being said, it is the nature of CSS that we should be able to add the vendor-prefixed properties simultaneously with the un-prefixed property and the browser should automatically know what to do, so we should no longer need to detect prefixes. Adding vendor-prefixed properties to inline styles is [fully supported in React](https://caniuse.com/#feat=transforms2d).

Thus my proposal is to do the following:

```jsx
(props) => <MyComponent style={{ WebkitTransform: '0px', transform: '0px' }} />
```

With this change, we can remove the Redux state that tracks the vendor prefix.

If accepted, this affects PR https://github.com/streetmix/streetmix/pull/1255.