### PR TITLE
Fix new segment data model to include "elevation"

### DIFF
--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -1,6 +1,7 @@
 {
   "lanes": {
     "asphalt": {
+      "elevation": 0,
       "variants": {
         "color": {
           "regular": {
@@ -20,9 +21,98 @@
           }
         }
       }
+    },
+    "sidewalk": {
+      "name": "Sidewalk",
+      "nameKey": "sidewalk",
+      "owner": "PEDESTRIAN",
+      "zIndex": 30,
+      "needRandSeed": true,
+      "elevation": 1,
+      "rules": {
+        "defaultWidth": 6,
+        "minWidth": 6
+      },
+      "variants": {
+        "density": {
+          "dense": {
+            "graphics": {
+              "repeat": "ground--concrete"
+            }
+          },
+          "normal": {
+            "graphics": {
+              "repeat": "ground--concrete"
+            }
+          },
+          "sparse": {
+            "graphics": {
+              "repeat": "ground--concrete"
+            }
+          },
+          "empty": {
+            "graphics": {
+              "repeat": "ground--concrete"
+            }
+          }
+        }
+      }
     }
   },
-  "objects": {},
+  "objects": {
+    "markings": {
+      "variants": {
+        "type|orientation": {
+          "lane": {
+            "right": {
+              "graphics": {
+                "right": "markings--lane-right"
+              }
+            },
+            "left": {
+              "graphics": {
+                "left": "markings--lane-left"
+              }
+            },
+            "both": {
+              "graphics": {
+                "right": "markings--lane-right",
+                "left": "markings--lane-left"
+              }
+            }
+          }
+        },
+        "type|direction|opacity": {
+          "straight": {
+            "inbound": {
+              "light": {
+                "graphics": {
+                  "center": "markings--straight-inbound-light"
+                }
+              },
+              "default": {
+                "graphics": {
+                  "center": "markings--straight-inbound"
+                }
+              }
+            },
+            "outbound": {
+              "light": {
+                "graphics": {
+                  "center": "markings--straight-outbound-light"
+                }
+              },
+              "default": {
+                "graphics": {
+                  "center": "markings--straight-outbound"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "vehicles": {
     "scooter": {
       "name": "Electric scooter",
@@ -39,16 +129,14 @@
           "inbound": {
             "graphics": {
               "center": [
-                "scooters--scooter-inbound",
-                "markings--straight-inbound-light"
+                "scooters--scooter-inbound"
               ]
             }
           },
           "outbound": {
             "graphics": {
               "center": [
-                "scooters--scooter-outbound",
-                "markings--straight-outbound-light"
+                "scooters--scooter-outbound"
               ]
             }
           }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -59,60 +59,29 @@
       }
     }
   },
-  "objects": {
-    "markings": {
-      "variants": {
-        "type|orientation": {
-          "lane": {
-            "right": {
-              "graphics": {
-                "right": "markings--lane-right"
-              }
-            },
-            "left": {
-              "graphics": {
-                "left": "markings--lane-left"
-              }
-            },
-            "both": {
-              "graphics": {
-                "right": "markings--lane-right",
-                "left": "markings--lane-left"
-              }
-            }
-          }
-        },
-        "type|direction|opacity": {
-          "straight": {
-            "inbound": {
-              "light": {
-                "graphics": {
-                  "center": "markings--straight-inbound-light"
-                }
-              },
-              "default": {
-                "graphics": {
-                  "center": "markings--straight-inbound"
-                }
-              }
-            },
-            "outbound": {
-              "light": {
-                "graphics": {
-                  "center": "markings--straight-outbound-light"
-                }
-              },
-              "default": {
-                "graphics": {
-                  "center": "markings--straight-outbound"
-                }
-              }
-            }
-          }
-        }
+  "markings": {
+    "markings--lane-right": {
+      "graphics": {
+        "right": "markings--lane-right"
+      }
+    },
+    "markings--lane-left": {
+      "graphics": {
+        "left": "markings--lane-left"
+      }
+    },
+    "markings--straight-inbound-light": {
+      "graphics": {
+        "center": "markings--straight-inbound-light"
+      }
+    },
+    "markings--straight-outbound-light": {
+      "graphics": {
+        "center": "markings--straight-outbound-light"
       }
     }
   },
+  "objects": {},
   "vehicles": {
     "scooter": {
       "name": "Electric scooter",

--- a/assets/scripts/segments/info.js
+++ b/assets/scripts/segments/info.js
@@ -1,5 +1,4 @@
 import SEGMENT_INFO from './info.json'
-import { testSegmentLookup } from './segment-dict.js'
 
 /**
  * Defines the meta-category of each segment, similar to "typechecking"
@@ -244,14 +243,7 @@ export function getSegmentInfo (type) {
  */
 export function getSegmentVariantInfo (type, variant) {
   const segment = getSegmentInfo(type)
-
-  const segmentVariantInfo = (segment && segment.details && segment.details[variant]) || SEGMENT_UNKNOWN_VARIANT
-
-  if (type === 'scooter' && !segmentVariantInfo.unknown) {
-    return testSegmentLookup(type, variant, segmentVariantInfo)
-  }
-
-  return segmentVariantInfo
+  return (segment && segment.details && segment.details[variant]) || SEGMENT_UNKNOWN_VARIANT
 }
 
 /**

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -31,7 +31,7 @@ function getSegmentInfo (group, id) {
  * Retrieves the information for all items that make up a particular component group by
  * looking up the component group and item id in `SEGMENT_COMPONENTS`.
  *
- * @param {string} group - component group name (i.e. `lanes`, `objects`, or `vehicles`)
+ * @param {string} group - component group name (i.e. `markings`, `lanes`, `objects`, or `vehicles`)
  * @param {Array} groupItems - items that make up the component group in shape of [{ id, variants }]
  * @returns {object} componentGroupInfo - returns object in shape of { id: { characteristics, rules, variants } }
  */
@@ -167,19 +167,25 @@ function getSegmentVariantInfo (type, variant) {
     // componentGroupInfo = [ { characteristics, rules, variants } ]
     const componentGroupInfo = getComponentGroupInfo(group, groupItems)
 
-    // componentGroupVariants = [ { graphics } ]
-    // 3) For each component group, look up the segment variant graphics for every item that makes up the component group.
-    const componentGroupVariants = getComponentGroupVariants(groupItems, componentGroupInfo)
+    // The "markings" component group does not have any variants, so we do not have to go through the variants in order
+    // to get the sprite definitions.
+    if (group === 'markings') {
+      Object.values(componentGroupInfo).forEach((groupItem) => { variantInfo.graphics.push(groupItem.graphics) })
+    } else {
+      // componentGroupVariants = [ { graphics } ]
+      // 3) For each component group, look up the segment variant graphics for every item that makes up the component group.
+      const componentGroupVariants = getComponentGroupVariants(groupItems, componentGroupInfo)
 
-    if (componentGroupVariants.length) {
-      // 4) Combine the variant graphics for each component group into one array
-      componentGroupVariants.forEach((groupItemVariants) => { variantInfo.graphics.push(groupItemVariants) })
-    }
+      if (componentGroupVariants.length) {
+        // 4) Combine the variant graphics for each component group into one array
+        componentGroupVariants.forEach((groupItemVariants) => { variantInfo.graphics.push(groupItemVariants) })
+      }
 
-    // 5) For each component group, look up any rules associated with each of the items that make up the component group.
-    const componentGroupRules = getComponentGroupRules(groupItems, componentGroupInfo)
-    if (componentGroupRules) {
-      return Object.assign(variantInfo, componentGroupRules)
+      // 5) For each component group, look up any rules associated with each of the items that make up the component group.
+      const componentGroupRules = getComponentGroupRules(groupItems, componentGroupInfo)
+      if (componentGroupRules) {
+        return Object.assign(variantInfo, componentGroupRules)
+      }
     }
 
     return variantInfo

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -33,7 +33,7 @@
     "outbound|regular": {
       "lanes": [
         {
-          "id": "road",
+          "id": "asphalt",
           "variants": {
             "color": "regular"
           }
@@ -63,7 +63,7 @@
     "inbound|green": {
       "lanes": [
         {
-          "id": "road",
+          "id": "asphalt",
           "variants": {
             "color": "green"
           }
@@ -93,7 +93,7 @@
     "outbound|green": {
       "lanes": [
         {
-          "id": "road",
+          "id": "asphalt",
           "variants": {
             "color": "green"
           }
@@ -123,7 +123,7 @@
     "inbound|red": {
       "lanes": [
         {
-          "id": "road",
+          "id": "asphalt",
           "variants": {
             "color": "red"
           }
@@ -153,7 +153,7 @@
     "outbound|red": {
       "lanes": [
         {
-          "id": "road",
+          "id": "asphalt",
           "variants": {
             "color": "red"
           }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -9,18 +9,12 @@
           }
         }
       ],
-      "objects": [
+      "markings": [
         {
-          "id": "markings",
-          "variants": {
-            "type|direction|opacity": [
-              "straight",
-              "inbound",
-              "light"
-            ]
-          }
+          "id": "markings--straight-inbound-light"
         }
       ],
+      "objects": [],
       "vehicles": [
         {
           "id": "scooter",
@@ -39,18 +33,12 @@
           }
         }
       ],
-      "objects": [
+      "markings": [
         {
-          "id": "markings",
-          "variants": {
-            "type|direction|opacity": [
-              "straight",
-              "outbound",
-              "light"
-            ]
-          }
+          "id": "markings--straight-outbound-light"
         }
       ],
+      "objects": [],
       "vehicles": [
         {
           "id": "scooter",
@@ -69,18 +57,12 @@
           }
         }
       ],
-      "objects": [
+      "markings": [
         {
-          "id": "markings",
-          "variants": {
-            "type|direction|opacity": [
-              "straight",
-              "inbound",
-              "light"
-            ]
-          }
+          "id": "markings--straight-inbound-light"
         }
       ],
+      "objects": [],
       "vehicles": [
         {
           "id": "scooter",
@@ -99,18 +81,12 @@
           }
         }
       ],
-      "objects": [
+      "markings": [
         {
-          "id": "markings",
-          "variants": {
-            "type|direction|opacity": [
-              "straight",
-              "outbound",
-              "light"
-            ]
-          }
+          "id": "markings--straight-outbound-light"
         }
       ],
+      "objects": [],
       "vehicles": [
         {
           "id": "scooter",
@@ -129,18 +105,12 @@
           }
         }
       ],
-      "objects": [
+      "markings": [
         {
-          "id": "markings",
-          "variants": {
-            "type|direction|opacity": [
-              "straight",
-              "inbound",
-              "light"
-            ]
-          }
+          "id": "markings--straight-inbound-light"
         }
       ],
+      "objects": [],
       "vehicles": [
         {
           "id": "scooter",
@@ -159,18 +129,12 @@
           }
         }
       ],
-      "objects": [
+      "markings": [
         {
-          "id": "markings",
-          "variants": {
-            "type|direction|opacity": [
-              "straight",
-              "outbound",
-              "light"
-            ]
-          }
+          "id": "markings--straight-outbound-light"
         }
       ],
+      "objects": [],
       "vehicles": [
         {
           "id": "scooter",

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -9,7 +9,18 @@
           }
         }
       ],
-      "objects": [],
+      "objects": [
+        {
+          "id": "markings",
+          "variants": {
+            "type|direction|opacity": [
+              "straight",
+              "inbound",
+              "light"
+            ]
+          }
+        }
+      ],
       "vehicles": [
         {
           "id": "scooter",
@@ -28,7 +39,18 @@
           }
         }
       ],
-      "objects": [],
+      "objects": [
+        {
+          "id": "markings",
+          "variants": {
+            "type|direction|opacity": [
+              "straight",
+              "outbound",
+              "light"
+            ]
+          }
+        }
+      ],
       "vehicles": [
         {
           "id": "scooter",
@@ -47,7 +69,18 @@
           }
         }
       ],
-      "objects": [],
+      "objects": [
+        {
+          "id": "markings",
+          "variants": {
+            "type|direction|opacity": [
+              "straight",
+              "inbound",
+              "light"
+            ]
+          }
+        }
+      ],
       "vehicles": [
         {
           "id": "scooter",
@@ -66,7 +99,18 @@
           }
         }
       ],
-      "objects": [],
+      "objects": [
+        {
+          "id": "markings",
+          "variants": {
+            "type|direction|opacity": [
+              "straight",
+              "outbound",
+              "light"
+            ]
+          }
+        }
+      ],
       "vehicles": [
         {
           "id": "scooter",
@@ -85,7 +129,18 @@
           }
         }
       ],
-      "objects": [],
+      "objects": [
+        {
+          "id": "markings",
+          "variants": {
+            "type|direction|opacity": [
+              "straight",
+              "inbound",
+              "light"
+            ]
+          }
+        }
+      ],
       "vehicles": [
         {
           "id": "scooter",
@@ -104,7 +159,18 @@
           }
         }
       ],
-      "objects": [],
+      "objects": [
+        {
+          "id": "markings",
+          "variants": {
+            "type|direction|opacity": [
+              "straight",
+              "outbound",
+              "light"
+            ]
+          }
+        }
+      ],
       "vehicles": [
         {
           "id": "scooter",

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -1,3 +1,4 @@
+import { testSegmentLookup } from './segment-dict'
 import { images } from '../app/load_resources'
 import { t } from '../locales/locale'
 import { saveStreetToServerIfNecessary } from '../streets/data_model'
@@ -216,6 +217,10 @@ function getGroundLevelOffset (elevation) {
 export function drawSegmentContents (ctx, type, variantString, actualWidth, offsetLeft, groundBaseline, randSeed, multiplier, dpi) {
   const variantInfo = getSegmentVariantInfo(type, variantString)
   const graphics = variantInfo.graphics
+
+  if (type === 'scooter') {
+    testSegmentLookup(type, variantString, variantInfo)
+  }
 
   // TODO: refactor this variable
   const segmentWidth = actualWidth * TILE_SIZE


### PR DESCRIPTION
- Added `elevation` value to `lanes`, where `asphalt` = 0 and `sidewalk` = 1. `getSegmentVariantInfo` now returns the `elevation` value of the segment based on the assumption that there will only be **one** `lane` component.
- Added `markings` component to `objects` (includes `markings--lane-` and `markings--straight-`)
- Added "type|orientation" and "type|direction|opacity" to `markings` variants
- Nested variants are denoted by the "|" symbol and are defined in `segment-lookup` by an array. `getComponentGroupVariants` can now handle nested variants.
- `testSegmentLookup` is now only called when drawing the segment and logs whether or not the segment was correctly mapped. (This is for testing purposes. When we are done migrating the old segment data model to use the new segment data model, we can use `getSegmentVariantInfo` instead of `testSegmentLookup`.)