### PR TITLE
Update travis.ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,10 @@ services:
   - mongodb
   - redis-server
 
-# We have `npm ci` errors, so force it to use `npm install`
-install:
-  - npm install
-
 before_script:
   # Artificial wait before connecting to MongoDB
   # https://docs.travis-ci.com/user/database-setup/#MongoDB-does-not-immediately-accept-connections
-  - sleep 15
+  # - sleep 15
   # Start the server and run it in background process
   - node index &
 
@@ -47,11 +43,4 @@ after_script:
 after_failure:
   - sudo service mongod status
 
-cache:
-  directories:
-    - node_modules
-    - .cache
-
-notifications:
-  slack:
-    secure: cqfsAO9mXGrdUl+f558aOlM1Z46UkvVU7dB5TvnXPUq7oim1NowQqCbSayCLtE2qayz+cVW1Qtid5znUygMOHgr3pWOJqnIN2Bjc6M2X+dLlnL6KAj+PS6uPHmlhwsArIdpDxkO1auVKODZAJbBuBhaFNhQphIzBbW4Cqc2Zn5w=
+cache: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ services:
   - redis-server
 
 before_script:
-  # Artificial wait before connecting to MongoDB
-  # https://docs.travis-ci.com/user/database-setup/#MongoDB-does-not-immediately-accept-connections
-  # - sleep 15
   # Start the server and run it in background process
   - node index &
 


### PR DESCRIPTION
- Removes `npm ci` workaround (related to `npm` being accidentally installed as a dependency?)
- Removes slack notification
- Removes artificial wait before Mongo connections
- Use travis-ci default caching (`.cache` in Parcel is likely to not be relevant between test instances)

Ideally this cuts test times down by a minute.
