### PR TITLE
Fixes "Cannot read `segmentBeforeEl` of null"

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -34,7 +34,7 @@ import { KEYS } from '../app/keys'
 import { trackEvent } from '../app/event_tracking'
 import { t } from '../locales/locale'
 import { setActiveSegment } from '../store/actions/ui'
-import { incrementSegmentWidth, removeSegmentAction, clearSegments } from '../store/actions/street'
+import { incrementSegmentWidth, removeSegmentAction, clearSegmentsAction } from '../store/actions/street'
 import { showStatusMessage } from '../store/actions/status'
 import './Segment.scss'
 
@@ -329,7 +329,7 @@ function mapDispatchToProps (dispatch, ownProps) {
   return {
     setActiveSegment: (position) => { dispatch(setActiveSegment(position)) },
     removeSegment: (position) => { dispatch(removeSegmentAction(position)) },
-    clearSegments: () => { dispatch(clearSegments()) },
+    clearSegments: () => { dispatch(clearSegmentsAction()) },
     incrementSegmentWidth: (dataNo, add, precise, resizeType) => dispatch(incrementSegmentWidth(dataNo, add, precise, ownProps.actualWidth, resizeType)),
     showStatusMessage: (message) => { dispatch(showStatusMessage(message, true)) }
   }

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -289,6 +289,13 @@ export const removeSegmentAction = (dataNo) => {
   }
 }
 
+export const clearSegmentsAction = () => {
+  return async (dispatch, getState) => {
+    await dispatch(clearSegments())
+    await dispatch(segmentsChanged())
+  }
+}
+
 export const incrementSegmentWidth = (dataNo, add, precise, origWidth, resizeType = RESIZE_TYPE_INCREMENT) => {
   return async (dispatch, getState) => {
     const units = getState().street.units


### PR DESCRIPTION
Issue #1272 occurred after removing all street segments at once (using `shift` + `DELETE` or `BACKSPACE`). After looking into it, it appears that `remainingWidth` was returning `undefined` when we were checking where in the street canvas the segment was being dropped. This caused the `draggingState` to remain `null` since without `remainingWidth` being defined, the function `isOverLeftOrRightCanvas` was unable to determine the position of the dropped segment.

This appears to be due to the `clearSegments` method in `<Segment />`, which is called when removing all street segments at once, not calling `segmentsChanged` after removing all segments. Similarly to how `this.props.removeSegment` in `<Segment />` dispatches `removeSegmentAction` instead of `removeSegment`, the solution was to create a new thunk action creator called `clearSegmentsAction` which after dispatching `clearSegments` will also dispatch `segmentsChanged`. 

Resolves #1272 