### PR TITLE
attach multiple refs to canvas element

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -106,8 +106,8 @@ export class Segment extends React.Component {
     }
 
     if (!prevState.switchSegments && this.state.switchSegments) {
-      this.props.updatePerspective(this.oldSegmentCanvas.firstChildElement)
-      this.props.updatePerspective(this.newSegmentCanvas.firstChildElement)
+      this.props.updatePerspective(this.oldSegmentCanvas.current)
+      this.props.updatePerspective(this.newSegmentCanvas.current)
     }
 
     this.props.updateSegmentData(this.streetSegment, this.props.dataNo, this.props.segmentPos)
@@ -166,7 +166,7 @@ export class Segment extends React.Component {
           type={segment.type}
           variantString={(isOldVariant) ? this.state.oldVariant : segment.variantString}
           randSeed={segment.randSeed}
-          ref={(isOldVariant) ? this.oldSegmentCanvas : this.newSegmentCanvas}
+          forwardRef={(isOldVariant) ? this.oldSegmentCanvas : this.newSegmentCanvas}
         />
       </div>
     ))

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -69,8 +69,6 @@ export class Segment extends React.Component {
   constructor (props) {
     super(props)
 
-    this.oldSegmentCanvas = React.createRef()
-    this.newSegmentCanvas = React.createRef()
     this.initialRender = true
 
     this.state = {
@@ -103,11 +101,6 @@ export class Segment extends React.Component {
 
     if (prevProps.segment.variantString && prevProps.segment.variantString !== this.props.segment.variantString) {
       this.switchSegments(prevProps.segment.variantString)
-    }
-
-    if (!prevState.switchSegments && this.state.switchSegments) {
-      this.props.updatePerspective(this.oldSegmentCanvas.current)
-      this.props.updatePerspective(this.newSegmentCanvas.current)
     }
 
     this.props.updateSegmentData(this.streetSegment, this.props.dataNo, this.props.segmentPos)
@@ -166,7 +159,8 @@ export class Segment extends React.Component {
           type={segment.type}
           variantString={(isOldVariant) ? this.state.oldVariant : segment.variantString}
           randSeed={segment.randSeed}
-          forwardRef={(isOldVariant) ? this.oldSegmentCanvas : this.newSegmentCanvas}
+          updatePerspective={this.props.updatePerspective}
+          switchSegments={this.state.switchSegments}
         />
       </div>
     ))

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -160,7 +160,6 @@ export class Segment extends React.Component {
           variantString={(isOldVariant) ? this.state.oldVariant : segment.variantString}
           randSeed={segment.randSeed}
           updatePerspective={this.props.updatePerspective}
-          switchSegments={this.state.switchSegments}
         />
       </div>
     ))

--- a/assets/scripts/segments/SegmentCanvas.jsx
+++ b/assets/scripts/segments/SegmentCanvas.jsx
@@ -19,7 +19,8 @@ class SegmentCanvas extends React.PureComponent {
     randSeed: PropTypes.number,
     multiplier: PropTypes.number,
     groundBaseline: PropTypes.number,
-    dpi: PropTypes.number
+    dpi: PropTypes.number,
+    forwardRef: PropTypes.object
   }
 
   static defaultProps = {
@@ -59,6 +60,14 @@ class SegmentCanvas extends React.PureComponent {
     drawSegmentContents(ctx, this.props.type, this.props.variantString, this.props.actualWidth, 0, this.props.groundBaseline, this.props.randSeed, this.props.multiplier, this.props.dpi)
   }
 
+  attachRefsToCanvas = (el) => {
+    this.canvasEl.current = el
+
+    if (this.props.forwardRef) {
+      this.props.forwardRef.current = el
+    }
+  }
+
   render () {
     // Determine the maximum width of the artwork for this segment
     const variantInfo = getSegmentVariantInfo(this.props.type, this.props.variantString)
@@ -85,7 +94,7 @@ class SegmentCanvas extends React.PureComponent {
     return (
       <canvas
         className="segment-image"
-        ref={this.canvasEl}
+        ref={this.attachRefsToCanvas}
         width={canvasWidth}
         height={canvasHeight}
         style={canvasStyle}

--- a/assets/scripts/segments/SegmentCanvas.jsx
+++ b/assets/scripts/segments/SegmentCanvas.jsx
@@ -20,7 +20,8 @@ class SegmentCanvas extends React.PureComponent {
     multiplier: PropTypes.number,
     groundBaseline: PropTypes.number,
     dpi: PropTypes.number,
-    forwardRef: PropTypes.object
+    switchSegments: PropTypes.bool,
+    updatePerspective: PropTypes.func
   }
 
   static defaultProps = {
@@ -43,6 +44,10 @@ class SegmentCanvas extends React.PureComponent {
   }
 
   componentDidUpdate (prevProps) {
+    if (!prevProps.switchSegments && this.props.switchSegments) {
+      this.props.updatePerspective(this.canvasEl.current)
+    }
+
     this.drawSegment()
   }
 
@@ -58,14 +63,6 @@ class SegmentCanvas extends React.PureComponent {
     ctx.clearRect(0, 0, canvas.width, canvas.height)
 
     drawSegmentContents(ctx, this.props.type, this.props.variantString, this.props.actualWidth, 0, this.props.groundBaseline, this.props.randSeed, this.props.multiplier, this.props.dpi)
-  }
-
-  attachRefsToCanvas = (el) => {
-    this.canvasEl.current = el
-
-    if (this.props.forwardRef) {
-      this.props.forwardRef.current = el
-    }
   }
 
   render () {
@@ -94,7 +91,7 @@ class SegmentCanvas extends React.PureComponent {
     return (
       <canvas
         className="segment-image"
-        ref={this.attachRefsToCanvas}
+        ref={this.canvasEl}
         width={canvasWidth}
         height={canvasHeight}
         style={canvasStyle}

--- a/assets/scripts/segments/SegmentCanvas.jsx
+++ b/assets/scripts/segments/SegmentCanvas.jsx
@@ -20,13 +20,13 @@ class SegmentCanvas extends React.PureComponent {
     multiplier: PropTypes.number,
     groundBaseline: PropTypes.number,
     dpi: PropTypes.number,
-    switchSegments: PropTypes.bool,
     updatePerspective: PropTypes.func
   }
 
   static defaultProps = {
     multiplier: 1,
-    groundBaseline: GROUND_BASELINE
+    groundBaseline: GROUND_BASELINE,
+    updatePerspective: () => {}
   }
 
   constructor (props) {
@@ -40,11 +40,12 @@ class SegmentCanvas extends React.PureComponent {
   }
 
   componentDidMount () {
+    this.props.updatePerspective(this.canvasEl.current)
     this.drawSegment()
   }
 
   componentDidUpdate (prevProps) {
-    if (!prevProps.switchSegments && this.props.switchSegments) {
+    if (prevProps.variantString !== this.props.variantString) {
       this.props.updatePerspective(this.canvasEl.current)
     }
 


### PR DESCRIPTION
Previously we attached a ref directly to the `<SegmentCanvas />`component but after updating our dependencies (specifically React), a warning message is now displayed in the console as shown below:
![image](https://user-images.githubusercontent.com/17012261/57627681-731e7280-7566-11e9-94ae-24711d9485ef.png)

After looking into the `<SegmentCanvas />` I noticed that `<SegmentCanvas />` also has attached a ref to its `canvas` element. In order to attach two refs to the same `canvas` element, I have forwarded the ref from the `<Segment />` component as a prop called `forwardRef` and called a function to attach both `this.props.forwardRef` and `this.canvasEl` to the `canvas` element similar to the solution discussed [here](https://github.com/facebook/react/issues/13029).

Another option that I am thinking is to only have one ref from the `<Segment />` component be passed into `<SegmentCanvas />` and attached to the `canvas` element. Instead of creating a new ref, `this.canvasEl`, in `<SegmentCanvas />` we could reuse `this.props.forwardRef` (or rename it to `this.props.canvasEl`) to do what is needed in `<SegmentCanvas />` which is to draw the segment. This way we could use the `React.forwardRef` as shown [here](https://stackoverflow.com/a/52223103)?

@louh Let me know which way sounds better. I think both of these solutions will remove the warning displayed in console.