### PR TITLE
Refactoring `SEGMENT_LOOKUP` and `SEGMENT_COMPONENTS` 

### DIFF
--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -97,6 +97,74 @@
           }
         }
       }
+    },
+    "taxi": {
+      "name": "Taxi",
+      "nameKey": "taxi",
+      "owner": "FLEX",
+      "zIndex": 15,
+      "variants": {
+        "direction|orientation": {
+          "inbound": {
+            "left": {
+              "graphics": {
+                "center": "vehicles--taxi-inbound-door-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "center": "vehicles--taxi-inbound-door-right"
+              }
+            }
+          },
+          "outbound": {
+            "left": {
+              "graphics": {
+                "center": "vehicles--taxi-outbound-door-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "center": "vehicles--taxi-outbound-door-right"
+              }
+            }
+          }
+        }
+      }
+    },
+    "rideshare": {
+      "name": "Rideshare",
+      "nameKey": "rideshare",
+      "owner": "FLEX",
+      "zIndex": 15,
+      "variants": {
+        "direction|orientation": {
+          "inbound": {
+            "left": {
+              "graphics": {
+                "center": "vehicles--rideshare-inbound-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "center": "vehicles--rideshare-inbound-right"
+              }
+            }
+          },
+          "outbound": {
+            "left": {
+              "graphics": {
+                "center": "vehicles--rideshare-outbound-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "center": "vehicles--rideshare-outbound-right"
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -75,6 +75,10 @@
   "objects": {},
   "vehicles": {
     "scooter": {
+      "name": "Electric scooter",
+      "nameKey": "scooter",
+      "owner": "BIKE",
+      "zIndex": 16,
       "variants": {
         "direction": {
           "inbound": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -142,24 +142,24 @@
           "inbound": {
             "left": {
               "graphics": {
-                "center": "vehicles--rideshare-inbound-left"
+                "center": "vehicles--rideshare-inbound-door-left"
               }
             },
             "right": {
               "graphics": {
-                "center": "vehicles--rideshare-inbound-right"
+                "center": "vehicles--rideshare-inbound-door-right"
               }
             }
           },
           "outbound": {
             "left": {
               "graphics": {
-                "center": "vehicles--rideshare-outbound-left"
+                "center": "vehicles--rideshare-outbound-door-left"
               }
             },
             "right": {
               "graphics": {
-                "center": "vehicles--rideshare-outbound-right"
+                "center": "vehicles--rideshare-outbound-door-right"
               }
             }
           }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -23,16 +23,7 @@
       }
     },
     "sidewalk": {
-      "name": "Sidewalk",
-      "nameKey": "sidewalk",
-      "owner": "PEDESTRIAN",
-      "zIndex": 30,
-      "needRandSeed": true,
       "elevation": 1,
-      "rules": {
-        "defaultWidth": 6,
-        "minWidth": 6
-      },
       "variants": {
         "density": {
           "dense": {
@@ -84,15 +75,6 @@
   "objects": {},
   "vehicles": {
     "scooter": {
-      "name": "Electric scooter",
-      "nameKey": "scooter",
-      "owner": "BIKE",
-      "zIndex": 16,
-      "enableWithFlag": "SEGMENT_SCOOTERS",
-      "rules": {
-        "defaultWidth": 5,
-        "minWidth": 4
-      },
       "variants": {
         "direction": {
           "inbound": {

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -240,12 +240,11 @@ function verifyCorrectness (originalVariantInfo, newVariantInfo) {
 export function testSegmentLookup (type, variant, segmentVariantInfo) {
   const newVariantInfo = getSegmentVariantInfo(type, variant)
 
-  console.log(segmentVariantInfo)
   if (verifyCorrectness(segmentVariantInfo, newVariantInfo)) {
-    console.log('Correctly mapped segment.')
     return newVariantInfo
   } else {
-    console.log(newVariantInfo)
+    console.log(`Incorrectly mapped segment of type "${type}" and variant "${variant}".`)
+    console.log(segmentVariantInfo, newVariantInfo)
     return segmentVariantInfo
   }
 }

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -203,6 +203,28 @@ function getSegmentVariantInfo (type, variant) {
 }
 
 /**
+ * Gets segment data for segment `type`. Safer than reading `type` directly
+ * from `SEGMENT_INFO`, because this will return the `SEGMENT_UNKNOWN`
+ * placeholder if the type is not found. The unknown segment placeholder
+ * allows means bad data, experimental segments, etc. won't break rendering.
+ *
+ * @param {string} type
+ * @returns {Object} segmentInfo
+ */
+export function getSegmentInfo (type) {
+  const segmentInfo = SEGMENT_LOOKUP[type] && SEGMENT_LOOKUP[type]['segment-info']
+  const segmentInfoKey = segmentInfo && segmentInfo.key
+
+  if (segmentInfoKey) {
+    const [ group, id ] = segmentInfoKey
+    const { variants, ...componentInfo } = getSegmentComponentInfo(group, id)
+    return componentInfo || SEGMENT_UNKNOWN
+  }
+
+  return segmentInfo || SEGMENT_UNKNOWN
+}
+
+/**
  * Temporary helper method that compares the original segment variant info with the variant info returned
  * by the new data model. If the new variant info contains all the keys from the original variant info, then
  * the variant info is correct.

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -16,14 +16,14 @@ function getSegmentLookup (type, variant) {
 }
 
 /**
- * Retrieves the specified segment information from the new segment data model using the
- * component group and the segment id.
+ * Retrieves the specified segment component information from the new segment data model using the
+ * component group and the segment component's id.
  *
  * @param {string} group - component group, one of values "lanes", "vehicles" or "objects"
  * @param {string} id - name of segment component, e.g. "scooter"
  * @returns {object} segmentInfo
  */
-function getSegmentInfo (group, id) {
+function getSegmentComponentInfo (group, id) {
   return (SEGMENT_COMPONENTS[group] && SEGMENT_COMPONENTS[group][id]) || SEGMENT_UNKNOWN
 }
 
@@ -37,7 +37,7 @@ function getSegmentInfo (group, id) {
  */
 function getComponentGroupInfo (group, groupItems) {
   return groupItems.reduce((obj, item) => {
-    obj[item.id] = getSegmentInfo(group, item.id)
+    obj[item.id] = getSegmentComponentInfo(group, item.id)
     return obj
   }, {})
 }
@@ -196,7 +196,7 @@ function getSegmentVariantInfo (type, variant) {
 
   // Assuming a segment has one "lane" component, a segment's elevation can be found using the id
   // of the first item in the "lane" component group.
-  const lane = getSegmentInfo('lanes', segmentLookup.lanes[0].id)
+  const lane = getSegmentComponentInfo('lanes', segmentLookup.lanes[0].id)
   variantInfo.elevation = lane.elevation
 
   return variantInfo

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -237,7 +237,7 @@ function getSegmentVariantInfo (type, variant) {
  * @returns {Object} segmentInfo
  */
 export function getSegmentInfo (type) {
-  const segmentInfo = SEGMENT_LOOKUP[type] && SEGMENT_LOOKUP[type]['segment-info']
+  const segmentInfo = SEGMENT_LOOKUP[type] && SEGMENT_LOOKUP[type].segmentInfo
   const segmentInfoKey = segmentInfo && segmentInfo.key
 
   if (segmentInfoKey) {

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -238,6 +238,11 @@ function verifyCorrectness (originalVariantInfo, newVariantInfo) {
  * @returns {object} variantInfo
  */
 export function testSegmentLookup (type, variant, segmentVariantInfo) {
+  // If segment lookup value not defined yet, return original variantInfo.
+  if (!getSegmentLookup(type, variant)) {
+    return segmentVariantInfo
+  }
+
   const newVariantInfo = getSegmentVariantInfo(type, variant)
 
   if (verifyCorrectness(segmentVariantInfo, newVariantInfo)) {

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -205,7 +205,7 @@ function getSegmentVariantInfo (type, variant) {
   // Assuming a segment has one "lane" component, a segment's elevation can be found using the id
   // of the first item in the "lane" component group.
   // 6) Set the segment's elevation level based on the "lane" component.
-  const lane = getSegmentComponentInfo(COMPONENT_GROUPS.LANES, segmentLookup.lanes[0].id)
+  const lane = getSegmentComponentInfo(COMPONENT_GROUPS.LANES, components.lanes[0].id)
   variantInfo.elevation = lane.elevation
 
   // 7) Get any additional segment info specific to the variant and any segment rules.
@@ -256,7 +256,6 @@ export function testSegmentLookup (type, variant, segmentVariantInfo) {
 
   const newVariantInfo = getSegmentVariantInfo(type, variant)
 
-  console.log(segmentVariantInfo, newVariantInfo)
   if (verifyCorrectness(segmentVariantInfo, newVariantInfo)) {
     return newVariantInfo
   } else {

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1,154 +1,159 @@
 {
   "scooter": {
-    "segmentInfo": {
-      "key": [
-        "vehicles",
-        "scooter"
-      ]
+    "name": "Electric scooter",
+    "nameKey": "scooter",
+    "owner": "BIKE",
+    "zIndex": 16,
+    "enableWithFlag": "SEGMENT_SCOOTERS",
+    "defaultWidth": 5,
+    "rules": {
+      "minWidth": 4
     },
-    "inbound|regular": {
-      "lanes": [
-        {
-          "id": "asphalt",
-          "variants": {
-            "color": "regular"
+    "details": {
+      "inbound|regular": {
+        "lanes": [
+          {
+            "id": "asphalt",
+            "variants": {
+              "color": "regular"
+            }
           }
-        }
-      ],
-      "markings": [
-        {
-          "id": "markings--straight-inbound-light"
-        }
-      ],
-      "objects": [],
-      "vehicles": [
-        {
-          "id": "scooter",
-          "variants": {
-            "direction": "inbound"
+        ],
+        "markings": [
+          {
+            "id": "markings--straight-inbound-light"
           }
-        }
-      ]
-    },
-    "outbound|regular": {
-      "lanes": [
-        {
-          "id": "asphalt",
-          "variants": {
-            "color": "regular"
+        ],
+        "objects": [],
+        "vehicles": [
+          {
+            "id": "scooter",
+            "variants": {
+              "direction": "inbound"
+            }
           }
-        }
-      ],
-      "markings": [
-        {
-          "id": "markings--straight-outbound-light"
-        }
-      ],
-      "objects": [],
-      "vehicles": [
-        {
-          "id": "scooter",
-          "variants": {
-            "direction": "outbound"
+        ]
+      },
+      "outbound|regular": {
+        "lanes": [
+          {
+            "id": "asphalt",
+            "variants": {
+              "color": "regular"
+            }
           }
-        }
-      ]
-    },
-    "inbound|green": {
-      "lanes": [
-        {
-          "id": "asphalt",
-          "variants": {
-            "color": "green"
+        ],
+        "markings": [
+          {
+            "id": "markings--straight-outbound-light"
           }
-        }
-      ],
-      "markings": [
-        {
-          "id": "markings--straight-inbound-light"
-        }
-      ],
-      "objects": [],
-      "vehicles": [
-        {
-          "id": "scooter",
-          "variants": {
-            "direction": "inbound"
+        ],
+        "objects": [],
+        "vehicles": [
+          {
+            "id": "scooter",
+            "variants": {
+              "direction": "outbound"
+            }
           }
-        }
-      ]
-    },
-    "outbound|green": {
-      "lanes": [
-        {
-          "id": "asphalt",
-          "variants": {
-            "color": "green"
+        ]
+      },
+      "inbound|green": {
+        "lanes": [
+          {
+            "id": "asphalt",
+            "variants": {
+              "color": "green"
+            }
           }
-        }
-      ],
-      "markings": [
-        {
-          "id": "markings--straight-outbound-light"
-        }
-      ],
-      "objects": [],
-      "vehicles": [
-        {
-          "id": "scooter",
-          "variants": {
-            "direction": "outbound"
+        ],
+        "markings": [
+          {
+            "id": "markings--straight-inbound-light"
           }
-        }
-      ]
-    },
-    "inbound|red": {
-      "lanes": [
-        {
-          "id": "asphalt",
-          "variants": {
-            "color": "red"
+        ],
+        "objects": [],
+        "vehicles": [
+          {
+            "id": "scooter",
+            "variants": {
+              "direction": "inbound"
+            }
           }
-        }
-      ],
-      "markings": [
-        {
-          "id": "markings--straight-inbound-light"
-        }
-      ],
-      "objects": [],
-      "vehicles": [
-        {
-          "id": "scooter",
-          "variants": {
-            "direction": "inbound"
+        ]
+      },
+      "outbound|green": {
+        "lanes": [
+          {
+            "id": "asphalt",
+            "variants": {
+              "color": "green"
+            }
           }
-        }
-      ]
-    },
-    "outbound|red": {
-      "lanes": [
-        {
-          "id": "asphalt",
-          "variants": {
-            "color": "red"
+        ],
+        "markings": [
+          {
+            "id": "markings--straight-outbound-light"
           }
-        }
-      ],
-      "markings": [
-        {
-          "id": "markings--straight-outbound-light"
-        }
-      ],
-      "objects": [],
-      "vehicles": [
-        {
-          "id": "scooter",
-          "variants": {
-            "direction": "outbound"
+        ],
+        "objects": [],
+        "vehicles": [
+          {
+            "id": "scooter",
+            "variants": {
+              "direction": "outbound"
+            }
           }
-        }
-      ]
+        ]
+      },
+      "inbound|red": {
+        "lanes": [
+          {
+            "id": "asphalt",
+            "variants": {
+              "color": "red"
+            }
+          }
+        ],
+        "markings": [
+          {
+            "id": "markings--straight-inbound-light"
+          }
+        ],
+        "objects": [],
+        "vehicles": [
+          {
+            "id": "scooter",
+            "variants": {
+              "direction": "inbound"
+            }
+          }
+        ]
+      },
+      "outbound|red": {
+        "lanes": [
+          {
+            "id": "asphalt",
+            "variants": {
+              "color": "red"
+            }
+          }
+        ],
+        "markings": [
+          {
+            "id": "markings--straight-outbound-light"
+          }
+        ],
+        "objects": [],
+        "vehicles": [
+          {
+            "id": "scooter",
+            "variants": {
+              "direction": "outbound"
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -11,148 +11,160 @@
     },
     "details": {
       "inbound|regular": {
-        "lanes": [
-          {
-            "id": "asphalt",
-            "variants": {
-              "color": "regular"
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
             }
-          }
-        ],
-        "markings": [
-          {
-            "id": "markings--straight-inbound-light"
-          }
-        ],
-        "objects": [],
-        "vehicles": [
-          {
-            "id": "scooter",
-            "variants": {
-              "direction": "inbound"
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
             }
-          }
-        ]
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
       },
       "outbound|regular": {
-        "lanes": [
-          {
-            "id": "asphalt",
-            "variants": {
-              "color": "regular"
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
             }
-          }
-        ],
-        "markings": [
-          {
-            "id": "markings--straight-outbound-light"
-          }
-        ],
-        "objects": [],
-        "vehicles": [
-          {
-            "id": "scooter",
-            "variants": {
-              "direction": "outbound"
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
             }
-          }
-        ]
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
       },
       "inbound|green": {
-        "lanes": [
-          {
-            "id": "asphalt",
-            "variants": {
-              "color": "green"
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
             }
-          }
-        ],
-        "markings": [
-          {
-            "id": "markings--straight-inbound-light"
-          }
-        ],
-        "objects": [],
-        "vehicles": [
-          {
-            "id": "scooter",
-            "variants": {
-              "direction": "inbound"
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
             }
-          }
-        ]
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
       },
       "outbound|green": {
-        "lanes": [
-          {
-            "id": "asphalt",
-            "variants": {
-              "color": "green"
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
             }
-          }
-        ],
-        "markings": [
-          {
-            "id": "markings--straight-outbound-light"
-          }
-        ],
-        "objects": [],
-        "vehicles": [
-          {
-            "id": "scooter",
-            "variants": {
-              "direction": "outbound"
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
             }
-          }
-        ]
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
       },
       "inbound|red": {
-        "lanes": [
-          {
-            "id": "asphalt",
-            "variants": {
-              "color": "red"
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
             }
-          }
-        ],
-        "markings": [
-          {
-            "id": "markings--straight-inbound-light"
-          }
-        ],
-        "objects": [],
-        "vehicles": [
-          {
-            "id": "scooter",
-            "variants": {
-              "direction": "inbound"
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
             }
-          }
-        ]
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
       },
       "outbound|red": {
-        "lanes": [
-          {
-            "id": "asphalt",
-            "variants": {
-              "color": "red"
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
             }
-          }
-        ],
-        "markings": [
-          {
-            "id": "markings--straight-outbound-light"
-          }
-        ],
-        "objects": [],
-        "vehicles": [
-          {
-            "id": "scooter",
-            "variants": {
-              "direction": "outbound"
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
             }
-          }
-        ]
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
       }
     }
   }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -167,5 +167,266 @@
         }
       }
     }
+  },
+  "flex-zone": {
+    "name": "Flex zone",
+    "nameKey": "flex-zone",
+    "owner": "FLEX",
+    "zIndex": 15,
+    "defaultWidth": 7,
+    "rules": {
+      "minWidth": 7,
+      "maxWidth": 10
+    },
+    "details": {
+      "taxi|inbound|left": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "taxi|inbound|right": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "taxi|outbound|left": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "taxi|outbound|right": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|inbound|left": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|inbound|right": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|outbound|left": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|outbound|right": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1,6 +1,6 @@
 {
   "scooter": {
-    "segment-info": {
+    "segmentInfo": {
       "key": [
         "vehicles",
         "scooter"

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1,5 +1,11 @@
 {
   "scooter": {
+    "segment-info": {
+      "key": [
+        "vehicles",
+        "scooter"
+      ]
+    },
     "inbound|regular": {
       "lanes": [
         {

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -218,9 +218,8 @@ export function drawSegmentContents (ctx, type, variantString, actualWidth, offs
   const variantInfo = getSegmentVariantInfo(type, variantString)
   const graphics = variantInfo.graphics
 
-  if (type === 'scooter') {
-    testSegmentLookup(type, variantString, variantInfo)
-  }
+  // Testing mapping segment to new segment data model.
+  testSegmentLookup(type, variantString, variantInfo)
 
   // TODO: refactor this variable
   const segmentWidth = actualWidth * TILE_SIZE


### PR DESCRIPTION
## Changes to `SEGMENT_LOOKUP`
- Information about the segment is no longer only found in the corresponding component in `SEGMENT_COMPONENTS`. Since information, such as `name`, `nameKey`, `owner`, `rules`, etc. may apply to a whole segment and not the individual components that make up the segment, the segment info can now be found in `SEGMENT_LOOKUP` under the segment's `type`. In order to distinguish that segment info from the variants, the `variants` along with their information are placed under the `details` key similar to how it was done in the old segment data model.
- A variant of a segment `type` may also contain information specific to that variant, such as `name`, `nameKey`, etc. The variant information can now be found under the `variantString` key in `SEGMENT_LOOKUP`. In order to separate the variant information from the mapping information to map the segment to its list of components (`lanes`, `vehicles`, `markings`, and `objects`), the components are now placed under the `components` key within the `variant` object. 

In order to provide an example on how these changes look like, this PR also includes the mapping of the segment `flex-zone` to the new segment data model.

## Changes to `SEGMENT_COMPONENTS`:
- Like previously mentioned, segment information no longer resides in the individual segment components. However, a segment component does have its own `name` and `nameKey` and any characteristics specific to that component instead of the "segment" it makes up (This is mostly applied to "vehicles" or "objects" as of now). For example, the "flex-zone" segment of variant "taxi|inbound|left" has a `nameKey` of "taxi-pick-up", but the "taxi" component itself has a `nameKey` of just "taxi" since it may be reused for a segment that is not a "Taxi loading zone".

## Misc. Changes:
- I've now defined an object called `COMPONENT_GROUPS` which just lists all the types of components we have as of now ("lanes", "vehicles", "markings", and "objects') inside `segment-dict.js`.
- A new function called `getSegmentInfo` inside `segment-dict.js` returns the top level segment information found in `SEGMENT_LOOKUP`.
- A new function called `applySegmentInfoOverridesAndRules` (may be subject to renaming) inside `segment-dict.js` updates the `variantInfo` for the specific segment to include any rules and any information specific to that variant. This allows us to remove the `getComponentGroupRules` function and the call to it inside the components loop.
- `testSegmentLookup` is no longer called under an `if` statement testing a particular segment `type` and/or `variant`. Instead it is always called when a segment is drawn but returns the original `variantInfo` if the segment `type` and `variant` does not exist in the `SEGMENT_LOOKUP` json yet. Also, console logs are now only made if the segment was incorrectly mapped to the new segment data model.

Working towards issue #1257 
