### PR TITLE
Mapped remaining segment types to new segment data model

### DIFF
--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -85,6 +85,16 @@
       "graphics": {
         "repeat": "markings--lane-horiz"
       }
+    },
+    "markings--sharrow-inbound": {
+      "graphics": {
+        "center": "markings--sharrow-inbound"
+      }
+    },
+    "markings--sharrow-outbound": {
+      "graphics": {
+        "center": "markings--sharrow-outbound"
+      }
     }
   },
   "objects": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -190,6 +190,11 @@
       "graphics": {
         "center": "markings--streetcar-track-02"
       }
+    },
+    "markings--stripes-diagonal": {
+      "graphics": {
+        "repeat": "markings--stripes-diagonal"
+      }
     }
   },
   "objects": {
@@ -469,11 +474,66 @@
     "planting-strip": {
       "name": "Planting strip",
       "nameKey": "planting-strip",
+      "owner": "NATURE",
+      "zIndex": 20,
+      "variants": {
+        "type": {
+          "grass": {
+            "graphics": {
+              "repeat": "plants--grass"
+            }
+          },
+          "bush": {
+            "graphics": {
+              "center": "plants--bush"
+            }
+          },
+          "flowers": {
+            "graphics": {
+              "center": "plants--flowers"
+            }
+          }
+        }
+      }
+    },
+    "planter-box": {
+      "name": "Planter box",
+      "nameKey": "planter-box",
+      "owner": "NATURE",
+      "zIndex": 20,
       "variants": {
         "type": {
           "default": {
             "graphics": {
-              "repeat": "plants--grass"
+              "center": "dividers--planter-box"
+            }
+          }
+        }
+      }
+    },
+    "bollard": {
+      "name": "Bollard",
+      "nameKey": "bollard",
+      "zIndex": 20,
+      "variants": {
+        "type": {
+          "default": {
+            "graphics": {
+              "center": "dividers--bollard"
+            }
+          }
+        }
+      }
+    },
+    "dome": {
+      "name": "Traffic exclusion dome",
+      "nameKey": "dome",
+      "zIndex": 20,
+      "variants": {
+        "type": {
+          "default": {
+            "graphics": {
+              "center": "dividers--dome"
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -95,6 +95,86 @@
       "graphics": {
         "center": "markings--sharrow-outbound"
       }
+    },
+    "markings--left-inbound": {
+      "graphics": {
+        "center": "markings--left-inbound"
+      }
+    },
+    "markings--left-straight-inbound": {
+      "graphics": {
+        "center": "markings--left-straight-inbound"
+      }
+    },
+    "markings--straight-inbound": {
+      "graphics": {
+        "center": "markings--straight-inbound"
+      }
+    },
+    "markings--right-straight-inbound": {
+      "graphics": {
+        "center": "markings--right-straight-inbound"
+      }
+    },
+    "markings--right-inbound": {
+      "graphics": {
+        "center": "markings--right-inbound"
+      }
+    },
+    "markings--both-inbound": {
+      "graphics": {
+        "center": "markings--both-inbound"
+      }
+    },
+    "markings--shared-inbound": {
+      "graphics": {
+        "center": "markings--shared-inbound"
+      }
+    },
+    "markings--center-lane-left": {
+      "graphics": {
+        "left": "markings--center-lane-left"
+      }
+    },
+    "markings--center-lane-right": {
+      "graphics": {
+        "right": "markings--center-lane-right"
+      }
+    },
+    "markings--left-outbound": {
+      "graphics": {
+        "center": "markings--left-outbound"
+      }
+    },
+    "markings--left-straight-outbound": {
+      "graphics": {
+        "center": "markings--left-straight-outbound"
+      }
+    },
+    "markings--straight-outbound": {
+      "graphics": {
+        "center": "markings--straight-outbound"
+      }
+    },
+    "markings--right-straight-outbound": {
+      "graphics": {
+        "center": "markings--right-straight-outbound"
+      }
+    },
+    "markings--right-outbound": {
+      "graphics": {
+        "center": "markings--right-outbound"
+      }
+    },
+    "markings--both-outbound": {
+      "graphics": {
+        "center": "markings--both-outbound"
+      }
+    },
+    "markings--shared-outbound": {
+      "graphics": {
+        "center": "markings--shared-outbound"
+      }
     }
   },
   "objects": {
@@ -341,6 +421,32 @@
           "outbound": {
             "graphics": {
               "center": "vehicles--car-outbound"
+            }
+          }
+        },
+        "direction|turn-orientation": {
+          "inbound": {
+            "right": {
+              "graphics": {
+                "center": "vehicles--car-inbound-turn-signal-right"
+              }
+            },
+            "left": {
+              "graphics": {
+                "center": "vehicles--car-inbound-turn-signal-left"
+              }
+            }
+          },
+          "outbound": {
+            "right": {
+              "graphics": {
+                "center": "vehicles--car-outbound-turn-signal-right"
+              }
+            },
+            "left": {
+              "graphics": {
+                "center": "vehicles--car-outbound-turn-signal-left"
+              }
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -301,6 +301,26 @@
           }
         }
       }
+    },
+    "car": {
+      "name": "Car",
+      "nameKey": "car",
+      "owner": "CAR",
+      "zIndex": 14,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "vehicles--car-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "vehicles--car-outbound"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -126,6 +126,26 @@
           }
         }
       }
+    },
+    "utility-pole": {
+      "name": "Utility pole",
+      "nameKey": "utility-pole",
+      "owner": "NONE",
+      "zIndex": 10,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "center": "utilities--utility-pole-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "center": "utilities--utility-pole-right"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -288,15 +288,29 @@
       "owner": "BIKE",
       "zIndex": 16,
       "variants": {
-        "direction": {
-          "inbound": {
-            "graphics": {
-              "center": "bikes--biker-01-inbound"
+        "type|direction": {
+          "biker-01": {
+            "inbound": {
+              "graphics": {
+                "center": "bikes--biker-01-inbound"
+              }
+            },
+            "outbound": {
+              "graphics": {
+                "center": "bikes--biker-01-outbound"
+              }
             }
           },
-          "outbound": {
-            "graphics": {
-              "center": "bikes--biker-01-outbound"
+          "biker-02": {
+            "inbound": {
+              "graphics": {
+                "center": "bikes--biker-02-inbound"
+              }
+            },
+            "outbound": {
+              "graphics": {
+                "center": "bikes--biker-02-outbound"
+              }
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -471,6 +471,26 @@
           }
         }
       }
+    },
+    "food-truck": {
+      "name": "Food truck",
+      "nameKey": "foodtruck",
+      "owner": "FLEX",
+      "zIndex": 20,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "center": "vehicles--foodtruck-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "center": "vehicles--foodtruck-right"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -246,6 +246,21 @@
           }
         }
       }
+    },
+    "train": {
+      "name": "“Inception” train",
+      "nameKey": "inception-train",
+      "owner": "TRANSIT",
+      "zIndex": 10,
+      "variants": {
+        "type": {
+          "default": {
+            "graphics": {
+              "center": "secret--inception-train"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -87,7 +87,47 @@
       }
     }
   },
-  "objects": {},
+  "objects": {
+    "pickup-sign": {
+      "name": "Pickup sign",
+      "nameKey": "pickup-sign",
+      "owner": "FLEX",
+      "zIndex": 30,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "right": "curb--pickup-sign-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "left": "curb--pickup-sign-right"
+            }
+          }
+        }
+      }
+    },
+    "person-waiting": {
+      "name": "Person waiting",
+      "nameKey": "person-waiting",
+      "zIndex": 30,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "center": "curb--person-waiting-01-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "center": "curb--person-waiting-01-right"
+            }
+          }
+        }
+      }
+    }
+  },
   "vehicles": {
     "scooter": {
       "name": "Electric scooter",

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -207,6 +207,16 @@
       "graphics": {
         "repeat": "markings--stripes-diagonal"
       }
+    },
+    "markings--parking-left": {
+      "graphics": {
+        "right": "markings--parking-left"
+      }
+    },
+    "markings--parking-right": {
+      "graphics": {
+        "left": "markings--parking-right"
+      }
     }
   },
   "objects": {
@@ -794,6 +804,92 @@
             "left": {
               "graphics": {
                 "center": "vehicles--car-outbound-turn-signal-left"
+              }
+            }
+          }
+        },
+        "direction|orientation": {
+          "inbound": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-inbound"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-inbound"
+              }
+            }
+          },
+          "outbound": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-outbound"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-outbound"
+              }
+            }
+          },
+          "sideways": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-sideways-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-sideways-right"
+              }
+            }
+          },
+          "angled-front-left": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-angled-front-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-angled-front-left"
+              }
+            }
+          },
+          "angled-front-right": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-angled-front-right"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-angled-front-right"
+              }
+            }
+          },
+          "angled-rear-left": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-angled-rear-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-angled-rear-left"
+              }
+            }
+          },
+          "angled-rear-right": {
+            "left": {
+              "graphics": {
+                "left": "vehicles--car-angled-rear-right"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "vehicles--car-angled-rear-right"
               }
             }
           }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -53,6 +53,18 @@
           }
         }
       }
+    },
+    "raised-sidewalk": {
+      "elevation": 2,
+      "variants": {
+        "type": {
+          "default": {
+            "graphics": {
+              "repeat": "ground--concrete-raised"
+            }
+          }
+        }
+      }
     }
   },
   "markings": {
@@ -534,6 +546,40 @@
           "default": {
             "graphics": {
               "center": "dividers--dome"
+            }
+          }
+        }
+      }
+    },
+    "transit-shelter": {
+      "name": "Transit shelter",
+      "nameKey": "transit-shelter",
+      "owner": "TRANSIT",
+      "zIndex": 20,
+      "variants": {
+        "type|orientation": {
+          "transit-shelter-01": {
+            "left": {
+              "graphics": {
+                "left": "transit--transit-shelter-01-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "transit--transit-shelter-01-right"
+              }
+            }
+          },
+          "transit-shelter-02": {
+            "left": {
+              "graphics": {
+                "left": "transit--transit-shelter-02-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "transit--transit-shelter-02-right"
+              }
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -281,6 +281,26 @@
           }
         }
       }
+    },
+    "bike": {
+      "name": "Bike",
+      "nameKey": "bike",
+      "owner": "BIKE",
+      "zIndex": 16,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "bikes--biker-01-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "bikes--biker-01-outbound"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -879,6 +879,26 @@
           }
         }
       }
+    },
+    "bus": {
+      "name": "Bus",
+      "nameKey": "bus",
+      "owner": "TRANSIT",
+      "zIndex": 15,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "transit--bus-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "transit--bus-outbound"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -290,6 +290,31 @@
           }
         }
       }
+    },
+    "bench": {
+      "name": "Bench",
+      "nameKey": "bench",
+      "owner": "PEDESTRIAN",
+      "zIndex": 24,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "left": "furniture--bench-left"
+            }
+          },
+          "center": {
+            "graphics": {
+              "center": "furniture--bench-center"
+            }
+          },
+          "right": {
+            "graphics": {
+              "right": "furniture--bench-right"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -175,6 +175,16 @@
       "graphics": {
         "center": "markings--shared-outbound"
       }
+    },
+    "markings--streetcar-track-01": {
+      "graphics": {
+        "center": "markings--streetcar-track-01"
+      }
+    },
+    "markings--streetcar-track-02": {
+      "graphics": {
+        "center": "markings--streetcar-track-02"
+      }
     }
   },
   "objects": {
@@ -450,6 +460,19 @@
           }
         }
       }
+    },
+    "grass": {
+      "name": "Grass",
+      "nameKey": "grass",
+      "variants": {
+        "type": {
+          "default": {
+            "graphics": {
+              "repeat": "plants--grass"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {
@@ -701,6 +724,26 @@
           "right": {
             "graphics": {
               "center": "vehicles--foodtruck-right"
+            }
+          }
+        }
+      }
+    },
+    "streetcar": {
+      "name": "Streetcar",
+      "nameKey": "streetcar",
+      "owner": "TRANSIT",
+      "zIndex": 15,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "transit--streetcar-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "transit--streetcar-outbound"
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -466,9 +466,9 @@
         }
       }
     },
-    "grass": {
-      "name": "Grass",
-      "nameKey": "grass",
+    "planting-strip": {
+      "name": "Planting strip",
+      "nameKey": "planting-strip",
       "variants": {
         "type": {
           "default": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -256,6 +256,40 @@
           }
         }
       }
+    },
+    "bike-rack": {
+      "name": "Bike rack",
+      "nameKey": "bike-rack",
+      "owner": "BIKE",
+      "zIndex": 23,
+      "variants": {
+        "direction|orientation": {
+          "parallel": {
+            "left": {
+              "graphics": {
+                "left": "bikes--bike-rack-parallel-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "bikes--bike-rack-parallel-right"
+              }
+            }
+          },
+          "perpendicular": {
+            "left": {
+              "graphics": {
+                "left": "bikes--bike-rack-perpendicular-left"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "bikes--bike-rack-perpendicular-right"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -236,6 +236,26 @@
           }
         }
       }
+    },
+    "tree": {
+      "name": "Tree",
+      "nameKey": "tree",
+      "owner": "NATURE",
+      "zIndex": 22,
+      "variants": {
+        "type": {
+          "big": {
+            "graphics": {
+              "center": "trees--tree"
+            }
+          },
+          "palm-tree": {
+            "graphics": {
+              "center": "trees--palm-tree"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -430,6 +430,26 @@
           }
         }
       }
+    },
+    "bikeshare": {
+      "name": "Bikeshare station",
+      "nameKey": "bikeshare-station",
+      "owner": "FLEX",
+      "zIndex": 21,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "left": "bikes--bikeshare-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "right": "bikes--bikeshare-right"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -345,6 +345,26 @@
           }
         }
       }
+    },
+    "truck": {
+      "name": "Truck",
+      "nameKey": "truck",
+      "owner": "CAR",
+      "zIndex": 14,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "vehicles--truck-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "vehicles--truck-outbound"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -70,6 +70,21 @@
       "graphics": {
         "center": "markings--straight-outbound-light"
       }
+    },
+    "markings--lane-left-half": {
+      "graphics": {
+        "left": "markings--lane-left-half"
+      }
+    },
+    "markings--lane-right-half": {
+      "graphics": {
+        "right": "markings--lane-right-half"
+      }
+    },
+    "markings--lane-horiz": {
+      "graphics": {
+        "repeat": "markings--lane-horiz"
+      }
     }
   },
   "objects": {},
@@ -93,6 +108,32 @@
               "center": [
                 "scooters--scooter-outbound"
               ]
+            }
+          }
+        },
+        "riders|orientation": {
+          "empty": {
+            "left": {
+              "graphics": {
+                "left": "scooters--scooter-left-docked"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "scooters--scooter-right-docked"
+              }
+            }
+          },
+          "sparse": {
+            "left": {
+              "graphics": {
+                "left": "scooters--scooter-left-rider"
+              }
+            },
+            "right": {
+              "graphics": {
+                "right": "scooters--scooter-right-rider"
+              }
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -410,6 +410,26 @@
           }
         }
       }
+    },
+    "parklet": {
+      "name": "Parklet",
+      "nameKey": "parklet",
+      "owner": "NATURE",
+      "zIndex": 15,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "left": "parklet--yerba-buena-parklet-left-v02"
+            }
+          },
+          "right": {
+            "graphics": {
+              "right": "parklet--yerba-buena-parklet-right-v02"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -315,6 +315,31 @@
           }
         }
       }
+    },
+    "wayfinding-sign": {
+      "name": "Wayfinding sign",
+      "nameKey": "wayfinding-sign",
+      "owner": "PEDESTRIAN",
+      "zIndex": 21,
+      "variants": {
+        "type": {
+          "small": {
+            "graphics": {
+              "center": "wayfinding--nyc-wayfinding-pylon-small"
+            }
+          },
+          "medium": {
+            "graphics": {
+              "center": "wayfinding--nyc-wayfinding-pylon-medium"
+            }
+          },
+          "large": {
+            "graphics": {
+              "center": "wayfinding--nyc-wayfinding-pylon-large"
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -18,6 +18,11 @@
             "graphics": {
               "repeat": "ground--asphalt-green"
             }
+          },
+          "gray": {
+            "graphics": {
+              "repeat": "ground--asphalt-gray"
+            }
           }
         }
       }
@@ -744,6 +749,26 @@
           "outbound": {
             "graphics": {
               "center": "transit--streetcar-outbound"
+            }
+          }
+        }
+      }
+    },
+    "light-rail": {
+      "name": "Light rail",
+      "nameKey": "light-rail",
+      "owner": "TRANSIT",
+      "zIndex": 15,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "transit--light-rail-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "transit--light-rail-outbound"
             }
           }
         }

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -340,6 +340,76 @@
           }
         }
       }
+    },
+    "lamp": {
+      "name": "Lamp",
+      "nameKey": "lamp",
+      "owner": "PEDESTRIAN",
+      "zIndex": 19,
+      "variants": {
+        "type|orientation": {
+          "modern": {
+            "right": {
+              "graphics": {
+                "right": "lamps--lamp-modern-right"
+              }
+            },
+            "left": {
+              "graphics": {
+                "left": "lamps--lamp-modern-left"
+              }
+            },
+            "both": {
+              "graphics": {
+                "center": "lamps--lamp-modern-both"
+              }
+            }
+          },
+          "traditional": {
+            "right": {
+              "graphics": {
+                "right": "lamps--lamp-traditional-right"
+              }
+            },
+            "left": {
+              "graphics": {
+                "left": "lamps--lamp-traditional-left"
+              }
+            },
+            "both": {
+              "graphics": {
+                "center": "lamps--lamp-traditional-center"
+              }
+            }
+          }
+        }
+      }
+    },
+    "pride-banner": {
+      "name": "Pride banner",
+      "nameKey": "pride-banner",
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "left": "lamps--pride-banner-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "right": "lamps--pride-banner-right"
+            }
+          },
+          "both": {
+            "graphics": {
+              "center": {
+                "id": "lamps--pride-banner-left",
+                "offsetX": 36
+              }
+            }
+          }
+        }
+      }
     }
   },
   "vehicles": {

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -1,7 +1,7 @@
 import SEGMENT_COMPONENTS from './components.json'
 import SEGMENT_LOOKUP from './segment-lookup.json'
 import { SEGMENT_UNKNOWN, SEGMENT_UNKNOWN_VARIANT } from './info'
-import { uniq } from 'lodash'
+import { uniq, difference, isEqualWith } from 'lodash'
 
 const COMPONENT_GROUPS = {
   LANES: 'lanes',
@@ -64,7 +64,7 @@ function getComponentGroupVariants (groupItems, componentGroupInfo) {
     // groupItemVariants - all variants possible for the particular group item
     const groupItemVariants = componentGroupInfo[id] && componentGroupInfo[id].variants
 
-    if (groupItemVariants) {
+    if (groupItemVariants && variants) {
       Object.entries(variants).forEach(([variantName, variantKey]) => {
         // variantInfo - graphics definition for specific variants defined by group item
         let variantInfo = groupItemVariants[variantName] || SEGMENT_UNKNOWN_VARIANT
@@ -225,18 +225,13 @@ function getSegmentVariantInfo (type, variant) {
  * @returns {boolean} correct
  */
 function verifyCorrectness (originalVariantInfo, newVariantInfo) {
-  const filteredKeys = Object.keys(originalVariantInfo).filter((key) => {
-    return (key === 'graphics') ? !newVariantInfo.graphics : originalVariantInfo[key] !== newVariantInfo[key]
-  })
+  const checkArrayEquality = (origValue, testValue) => {
+    if (Array.isArray(origValue) && Array.isArray(testValue)) {
+      return !difference(origValue, testValue).length
+    }
+  }
 
-  const filteredGraphics = Object.entries(originalVariantInfo.graphics).filter((item) => {
-    const [ key, value ] = item
-    const originalGraphics = Array.isArray(value) ? value.sort() : value
-    const newGraphics = Array.isArray(newVariantInfo.graphics[key]) ? newVariantInfo.graphics[key].sort() : newVariantInfo.graphics[key]
-    return !(JSON.stringify(originalGraphics) === JSON.stringify(newGraphics))
-  })
-
-  return (filteredKeys.length === 0 && filteredGraphics.length === 0)
+  return isEqualWith(originalVariantInfo, newVariantInfo, checkArrayEquality)
 }
 
 /**

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -1,7 +1,7 @@
 import SEGMENT_COMPONENTS from './components.json'
 import SEGMENT_LOOKUP from './segment-lookup.json'
 import { SEGMENT_UNKNOWN, SEGMENT_UNKNOWN_VARIANT } from './info'
-import { uniq, difference, isEqualWith } from 'lodash'
+import { uniq, differenceWith, isEqual, isEqualWith } from 'lodash'
 
 const COMPONENT_GROUPS = {
   LANES: 'lanes',
@@ -229,7 +229,7 @@ function getSegmentVariantInfo (type, variant) {
 function verifyCorrectness (originalVariantInfo, newVariantInfo) {
   const checkArrayEquality = (origValue, testValue) => {
     if (Array.isArray(origValue) && Array.isArray(testValue)) {
-      return !difference(origValue, testValue).length
+      return !differenceWith(origValue, testValue, isEqual).length
     }
   }
 

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -107,16 +107,18 @@ function appendVariantSprites (target, source) {
  */
 function mergeVariantGraphics (variantGraphics) {
   return variantGraphics.reduce((graphics, variantInfo) => {
-    Object.keys(variantInfo).forEach((key) => {
-      const target = graphics[key]
-      const source = variantInfo[key]
+    if (variantInfo) {
+      Object.keys(variantInfo).forEach((key) => {
+        const target = graphics[key]
+        const source = variantInfo[key]
 
-      if (target) {
-        graphics[key] = appendVariantSprites(target, source)
-      } else {
-        graphics[key] = source
-      }
-    })
+        if (target) {
+          graphics[key] = appendVariantSprites(target, source)
+        } else {
+          graphics[key] = source
+        }
+      })
+    }
 
     return graphics
   }, {})

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1852,5 +1852,153 @@
         }
       }
     }
+  },
+  "sidewalk-bike-rack": {
+    "name": "Bike rack",
+    "nameKey": "bike-rack",
+    "owner": "BIKE",
+    "zIndex": 23,
+    "defaultWidth": 5,
+    "paletteIcon": "left|sidewalk",
+    "details": {
+      "left|sidewalk-parallel": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bike-rack",
+              "variants": {
+                "direction|orientation": [
+                  "parallel",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|sidewalk-parallel": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bike-rack",
+              "variants": {
+                "direction|orientation": [
+                  "parallel",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|sidewalk": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bike-rack",
+              "variants": {
+                "direction|orientation": [
+                  "perpendicular",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|sidewalk": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bike-rack",
+              "variants": {
+                "direction|orientation": [
+                  "perpendicular",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|road": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bike-rack",
+              "variants": {
+                "direction|orientation": [
+                  "perpendicular",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|road": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bike-rack",
+              "variants": {
+                "direction|orientation": [
+                  "perpendicular",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2646,7 +2646,7 @@
           ],
           "objects": [
             {
-              "id": "grass",
+              "id": "planting-strip",
               "variants": {
                 "type": "default"
               }
@@ -2682,7 +2682,7 @@
           ],
           "objects": [
             {
-              "id": "grass",
+              "id": "planting-strip",
               "variants": {
                 "type": "default"
               }
@@ -2835,7 +2835,7 @@
           ],
           "objects": [
             {
-              "id": "grass",
+              "id": "planting-strip",
               "variants": {
                 "type": "default"
               }
@@ -2871,7 +2871,7 @@
           ],
           "objects": [
             {
-              "id": "grass",
+              "id": "planting-strip",
               "variants": {
                 "type": "default"
               }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2648,7 +2648,7 @@
             {
               "id": "planting-strip",
               "variants": {
-                "type": "default"
+                "type": "grass"
               }
             }
           ],
@@ -2684,7 +2684,7 @@
             {
               "id": "planting-strip",
               "variants": {
-                "type": "default"
+                "type": "grass"
               }
             }
           ],
@@ -2837,7 +2837,7 @@
             {
               "id": "planting-strip",
               "variants": {
-                "type": "default"
+                "type": "grass"
               }
             }
           ],
@@ -2873,7 +2873,7 @@
             {
               "id": "planting-strip",
               "variants": {
-                "type": "default"
+                "type": "grass"
               }
             }
           ],

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1109,5 +1109,70 @@
         }
       }
     }
+  },
+  "drive-lane": {
+    "name": "Drive lane",
+    "nameKey": "drive-lane",
+    "owner": "CAR",
+    "zIndex": 14,
+    "defaultWidth": 10,
+    "rules": {
+      "minWidth": 8,
+      "maxWidth": 11.9
+    },
+    "details": {
+      "inbound|car": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|car": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -956,7 +956,10 @@
             {
               "id": "bike",
               "variants": {
-                "direction": "inbound"
+                "type|direction": [
+                  "biker-01",
+                  "inbound"
+                ]
               }
             }
           ]
@@ -982,7 +985,10 @@
             {
               "id": "bike",
               "variants": {
-                "direction": "outbound"
+                "type|direction": [
+                  "biker-01",
+                  "outbound"
+                ]
               }
             }
           ]
@@ -1012,7 +1018,10 @@
             {
               "id": "bike",
               "variants": {
-                "direction": "inbound"
+                "type|direction": [
+                  "biker-01",
+                  "inbound"
+                ]
               }
             }
           ]
@@ -1042,7 +1051,10 @@
             {
               "id": "bike",
               "variants": {
-                "direction": "outbound"
+                "type|direction": [
+                  "biker-01",
+                  "outbound"
+                ]
               }
             }
           ]
@@ -1072,7 +1084,10 @@
             {
               "id": "bike",
               "variants": {
-                "direction": "inbound"
+                "type|direction": [
+                  "biker-01",
+                  "inbound"
+                ]
               }
             }
           ]
@@ -1102,7 +1117,10 @@
             {
               "id": "bike",
               "variants": {
-                "direction": "outbound"
+                "type|direction": [
+                  "biker-01",
+                  "outbound"
+                ]
               }
             }
           ]

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2000,5 +2000,74 @@
         }
       }
     }
+  },
+  "sidewalk-bench": {
+    "name": "Bench",
+    "nameKey": "bench",
+    "owner": "PEDESTRIAN",
+    "zIndex": 24,
+    "defaultWidth": 4,
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bench",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "center": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bench",
+              "variants": {
+                "orientation": "center"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "bench",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -719,5 +719,114 @@
         }
       }
     }
+  },
+  "flex-zone-curb": {
+    "name": "Waiting area",
+    "nameKey": "flex-zone-curb",
+    "owner": "FLEX",
+    "zIndex": 30,
+    "defaultWidth": 4,
+    "details": {
+      "sparse|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "right"
+              }
+            },
+            {
+              "id": "person-waiting",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      },
+      "sparse|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "left"
+              }
+            },
+            {
+              "id": "person-waiting",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      },
+      "empty|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      },
+      "empty|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2433,5 +2433,74 @@
         }
       }
     }
+  },
+  "bikeshare": {
+    "name": "Bikeshare station",
+    "nameKey": "bikeshare-station",
+    "owner": "FLEX",
+    "zIndex": 21,
+    "defaultWidth": 7,
+    "rules": {
+      "minWidth": 7,
+      "maxWidth": 10
+    },
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [
+            {
+              "id": "bikeshare",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [
+            {
+              "id": "bikeshare",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2377,5 +2377,61 @@
         }
       }
     }
+  },
+  "parklet": {
+    "name": "Parklet",
+    "nameKey": "parklet",
+    "owner": "NATURE",
+    "zIndex": 15,
+    "defaultWidth": 8,
+    "description": {
+      "key": "parklet",
+      "image": "parklets-01.jpg"
+    },
+    "rules": {
+      "minWidth": 8
+    },
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "parklet",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "parklet",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1754,5 +1754,61 @@
         }
       }
     }
+  },
+  "food-truck": {
+    "name": "Food truck",
+    "nameKey": "foodtruck",
+    "owner": "FLEX",
+    "zIndex": 20,
+    "defaultWidth": 10,
+    "rules": {
+      "minWidth": 10
+    },
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "food-truck",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "food-truck",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1883,5 +1883,58 @@
         }
       }
     }
+  },
+  "sidewalk-tree": {
+    "name": "Sidewalk tree",
+    "nameKey": "sidewalk-tree",
+    "owner": "NATURE",
+    "zIndex": 22,
+    "defaultWidth": 4,
+    "details": {
+      "big": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "tree",
+              "variants": {
+                "type": "big"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      },
+      "palm-tree": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "tree",
+              "variants": {
+                "type": "palm-tree"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -25,7 +25,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -51,7 +50,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -77,7 +75,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -103,7 +100,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -129,7 +125,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -155,7 +150,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -198,7 +192,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -233,7 +226,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -268,7 +260,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -303,7 +294,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -338,7 +328,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -373,7 +362,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -408,7 +396,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -443,7 +430,6 @@
               "id": "markings--lane-horiz"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "scooter",
@@ -487,7 +473,6 @@
               "id": "markings--lane-right"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "taxi",
@@ -518,7 +503,6 @@
               "id": "markings--lane-left"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "taxi",
@@ -549,7 +533,6 @@
               "id": "markings--lane-right"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "taxi",
@@ -580,7 +563,6 @@
               "id": "markings--lane-left"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "taxi",
@@ -611,7 +593,6 @@
               "id": "markings--lane-right"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "rideshare",
@@ -642,7 +623,6 @@
               "id": "markings--lane-left"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "rideshare",
@@ -673,7 +653,6 @@
               "id": "markings--lane-right"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "rideshare",
@@ -704,7 +683,6 @@
               "id": "markings--lane-left"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "rideshare",
@@ -737,7 +715,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "pickup-sign",
@@ -751,8 +728,7 @@
                 "orientation": "right"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       },
       "sparse|right": {
@@ -765,7 +741,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "pickup-sign",
@@ -779,8 +754,7 @@
                 "orientation": "left"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       },
       "empty|left": {
@@ -793,7 +767,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "pickup-sign",
@@ -801,8 +774,7 @@
                 "orientation": "right"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       },
       "empty|right": {
@@ -815,7 +787,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "pickup-sign",
@@ -823,8 +794,7 @@
                 "orientation": "left"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       }
     }
@@ -854,8 +824,6 @@
               }
             }
           ],
-          "markings": [],
-          "objects": [],
           "vehicles": [
             {
               "id": "train",
@@ -886,7 +854,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "utility-pole",
@@ -894,8 +861,7 @@
                 "orientation": "left"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       },
       "right": {
@@ -908,7 +874,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "utility-pole",
@@ -916,8 +881,7 @@
                 "orientation": "right"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       }
     }
@@ -951,7 +915,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "bike",
@@ -980,7 +943,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "bike",
@@ -1013,7 +975,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "bike",
@@ -1046,7 +1007,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "bike",
@@ -1079,7 +1039,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "bike",
@@ -1112,7 +1071,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "bike",
@@ -1154,7 +1112,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1180,7 +1137,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1217,7 +1173,6 @@
               "id": "markings--sharrow-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1263,7 +1218,6 @@
               "id": "markings--sharrow-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1298,7 +1252,6 @@
               "id": "markings--straight-inbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "truck",
@@ -1324,7 +1277,6 @@
               "id": "markings--straight-outbound-light"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "truck",
@@ -1363,7 +1315,6 @@
               "id": "markings--left-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1392,7 +1343,6 @@
               "id": "markings--left-straight-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1423,7 +1373,6 @@
               "id": "markings--straight-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1449,7 +1398,6 @@
               "id": "markings--right-straight-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1478,7 +1426,6 @@
               "id": "markings--right-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1507,7 +1454,6 @@
               "id": "markings--both-inbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1543,9 +1489,7 @@
             {
               "id": "markings--center-lane-right"
             }
-          ],
-          "objects": [],
-          "vehicles": []
+          ]
         }
       },
       "outbound|left": {
@@ -1563,7 +1507,6 @@
               "id": "markings--left-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1592,7 +1535,6 @@
               "id": "markings--left-straight-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1623,7 +1565,6 @@
               "id": "markings--straight-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1649,7 +1590,6 @@
               "id": "markings--right-straight-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1678,7 +1618,6 @@
               "id": "markings--right-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1707,7 +1646,6 @@
               "id": "markings--both-outbound"
             }
           ],
-          "objects": [],
           "vehicles": [
             {
               "id": "car",
@@ -1748,9 +1686,7 @@
             {
               "id": "markings--center-lane-right"
             }
-          ],
-          "objects": [],
-          "vehicles": []
+          ]
         }
       }
     }
@@ -1775,8 +1711,6 @@
               }
             }
           ],
-          "markings": [],
-          "objects": [],
           "vehicles": [
             {
               "id": "food-truck",
@@ -1797,8 +1731,6 @@
               }
             }
           ],
-          "markings": [],
-          "objects": [],
           "vehicles": [
             {
               "id": "food-truck",
@@ -1831,10 +1763,7 @@
                 "density": "dense"
               }
             }
-          ],
-          "markings": [],
-          "objects": [],
-          "vehicles": []
+          ]
         }
       },
       "normal": {
@@ -1846,10 +1775,7 @@
                 "density": "normal"
               }
             }
-          ],
-          "markings": [],
-          "objects": [],
-          "vehicles": []
+          ]
         }
       },
       "sparse": {
@@ -1861,10 +1787,7 @@
                 "density": "sparse"
               }
             }
-          ],
-          "markings": [],
-          "objects": [],
-          "vehicles": []
+          ]
         }
       },
       "empty": {
@@ -1876,10 +1799,7 @@
                 "density": "empty"
               }
             }
-          ],
-          "markings": [],
-          "objects": [],
-          "vehicles": []
+          ]
         }
       }
     }
@@ -1901,7 +1821,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "tree",
@@ -1909,8 +1828,7 @@
                 "type": "big"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       },
       "palm-tree": {
@@ -1923,7 +1841,6 @@
               }
             }
           ],
-          "markings": [],
           "objects": [
             {
               "id": "tree",
@@ -1931,8 +1848,7 @@
                 "type": "palm-tree"
               }
             }
-          ],
-          "vehicles": []
+          ]
         }
       }
     }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2896,5 +2896,287 @@
         }
       }
     }
+  },
+  "divider": {
+    "name": "Buffer",
+    "nameKey": "divider",
+    "owner": "NATURE",
+    "zIndex": 20,
+    "defaultWidth": 2,
+    "paletteIcon": "planting-strip",
+    "details": {
+      "planting-strip": {
+        "name": "Planting strip",
+        "nameKey": "planting-strip",
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            }
+          ]
+        }
+      },
+      "planter-box": {
+        "name": "Planter box",
+        "nameKey": "planter-box",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--stripes-diagonal"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [
+            {
+              "id": "planter-box",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ]
+        }
+      },
+      "median": {
+        "name": "Median",
+        "nameKey": "median",
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ]
+        }
+      },
+      "striped-buffer": {
+        "name": "Buffer",
+        "nameKey": "divider",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--stripes-diagonal"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ]
+        }
+      },
+      "bush": {
+        "name": "Planting strip",
+        "nameKey": "planting-strip",
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            },
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "bush"
+              }
+            }
+          ]
+        }
+      },
+      "flowers": {
+        "name": "Planting strip",
+        "nameKey": "planting-strip",
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            },
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "flowers"
+              }
+            }
+          ]
+        }
+      },
+      "big-tree": {
+        "name": "Planting strip",
+        "nameKey": "planting-strip",
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            },
+            {
+              "id": "tree",
+              "variants": {
+                "type": "big"
+              }
+            }
+          ]
+        }
+      },
+      "palm-tree": {
+        "name": "Planting strip",
+        "nameKey": "planting-strip",
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            },
+            {
+              "id": "tree",
+              "variants": {
+                "type": "palm-tree"
+              }
+            }
+          ]
+        }
+      },
+      "bollard": {
+        "name": "Bollard",
+        "nameKey": "bollard",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--stripes-diagonal"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [
+            {
+              "id": "bollard",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ]
+        }
+      },
+      "dome": {
+        "name": "Traffic exclusion dome",
+        "nameKey": "dome",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--stripes-diagonal"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [
+            {
+              "id": "dome",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2142,5 +2142,240 @@
         }
       }
     }
+  },
+  "sidewalk-lamp": {
+    "name": "Lamp",
+    "nameKey": "sidewalk-lamp",
+    "owner": "PEDESTRIAN",
+    "zIndex": 19,
+    "defaultWidth": 4,
+    "paletteIcon": "both|traditional",
+    "details": {
+      "right|modern": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "modern",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "both|modern": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "modern",
+                  "both"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|modern": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "modern",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|traditional": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "traditional",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "both|traditional": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "traditional",
+                  "both"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|traditional": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "traditional",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|pride": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "modern",
+                  "right"
+                ]
+              }
+            },
+            {
+              "id": "pride-banner",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      },
+      "left|pride": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "modern",
+                  "left"
+                ]
+              }
+            },
+            {
+              "id": "pride-banner",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "both|pride": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "lamp",
+              "variants": {
+                "type|orientation": [
+                  "modern",
+                  "both"
+                ]
+              }
+            },
+            {
+              "id": "pride-banner",
+              "variants": {
+                "orientation": "both"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -921,5 +921,193 @@
         }
       }
     }
+  },
+  "bike-lane": {
+    "name": "Bike lane",
+    "nameKey": "bike-lane",
+    "owner": "BIKE",
+    "zIndex": 16,
+    "defaultWidth": 6,
+    "description": {
+      "key": "bike-lane",
+      "image": "bike-lane-02.jpg"
+    },
+    "rules": {
+      "minWidth": 5
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|green": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|green": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|red": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|red": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2502,5 +2502,202 @@
         }
       }
     }
+  },
+  "streetcar": {
+    "name": "Streetcar",
+    "nameKey": "streetcar",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 14
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-01"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-01"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [
+            {
+              "id": "grass",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [
+            {
+              "id": "grass",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -168,6 +168,297 @@
       }
     }
   },
+  "scooter-drop-zone": {
+    "name": "Scooter drop zone",
+    "nameKey": "scooter-drop-zone",
+    "owner": "FLEX",
+    "zIndex": 21,
+    "defaultWidth": 5,
+    "enableWithFlag": "SEGMENT_SCOOTERS",
+    "paletteIcon": "right|sidewalk|empty",
+    "details": {
+      "left|sidewalk|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|sidewalk|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|sidewalk|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|sidewalk|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|road|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|road|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|road|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|road|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
   "flex-zone": {
     "name": "Flex zone",
     "nameKey": "flex-zone",

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -828,5 +828,44 @@
         }
       }
     }
+  },
+  "train": {
+    "name": "“Inception” train",
+    "nameKey": "inception-train",
+    "owner": "TRANSIT",
+    "zIndex": 10,
+    "defaultWidth": 14,
+    "enableWithFlag": "SEGMENT_INCEPTION_TRAIN",
+    "description": {
+      "key": "inception-train",
+      "image": "train.jpg"
+    },
+    "rules": {
+      "minWidth": 14
+    },
+    "details": {
+      "": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "train",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -3178,5 +3178,124 @@
         }
       }
     }
+  },
+  "transit-shelter": {
+    "name": "Transit shelter",
+    "nameKey": "transit-shelter",
+    "owner": "TRANSIT",
+    "zIndex": 20,
+    "defaultWidth": 9,
+    "paletteIcon": "right|light-rail",
+    "rules": {
+      "minWidth": 9
+    },
+    "details": {
+      "left|street-level": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-01",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|street-level": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-01",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|light-rail": {
+        "description": {
+          "key": "transit-shelter-elevated",
+          "image": "transit-station-elevated.jpg"
+        },
+        "rules": {
+          "minWidth": 8
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "raised-sidewalk",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-02",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|light-rail": {
+        "description": {
+          "key": "transit-shelter-elevated",
+          "image": "transit-station-elevated.jpg"
+        },
+        "rules": {
+          "minWidth": 8
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "raised-sidewalk",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-02",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1282,6 +1282,58 @@
             }
           ]
         }
+      },
+      "inbound|truck": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "truck",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|truck": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "truck",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
       }
     }
   }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1336,5 +1336,423 @@
         }
       }
     }
+  },
+  "turn-lane": {
+    "name": "Turn lane",
+    "nameKey": "turn-lane",
+    "owner": "CAR",
+    "zIndex": 13,
+    "defaultWidth": 10,
+    "rules": {
+      "minWidth": 9,
+      "maxWidth": 12
+    },
+    "details": {
+      "inbound|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|left-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-straight-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|straight": {
+        "name": "No turn lane",
+        "nameKey": "turn-lane-straight",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|right-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-straight-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|both": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--both-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|shared": {
+        "name": "Center turn lane",
+        "nameKey": "turn-lane-center",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--shared-inbound"
+            },
+            {
+              "id": "markings--center-lane-left"
+            },
+            {
+              "id": "markings--center-lane-right"
+            }
+          ],
+          "objects": [],
+          "vehicles": []
+        }
+      },
+      "outbound|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|left-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-straight-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|straight": {
+        "name": "No turn lane",
+        "nameKey": "turn-lane-straight",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|right-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-straight-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|both": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--both-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|shared": {
+        "name": "Center turn lane",
+        "nameKey": "turn-lane-center",
+        "rules": {
+          "minWidth": 10,
+          "maxWidth": 16
+        },
+        "defaultWidth": 12,
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--shared-outbound"
+            },
+            {
+              "id": "markings--center-lane-left"
+            },
+            {
+              "id": "markings--center-lane-right"
+            }
+          ],
+          "objects": [],
+          "vehicles": []
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1810,5 +1810,78 @@
         }
       }
     }
+  },
+  "sidewalk": {
+    "name": "Sidewalk",
+    "nameKey": "sidewalk",
+    "owner": "PEDESTRIAN",
+    "zIndex": 30,
+    "defaultWidth": 6,
+    "needRandSeed": true,
+    "rules": {
+      "minWidth": 6
+    },
+    "details": {
+      "dense": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "dense"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": []
+        }
+      },
+      "normal": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "normal"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": []
+        }
+      },
+      "sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "sparse"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": []
+        }
+      },
+      "empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [],
+          "vehicles": []
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -867,5 +867,59 @@
         }
       }
     }
+  },
+  "utilities": {
+    "name": "Utility pole",
+    "nameKey": "utility-pole",
+    "owner": "NONE",
+    "zIndex": 10,
+    "defaultWidth": 4,
+    "enableWithFlag": "SEGMENT_UTILITIES",
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "utility-pole",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [],
+          "objects": [
+            {
+              "id": "utility-pole",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ],
+          "vehicles": []
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -3506,5 +3506,422 @@
         }
       }
     }
+  },
+  "parking-lane": {
+    "name": "Parking lane",
+    "nameKey": "parking-lane",
+    "owner": "CAR",
+    "zIndex": 13,
+    "defaultWidth": 7,
+    "rules": {
+      "minWidth": 7,
+      "maxWidth": 10
+    },
+    "details": {
+      "inbound|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--parking-left"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "offsetX": 6,
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--parking-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--parking-left"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "offsetX": 6,
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--parking-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "sideways|left": {
+        "name": "Perpendicular parking",
+        "nameKey": "perpendicular-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 20
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "sideways",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "sideways|right": {
+        "name": "Perpendicular parking",
+        "nameKey": "perpendicular-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 20
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "sideways",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-front-left|left": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-front-left",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-front-right|left": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-front-right",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-rear-left|left": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-rear-left",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-rear-right|left": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-rear-right",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-front-left|right": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-front-left",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-front-right|right": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-front-right",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-rear-left|right": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-rear-left",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "angled-rear-right|right": {
+        "name": "Angled parking",
+        "nameKey": "angled-parking",
+        "rules": {
+          "minWidth": 14,
+          "maxWidth": 18
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|orientation": [
+                  "angled-rear-right",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -3297,5 +3297,214 @@
         }
       }
     }
+  },
+  "bus-lane": {
+    "name": "Bus lane",
+    "nameKey": "bus-lane",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 13
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|shared": {
+        "name": "Shared bus/bike lane",
+        "nameKey": "bus-lane-shared",
+        "defaultWidth": 14,
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-inbound"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            },
+            {
+              "id": "bike",
+              "offsetX": 30,
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "inbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|shared": {
+        "name": "Shared bus/bike lane",
+        "nameKey": "bus-lane-shared",
+        "defaultWidth": 14,
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-outbound"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            },
+            {
+              "id": "bike",
+              "offsetX": -30,
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2699,5 +2699,202 @@
         }
       }
     }
+  },
+  "light-rail": {
+    "name": "Light rail",
+    "nameKey": "light-rail",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 14
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "gray"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "gray"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "grass",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "grass",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -2069,5 +2069,78 @@
         }
       }
     }
+  },
+  "sidewalk-wayfinding": {
+    "name": "Wayfinding sign",
+    "nameKey": "wayfinding-sign",
+    "owner": "PEDESTRIAN",
+    "zIndex": 21,
+    "defaultWidth": 4,
+    "description": {
+      "key": "wayfinding-sign",
+      "image": "wayfinding-02.jpg"
+    },
+    "details": {
+      "large": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "wayfinding-sign",
+              "variants": {
+                "type": "large"
+              }
+            }
+          ]
+        }
+      },
+      "medium": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "wayfinding-sign",
+              "variants": {
+                "type": "medium"
+              }
+            }
+          ]
+        }
+      },
+      "small": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "wayfinding-sign",
+              "variants": {
+                "type": "small"
+              }
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1190,6 +1190,98 @@
             }
           ]
         }
+      },
+      "inbound|sharrow": {
+        "name": "Sharrow",
+        "nameKey": "sharrow",
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "defaultWidth": 14,
+        "description": {
+          "key": "sharrow",
+          "image": "sharrow-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-inbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "inbound"
+              }
+            },
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "inbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|sharrow": {
+        "name": "Sharrow",
+        "nameKey": "sharrow",
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "defaultWidth": 14,
+        "description": {
+          "key": "sharrow",
+          "image": "sharrow-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-outbound"
+            }
+          ],
+          "objects": [],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "outbound"
+              }
+            },
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
       }
     }
   }


### PR DESCRIPTION
Currently no code actually uses the new segment data model. Instead, we are simply logging when the segment is mapped incorrectly. However, once this is reviewed, we should be able to replace the existing `getSegmentVariantInfo` from `info.js` with the one in `segment-dict.js`. 

Some updates/refactoring:
- `verifyCorrectness` now uses some helpful functions provided by [lodash](https://lodash.com/docs/4.17.11) to check if the original `variantInfo` differs from the test `variantInfo` using the new `getSegmentVariantInfo` function.
- Originally even if a segment was not made up of any "objects" components, "objects" was included in the lookup value with an empty array. Now, any empty component groups are removed from the lookup value.
- Offsets can now be applied to a specific segment component. `offsetY` was removed from the sprite definitions in a previous PR (#1271). However, `offsetX` appeared to not be based on the elevation or a specific component so I was unable to remove it. This led to the thought that perhaps we do want a way to apply a customized `offset` to a component for a specific segment. Now we can specify the `offsetX` or `offsetY` in a specific component of a specific segment and it will be applied in `getSegmentVariantInfo`. For an example of how that looks, the segment type "bus-lane" or variant string "inbound|shared" has a `offsetX` for its "bike" component and the offset is applied using the function `applyOffsetsIfAnyToSprites`.