### PR TITLE
Remove some redundant data storage

### DIFF
--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -85,10 +85,9 @@ export class StreetEditable extends React.Component {
     const segment = segments[dataNo]
 
     if (segment) {
-      segment.el = ref
-      segment.el.dataNo = dataNo
-      segment.el.savedLeft = Math.round(segmentPos)
-      segment.el.cssTransformLeft = Math.round(segmentPos)
+      ref.dataNo = dataNo
+      ref.savedLeft = Math.round(segmentPos)
+      ref.cssTransformLeft = Math.round(segmentPos)
     }
   }
 

--- a/assets/scripts/app/__tests__/__snapshots__/StreetEditable.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/StreetEditable.test.js.snap
@@ -9,7 +9,6 @@ exports[`StreetEditable segment warnings too large KEY.EQUAL does not increase t
     <div
       class="segment hover show-drag-handles warning"
       data-testid="segment"
-      data-width="400"
       style="width: 4800px; z-index: 1; transform: translateX(0px);"
     >
       <div

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -263,7 +263,6 @@ export class Segment extends React.Component {
     }
 
     const dataAttributes = {
-      'data-width': actualWidth,
       'data-testid': 'segment'
     }
 

--- a/assets/scripts/segments/__tests__/__snapshots__/Segment.test.js.snap
+++ b/assets/scripts/segments/__tests__/__snapshots__/Segment.test.js.snap
@@ -5,7 +5,6 @@ exports[`Segment renders correctly 1`] = `
   <div
     class="segment hover show-drag-handles"
     data-testid="segment"
-    data-width="200"
     style="width: 2400px; z-index: 1; transform: translateX(undefinedpx);"
   >
     <div

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -130,7 +130,7 @@ function handleSegmentResizeStart (event) {
   draggingResize.elY = pos[1]
 
   draggingResize.originalX = draggingResize.elX
-  draggingResize.originalWidth = parseFloat(el.parentNode.getAttribute('data-width'))
+  draggingResize.originalWidth = store.getState().street.segments[el.parentNode.dataNo].width
   draggingResize.segmentEl = el.parentNode
 
   draggingResize.segmentEl.classList.add('hover')


### PR DESCRIPTION
- Removes legacy use of `data-width` attribute to store segment width on the element. Width should always be read from Redux store (single state of truth).
- Removes storing the segment element in Redux store. I don't believe it's read by anything currently, and storing non-serializable data such as an HTML element in store causes problems in Redux (notably, also causes Redux DevTools extension to crash immediately).