### PR TITLE
Update removeSegment to call segmentsChanged

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -34,7 +34,7 @@ import { KEYS } from '../app/keys'
 import { trackEvent } from '../app/event_tracking'
 import { t } from '../locales/locale'
 import { setActiveSegment } from '../store/actions/ui'
-import { incrementSegmentWidth, removeSegment as removeSegmentAction, clearSegments } from '../store/actions/street'
+import { incrementSegmentWidth, removeSegmentAction, clearSegments } from '../store/actions/street'
 import { showStatusMessage } from '../store/actions/status'
 
 export class Segment extends React.Component {

--- a/assets/scripts/segments/remove.js
+++ b/assets/scripts/segments/remove.js
@@ -2,7 +2,7 @@ import { showStatusMessage } from '../app/status_message'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { segmentsChanged } from './view'
 import { t } from '../locales/locale'
-import { clearSegments } from '../store/actions/street'
+import { removeSegment as removeSegmentActionCreator, clearSegments } from '../store/actions/street'
 import store from '../store'
 
 /**
@@ -19,6 +19,7 @@ export function removeSegment (position) {
 
   // Update the store
   // ToDo: Refactor all other methods that use this to update the store via there dispatch
+  store.dispatch(removeSegmentActionCreator(position, false))
 
   segmentsChanged()
 

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -244,6 +244,22 @@ export function setEnvironment (env) {
   }
 }
 
+export const segmentsChanged = () => {
+  return async (dispatch, getState) => {
+    const street = getState().street
+    const updatedStreet = recalculateWidth(street)
+    await dispatch(updateSegments(updatedStreet.segments, updatedStreet.occupiedWidth, updatedStreet.remainingWidth))
+    console.log(updatedStreet)
+    // ToDo: Refactor this out to be dispatched as well
+    saveStreetToServerIfNecessary()
+  }
+}
+export const removeSegmentAction = (dataNo) => {
+  return async (dispatch, getState) => {
+    await dispatch(removeSegment(dataNo, false))
+    await dispatch(segmentsChanged())
+  }
+}
 export const incrementSegmentWidth = (dataNo, add, precise, origWidth, resizeType = RESIZE_TYPE_INITIAL) => {
   return async (dispatch, getState) => {
     const { unitSettings } = getState().ui
@@ -262,10 +278,6 @@ export const incrementSegmentWidth = (dataNo, add, precise, origWidth, resizeTyp
     cancelSegmentResizeTransitions()
     const width = normalizeSegmentWidth(origWidth + increment, increment)
     await dispatch(changeSegmentWidth(dataNo, width))
-    const street = getState().street
-    const updatedStreet = recalculateWidth(street)
-    await dispatch(updateSegments(updatedStreet.segments, updatedStreet.occupiedWidth, updatedStreet.remainingWidth))
-    // ToDo: Refactor this out to be dispatched as well
-    saveStreetToServerIfNecessary()
+    await dispatch(segmentsChanged())
   }
 }

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -249,7 +249,6 @@ export const segmentsChanged = () => {
     const street = getState().street
     const updatedStreet = recalculateWidth(street)
     await dispatch(updateSegments(updatedStreet.segments, updatedStreet.occupiedWidth, updatedStreet.remainingWidth))
-    console.log(updatedStreet)
     // ToDo: Refactor this out to be dispatched as well
     saveStreetToServerIfNecessary()
   }


### PR DESCRIPTION
## What does this PR do?
fixes #1628

refactor `segmentsChanged` into a separate method
add old methods to `remove.js` since the remove button does not use the new way just yet.