### PR TITLE
Street thumbnails

### DIFF
--- a/assets/scripts/streets/image.js
+++ b/assets/scripts/streets/image.js
@@ -82,7 +82,7 @@ export function initStreetThumbnailSubscriber () {
     _savedThumbnail = false
 
     // Save street thumbnail every 30 minutes if any changes to street.
-    if (timeElapsed >= SAVE_THUMBNAIL_TIME_INTERVAL) {
+    if (timeElapsed && timeElapsed >= SAVE_THUMBNAIL_TIME_INTERVAL) {
       const street = trimStreetData(store.getState().street)
       saveStreetThumbnail(street, SAVE_THUMBNAIL_EVENTS.TIMER)
     }
@@ -95,6 +95,7 @@ export function initStreetThumbnailSubscriber () {
 export async function saveStreetThumbnail (street, event) {
   if (_savedThumbnail) return
 
+  _lastSavedTimestamp = Date.now()
   const thumbnail = getStreetImage(street, false, false, true, 2.0, false)
 
   try {
@@ -127,7 +128,6 @@ export async function saveStreetThumbnail (street, event) {
     }
 
     const response = await window.fetch(url, options)
-    _lastSavedTimestamp = Date.now()
 
     if (response.ok) {
       console.log('Updated street thumbnail.')

--- a/assets/scripts/streets/image.js
+++ b/assets/scripts/streets/image.js
@@ -73,7 +73,8 @@ export function initStreetThumbnailSubscriber () {
   saveStreetThumbnail(trimStreetData(store.getState().street), SAVE_THUMBNAIL_EVENTS.INITIAL)
 
   const select = (state) => {
-    return state.street.editCount
+    const street = { editCount: state.street.editCount, id: state.street.id }
+    return JSON.stringify(street)
   }
 
   const onChange = () => {


### PR DESCRIPTION
After looking at the papertrail logs, I noticed that the "TIMER" event seems to occur even before 30 minutes have passed. I think it might be because if a user is editing the street before the previous POST request finishes, the `_lastSavedTimestamp` doesn't get updated yet since it is set after awaiting for the response of the POST request. The unchanged `_lastSavedTimestamp` and the change in the `editCount` triggers another POST request even though 30 minutes have not passed. This PR now sets `_lastSavedTimestamp` from the very start of the `saveStreetThumbnail` function before the async request is made. This seems to fix the problem where multiple "TIMER" POST requests are made one after the other.

Another thought that I had was that only observing the store for changes in `editCount` might not trigger a change when switching between gallery streets if the previous street and the street we are switching to have the same `editCount`. This PR now observes the store for changes in both the `editCount` and the street id. 