### PR TITLE
Try some React hooks!

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,9 +13,17 @@
     "es6": true,
     "mocha": true
   },
-  "plugins": ["react"],
-  "extends": ["standard", "standard-react"],
+  "plugins": [
+    "react",
+    "react-hooks"
+  ],
+  "extends": [
+    "standard",
+    "standard-react"
+  ],
   "rules": {
-    "jsx-quotes": ["error", "prefer-double"]
+    "jsx-quotes": ["error", "prefer-double"],
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/assets/scripts/streets/StreetMetaWidthMenu.jsx
+++ b/assets/scripts/streets/StreetMetaWidthMenu.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { SETTINGS_UNITS_IMPERIAL, SETTINGS_UNITS_METRIC } from '../users/constants'
 import { normalizeStreetWidth } from '../streets/width'
@@ -12,35 +12,22 @@ import './StreetMetaWidthMenu.scss'
 
 const DEFAULT_STREET_WIDTHS = [40, 60, 80]
 
-export default class StreetMetaWidthMenu extends Component {
-  static propTypes = {
-    // pass intl's formatMessage() to here to avoid HOC wrapper
-    formatMessage: PropTypes.func.isRequired,
+// Custom hook to focus an element after it's mounted
+// To use, call this function in a ref prop
+function useFocus () {
+  const el = useRef(null)
+  useEffect(() => {
+    el.current.focus()
+  }, [])
+  return el
+}
 
-    // from parent component
-    street: PropTypes.shape({
-      units: PropTypes.number,
-      width: PropTypes.number,
-      occupiedWidth: PropTypes.number
-    }).isRequired,
-    onChange: PropTypes.func.isRequired
+const StreetMetaWidthMenu = (props) => {
+  function handleChange (event) {
+    props.onChange(event.target.value)
   }
 
-  constructor (props) {
-    super(props)
-
-    this.selectRef = React.createRef()
-  }
-
-  componentDidMount () {
-    this.selectRef.current.focus()
-  }
-
-  handleChange = (event) => {
-    this.props.onChange(event.target.value)
-  }
-
-  renderOption = (width, units) => {
+  function renderOption (width, units) {
     return (
       <option key={width} value={width}>
         {prettifyWidth(width, units)}
@@ -48,67 +35,82 @@ export default class StreetMetaWidthMenu extends Component {
     )
   }
 
-  render () {
-    const formatMessage = this.props.formatMessage
-    const { units, width, occupiedWidth } = this.props.street
+  // Get ready to render
+  const formatMessage = props.formatMessage
+  const { units, width, occupiedWidth } = props.street
 
-    // Create options for default widths. This will also convert the widths
-    // the proper units for the street.
-    const defaultWidths = DEFAULT_STREET_WIDTHS.map((width) => normalizeStreetWidth(width, units))
-    const DefaultWidthOptions = defaultWidths.map((width) => this.renderOption(width, units))
+  // Create options for default widths. This will also convert the widths
+  // the proper units for the street.
+  const defaultWidths = DEFAULT_STREET_WIDTHS.map((width) => normalizeStreetWidth(width, units))
+  const DefaultWidthOptions = defaultWidths.map((width) => renderOption(width, units))
 
-    // If the street width doesn't match any of the default widths,
-    // render another choice representing the current width
-    const CustomWidthOption = (defaultWidths.indexOf(Number.parseFloat(width)) === -1)
-      ? (
-        <React.Fragment>
-          <option disabled />
-          {this.renderOption(width, units)}
-        </React.Fragment>
-      ) : null
+  // If the street width doesn't match any of the default widths,
+  // render another choice representing the current width
+  const CustomWidthOption = (defaultWidths.indexOf(Number.parseFloat(width)) === -1)
+    ? (
+      <React.Fragment>
+        <option disabled />
+        {renderOption(width, units)}
+      </React.Fragment>
+    ) : null
 
-    return (
-      <select
-        ref={this.selectRef}
-        onChange={this.handleChange}
-        value={width}
-        className="street-width-select"
-        title={formatMessage({
-          id: 'tooltip.street-width',
-          defaultMessage: 'Change width of the street'
-        })}
+  return (
+    <select
+      // Focus the <select> element after mounting
+      ref={useFocus()}
+      onChange={handleChange}
+      value={width}
+      className="street-width-select"
+      title={formatMessage({
+        id: 'tooltip.street-width',
+        defaultMessage: 'Change width of the street'
+      })}
+    >
+      <option disabled>
+        {formatMessage({ id: 'width.occupied', defaultMessage: 'Occupied width:' })}
+      </option>
+      <option disabled>
+        {prettifyWidth(occupiedWidth, units)}
+      </option>
+      <option disabled />
+      <option disabled>
+        {formatMessage({ id: 'width.building', defaultMessage: 'Building-to-building width:' })}
+      </option>
+      {DefaultWidthOptions}
+      {CustomWidthOption}
+      <option value={STREET_WIDTH_CUSTOM} >
+        {formatMessage({ id: 'width.different', defaultMessage: 'Different width…' })}
+      </option>
+      <option disabled />
+      <option
+        id="switch-to-imperial-units"
+        value={STREET_WIDTH_SWITCH_TO_IMPERIAL}
+        disabled={units === SETTINGS_UNITS_IMPERIAL}
       >
-        <option disabled>
-          {formatMessage({ id: 'width.occupied', defaultMessage: 'Occupied width:' })}
-        </option>
-        <option disabled>
-          {prettifyWidth(occupiedWidth, units)}
-        </option>
-        <option disabled />
-        <option disabled>
-          {formatMessage({ id: 'width.building', defaultMessage: 'Building-to-building width:' })}
-        </option>
-        {DefaultWidthOptions}
-        {CustomWidthOption}
-        <option value={STREET_WIDTH_CUSTOM} >
-          {formatMessage({ id: 'width.different', defaultMessage: 'Different width…' })}
-        </option>
-        <option disabled />
-        <option
-          id="switch-to-imperial-units"
-          value={STREET_WIDTH_SWITCH_TO_IMPERIAL}
-          disabled={units === SETTINGS_UNITS_IMPERIAL}
-        >
-          {formatMessage({ id: 'width.imperial', defaultMessage: 'Switch to imperial units (feet)' })}
-        </option>
-        <option
-          id="switch-to-metric-units"
-          value={STREET_WIDTH_SWITCH_TO_METRIC}
-          disabled={units === SETTINGS_UNITS_METRIC}
-        >
-          {formatMessage({ id: 'width.metric', defaultMessage: 'Switch to metric units' })}
-        </option>
-      </select>
-    )
-  }
+        {formatMessage({ id: 'width.imperial', defaultMessage: 'Switch to imperial units (feet)' })}
+      </option>
+      <option
+        id="switch-to-metric-units"
+        value={STREET_WIDTH_SWITCH_TO_METRIC}
+        disabled={units === SETTINGS_UNITS_METRIC}
+      >
+        {formatMessage({ id: 'width.metric', defaultMessage: 'Switch to metric units' })}
+      </option>
+    </select>
+  )
 }
+
+StreetMetaWidthMenu.propTypes = {
+  // pass intl's formatMessage() to here to avoid HOC wrapper
+  formatMessage: PropTypes.func.isRequired,
+
+  // from parent component
+  street: PropTypes.shape({
+    units: PropTypes.number,
+    width: PropTypes.number,
+    occupiedWidth: PropTypes.number
+  }).isRequired,
+  onChange: PropTypes.func.isRequired
+}
+
+export default StreetMetaWidthMenu

--- a/package-lock.json
+++ b/package-lock.json
@@ -5552,6 +5552,12 @@
         }
       }
     },
+    "eslint-plugin-react-hooks": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
+      "integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+      "dev": true
+    },
     "eslint-plugin-standard": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "eslint-plugin-node": "9.0.1",
     "eslint-plugin-promise": "4.1.1",
     "eslint-plugin-react": "7.13.0",
+    "eslint-plugin-react-hooks": "1.6.0",
     "eslint-plugin-standard": "4.0.0",
     "husky": "2.2.0",
     "jest": "24.8.0",


### PR DESCRIPTION
It's time to try some React hooks!

When I created / refactored the `<StreetMetaWidthMenu>` component earlier this week, it was a class component, because it relied on the React lifecycle method `componentDidMount` in order to perform a DOM side effect -- focusing the `<select>` element when it mounts. In fact, that's the only reason why it couldn't be refactored into a function component (the way its counterpart, `<StreetMetaWidthLabel>`, already is). With hooks, it can now be a function component. Instead of using the class lifecycle method, I create a custom `useFocus()` hook, which uses the built-in React hooks `useRef()` (to get a ref to the `<select>`) and `useEffect()` which runs the effect after mounting. 

More information about hooks, and rationale for using function components over class components, here: https://reactjs.org/docs/hooks-intro.html#complex-components-become-hard-to-understand

In addition, this PR adds linting rules for hook usage.