### PR TITLE
Consolidates <IntlProvider> at the top of the React tree

### DIFF
--- a/assets/scripts/app/App.jsx
+++ b/assets/scripts/app/App.jsx
@@ -41,47 +41,36 @@ class App extends React.PureComponent {
 
   render () {
     return (
-      <React.Fragment>
-        <IntlProvider
-          locale={this.props.locale.locale}
-          key={`3_${this.props.locale.locale}`}
-          messages={this.props.locale.messages}
-        >
-          <React.Fragment>
-            <BlockingShield />
-            <BlockingError />
-            <Gallery />
-            <NotificationBar locale={this.props.locale.locale} notification={NOTIFICATION} />
-          </React.Fragment>
-        </IntlProvider>
-        <div className="main-screen">
-          <IntlProvider
-            locale={this.props.locale.locale}
-            key={this.props.locale.locale}
-            messages={this.props.locale.messages}
-          >
-            <React.Fragment>
-              <GalleryShield />
-              <MenusContainer />
-              <StreetNameCanvas />
-              <InfoBubble />
-              <DebugHoverPolygon />
-              <WelcomePanel />
-              <PaletteContainer />
-              <DialogRoot />
-              <StatusMessage />
-              <NoConnectionMessage />
-              <EnvironmentEditor />
-            </React.Fragment>
-          </IntlProvider>
-          <SegmentDragLayer />
-          <StreetView />
-        </div>
-
-        <Flash />
-        <DebugInfo />
-        <PrintContainer />
-      </React.Fragment>
+      <IntlProvider
+        locale={this.props.locale.locale}
+        key={this.props.locale.locale}
+        messages={this.props.locale.messages}
+      >
+        <React.Fragment>
+          <NotificationBar locale={this.props.locale.locale} notification={NOTIFICATION} />
+          <BlockingShield />
+          <BlockingError />
+          <Gallery />
+          <Flash />
+          <DebugInfo />
+          <PrintContainer />
+          <div className="main-screen">
+            <GalleryShield />
+            <MenusContainer />
+            <StreetNameCanvas />
+            <InfoBubble />
+            <DebugHoverPolygon />
+            <WelcomePanel />
+            <PaletteContainer />
+            <DialogRoot />
+            <StatusMessage />
+            <NoConnectionMessage />
+            <EnvironmentEditor />
+            <SegmentDragLayer />
+            <StreetView />
+          </div>
+        </React.Fragment>
+      </IntlProvider>
     )
   }
 }

--- a/assets/scripts/app/StreetViewDirt.jsx
+++ b/assets/scripts/app/StreetViewDirt.jsx
@@ -1,6 +1,14 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
+import { getStreetSectionTop } from './window_resize'
 import './StreetViewDirt.scss'
+
+// Legacy height setter w/ DOM methods.
+function handleResize () {
+  const streetSectionTop = getStreetSectionTop()
+  const streetSectionDirtPos = window.innerHeight - streetSectionTop - 400 + 180
+  document.getElementById('street-section-dirt').style.height = streetSectionDirtPos + 'px'
+}
 
 const StreetViewDirt = (props) => {
   const dirtStyle = {
@@ -8,6 +16,19 @@ const StreetViewDirt = (props) => {
     marginRight: (-props.buildingWidth) + 'px'
   }
   const width = `${props.buildingWidth}px`
+
+  // On window resize, figure out what height it should be and apply it
+  // TODO: less stop relying on querying other DOM elements
+  // (this is legacy behavior, ported to this component)
+  useEffect(() => {
+    // Set window listener to do this
+    window.addEventListener('resize', handleResize)
+    // Do it one time
+    handleResize()
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
 
   return (
     <section id="street-section-dirt" style={dirtStyle}>

--- a/assets/scripts/app/StreetViewDirt.jsx
+++ b/assets/scripts/app/StreetViewDirt.jsx
@@ -1,37 +1,37 @@
-import React, { useEffect } from 'react'
+import React, { useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { getStreetSectionTop } from './window_resize'
 import './StreetViewDirt.scss'
 
-// Legacy height setter w/ DOM methods.
-function handleResize () {
+function getDirtElementHeight () {
   const streetSectionTop = getStreetSectionTop()
-  const streetSectionDirtPos = window.innerHeight - streetSectionTop - 400 + 180
-  document.getElementById('street-section-dirt').style.height = streetSectionDirtPos + 'px'
+  return window.innerHeight - streetSectionTop - 400 + 180
 }
 
-const StreetViewDirt = (props) => {
+const StreetViewDirt = ({ buildingWidth }) => {
   const dirtStyle = {
-    marginLeft: (-props.buildingWidth) + 'px',
-    marginRight: (-props.buildingWidth) + 'px'
+    marginLeft: (-buildingWidth) + 'px',
+    marginRight: (-buildingWidth) + 'px',
+    height: getDirtElementHeight() + 'px'
   }
-  const width = `${props.buildingWidth}px`
+  const width = `${buildingWidth}px`
 
   // On window resize, figure out what height it should be and apply it
-  // TODO: less stop relying on querying other DOM elements
-  // (this is legacy behavior, ported to this component)
+  const dirtEl = useRef(null)
   useEffect(() => {
+    function handleResize () {
+      dirtEl.current.style.height = getDirtElementHeight() + 'px'
+    }
+
     // Set window listener to do this
     window.addEventListener('resize', handleResize)
-    // Do it one time
-    handleResize()
     return () => {
       window.removeEventListener('resize', handleResize)
     }
   }, [])
 
   return (
-    <section id="street-section-dirt" style={dirtStyle}>
+    <section className="street-section-dirt" ref={dirtEl} style={dirtStyle}>
       <div className="street-section-dirt-left" style={{ width }} />
       <div className="street-section-dirt-right" style={{ width }} />
     </section>

--- a/assets/scripts/app/StreetViewDirt.scss
+++ b/assets/scripts/app/StreetViewDirt.scss
@@ -3,7 +3,7 @@
 $dirt-height: 40px;
 $dirt-height-minimum: 5px;
 
-#street-section-dirt {
+.street-section-dirt {
   position: absolute;
   left: 0;
   right: 0;

--- a/assets/scripts/app/window_resize.js
+++ b/assets/scripts/app/window_resize.js
@@ -9,6 +9,7 @@ export function getStreetSectionTop () {
   return streetSectionTop
 }
 
+// TODO: less stop relying on querying other DOM elements
 export function setStreetSectionTop () {
   const viewportHeight = window.innerHeight
   const streetSectionHeight = document.querySelector('#street-section-inner').offsetHeight

--- a/assets/scripts/app/window_resize.js
+++ b/assets/scripts/app/window_resize.js
@@ -9,10 +9,8 @@ export function getStreetSectionTop () {
   return streetSectionTop
 }
 
-export function onResize () {
-  store.dispatch(windowResize(window.innerWidth, window.innerHeight))
+export function setStreetSectionTop () {
   const viewportHeight = window.innerHeight
-
   const streetSectionHeight = document.querySelector('#street-section-inner').offsetHeight
   const paletteTop = document.querySelector('.palette-container').offsetTop || viewportHeight
 
@@ -31,10 +29,10 @@ export function onResize () {
   if (streetSectionTop + document.querySelector('#street-section-inner').offsetHeight > paletteTop - 20 + 180) { // gallery height
     streetSectionTop = paletteTop - 20 - streetSectionHeight + 180
   }
+}
 
-  const streetSectionDirtPos = viewportHeight - streetSectionTop - 400 + 180
-
-  document.querySelector('#street-section-dirt').style.height = streetSectionDirtPos + 'px'
-
+export function onResize () {
+  store.dispatch(windowResize(window.innerWidth, window.innerHeight))
+  setStreetSectionTop()
   infoBubble.show(true)
 }


### PR DESCRIPTION
We have now fully refactored our UI to the point where it's now possible to fully re-mount the entire application component tree when the locale changes!

The only thing that seems to break was the height of the dirt component, which is manually set when the application loads, and when the window resizes. Some light refactoring enables us to bring that functionality into the component with hooks. (We will eventually need to refactor this more, so that various parts of the app are less reliant on measuring layout of other components for placement, but that's outside the scope of this particular PR.)