### PR TITLE
User's flags property no longer `Map` schema type

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -12,7 +12,7 @@ const userSchema = new mongoose.Schema({
   created_at: Date,
   updated_at: Date,
   last_street_id: Number,
-  flags: { type: Map, of: Boolean },
+  flags: mongoose.Schema.Types.Mixed,
   roles: [ String ]
 })
 


### PR DESCRIPTION
When the `flags` property belonging to the `User` model was of type `Map`, updating the flags value by doing `targetUser.flags = body.flags || targetUser.flags` didn't actually work leading to user's flags not being updated correctly. This is because when using Mongoose `Map`, we need to use the `.set()` method to actually set an individual key ([as explained here](https://thecodebarbarian.com/whats-new-in-mongoose-5.1-map-support.html)) and from what I am able to tell there is no way to replace the entire `flags` property with a new Map value. 

The two choices were either to use a conditional and inside a `forEach` loop call `.set()` and `.delete()` when updating flags or to switch back to using `mongoose.Schema.Types.Mixed` instead. In this PR, I am switching back to using `mongoose.Schema.Types.Mixed` but if we prefer keeping the `flags` property to be of type `Map` I can do that too. 