### PR TITLE
Updating segment data model

### DIFF
--- a/assets/scripts/segments/__tests__/info.test.js
+++ b/assets/scripts/segments/__tests__/info.test.js
@@ -1,4 +1,6 @@
 /* eslint-env jest */
+import { differenceWith, isEqual, isEqualWith } from 'lodash'
+import SEGMENT_INFO from '../info.json'
 import module, {
   getSpriteDef,
   getAllSegmentInfo,
@@ -64,6 +66,15 @@ describe('segment info', () => {
       const segment = getSegmentInfo('foo')
       expect(segment.unknown).toBe(true)
     })
+
+    it('returns the same segment info as the old segment data model', () => {
+      const segment = getSegmentInfo('sidewalk')
+      expect(segment.unknown).toBeFalsy()
+
+      const { details, rules, ...segmentInfo } = segment
+      const { details: original, ...originalSegmentInfo } = SEGMENT_INFO['sidewalk']
+      expect(segmentInfo).toEqual(originalSegmentInfo)
+    })
   })
 
   describe('getSegmentVariantInfo()', () => {
@@ -80,6 +91,22 @@ describe('segment info', () => {
     it('returns placeholder data for an unknown segment type and variant', () => {
       const variant = getSegmentVariantInfo('foo', 'bar')
       expect(variant.unknown).toBe(true)
+    })
+
+    it('returns the same data as the old segment data model', () => {
+      const variant = getSegmentVariantInfo('turn-lane', 'inbound|straight')
+      expect(variant.unknown).toBeFalsy()
+
+      const original = SEGMENT_INFO['turn-lane'].details['inbound|straight']
+
+      const checkArrayEquality = (origValue, testValue) => {
+        if (Array.isArray(origValue) && Array.isArray(testValue)) {
+          return !differenceWith(origValue, testValue, isEqual).length
+        }
+      }
+
+      const correct = isEqualWith(original, variant, checkArrayEquality)
+      expect(correct).toEqual(true)
     })
   })
 })

--- a/assets/scripts/segments/__tests__/segment-dict.test.js
+++ b/assets/scripts/segments/__tests__/segment-dict.test.js
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+import SEGMENT_COMPONENTS from '../components.json'
+import {
+  getSegmentLookup,
+  getSegmentComponentInfo,
+  applySegmentInfoOverridesAndRules,
+  getSegmentSprites
+} from '../segment-dict'
+
+describe('getSegmentLookup()', () => {
+  it('returns component groups data for a segment type and variant', () => {
+    const segmentLookup = getSegmentLookup('sidewalk', 'normal')
+    expect(segmentLookup.components).toBeTruthy()
+    expect(segmentLookup.components.lanes).toBeTruthy()
+    expect(segmentLookup.components.lanes.length).toBeGreaterThan(0)
+    expect(segmentLookup.components.lanes[0].id).toEqual('sidewalk')
+  })
+
+  it('returns false for an unknown segment', () => {
+    const segmentLookup = getSegmentLookup('foo', 'bar')
+    expect(segmentLookup).toBeFalsy()
+  })
+})
+
+describe('getSegmentComponentInfo()', () => {
+  it('returns data for a segment component', () => {
+    const component = getSegmentComponentInfo('lanes', 'sidewalk')
+    expect(component.unknown).toBeFalsy()
+  })
+
+  it('returns placeholder data for an unknown segment component type', () => {
+    const component = getSegmentComponentInfo('lanes', 'foo')
+    expect(component.unknown).toBe(true)
+  })
+
+  it('returns placeholder data for an unknown component group and type', () => {
+    const component = getSegmentComponentInfo('foo', 'bar')
+    expect(component.unknown).toBe(true)
+  })
+})
+
+describe('applySegmentInfoOverridesAndRules()', () => {
+  it('returns rules and information for a segment type and variant', () => {
+    const segmentRules = { 'minWidth': 0, 'maxWidth': 2 }
+    const details = {
+      'name': 'Bar',
+      'nameKey': 'bar',
+      'rules': {
+        'minWidth': 1
+      }
+    }
+
+    const variantInfo = applySegmentInfoOverridesAndRules(details, segmentRules)
+    expect(variantInfo).toEqual({
+      'name': 'Bar',
+      'nameKey': 'bar',
+      'minWidth': 1,
+      'maxWidth': 2
+    })
+  })
+})
+
+describe('getSegmentSprites()', () => {
+  const type = 'sidewalk'
+  const variantName = 'density'
+  const variant = 'normal'
+
+  const { components } = getSegmentLookup(type, variant)
+  const sprites = getSegmentSprites(components)
+  expect(sprites).toBeTruthy()
+
+  const { graphics } = SEGMENT_COMPONENTS.lanes[type].variants[variantName][variant]
+  expect(sprites).toEqual(graphics)
+})

--- a/assets/scripts/segments/info.js
+++ b/assets/scripts/segments/info.js
@@ -1,4 +1,11 @@
-import SEGMENT_INFO from './info.json'
+import SEGMENT_LOOKUP from './segment-lookup.json'
+import {
+  getSegmentLookup,
+  applySegmentInfoOverridesAndRules,
+  getSegmentComponentInfo,
+  getSegmentSprites,
+  COMPONENT_GROUPS
+} from './segment-dict'
 
 /**
  * Defines the meta-category of each segment, similar to "typechecking"
@@ -205,7 +212,7 @@ const SPRITE_DEFS = {
  * @returns {Object}
  */
 export function getAllSegmentInfo () {
-  return SEGMENT_INFO
+  return SEGMENT_LOOKUP
 }
 
 /**
@@ -215,8 +222,8 @@ export function getAllSegmentInfo () {
  * @returns {Object}
  */
 export function getAllSegmentInfoArray () {
-  return Object.keys(SEGMENT_INFO).map(id => {
-    const segment = { ...SEGMENT_INFO[id] }
+  return Object.keys(SEGMENT_LOOKUP).map(id => {
+    const segment = { ...SEGMENT_LOOKUP[id] }
     segment.id = id
     return segment
   })
@@ -232,21 +239,35 @@ export function getAllSegmentInfoArray () {
  * @returns {Object}
  */
 export function getSegmentInfo (type) {
-  return SEGMENT_INFO[type] || SEGMENT_UNKNOWN
+  return SEGMENT_LOOKUP[type] || SEGMENT_UNKNOWN
 }
 
 /**
- * Gets variant data for segment `type` and `variant`. Safer than reading
- * `type` directly from `SEGMENT_INFO`, or `variant` from the segment,
- * because this will return a placeholder if the variant is not found.
+ * Maps the old segment data model to the new segment data model and returns the graphic sprites necessary
+ * to draw the segment as well as any rules to follow, e.g. `minWidth` based on the `type` and `variant`.
  *
  * @param {string} type
  * @param {string} variant
- * @returns {Object}
+ * @returns {object} variantInfo - returns an object in the shape of { graphics, ...rules }
  */
 export function getSegmentVariantInfo (type, variant) {
-  const segment = getSegmentInfo(type)
-  return (segment && segment.details && segment.details[variant]) || SEGMENT_UNKNOWN_VARIANT
+  const segmentLookup = getSegmentLookup(type, variant)
+  const { rules } = getSegmentInfo(type)
+
+  if (!segmentLookup || !segmentLookup.components) {
+    return SEGMENT_UNKNOWN_VARIANT
+  }
+
+  const { components, ...details } = segmentLookup
+  const variantInfo = applySegmentInfoOverridesAndRules(details, rules)
+  variantInfo.graphics = getSegmentSprites(components)
+
+  // Assuming a segment has one "lane" component, a segment's elevation can be found using the id
+  // of the first item in the "lane" component group.
+  const lane = getSegmentComponentInfo(COMPONENT_GROUPS.LANES, components.lanes[0].id)
+  variantInfo.elevation = lane.elevation
+
+  return variantInfo
 }
 
 /**

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -156,7 +156,7 @@ function mergeVariantGraphics (variantGraphics) {
  * @param {Object} segmentRules - rules applied to the segment `type`
  * @returns {Object} variantInfo - object with any rules or segment info overrides
  */
-export function applySegmentInfoOverridesAndRules (details, type, segmentRules) {
+export function applySegmentInfoOverridesAndRules (details, segmentRules) {
   const { rules, ...segmentInfoOverrides } = details
   return { ...segmentRules, ...rules, ...segmentInfoOverrides }
 }

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -155,8 +155,7 @@ function mergeVariantGraphics (variantGraphics) {
  * @returns {Object} segmentInfo
  */
 function getSegmentInfo (type) {
-  const { details, ...segmentInfo } = SEGMENT_LOOKUP[type] || {}
-  return segmentInfo || SEGMENT_UNKNOWN
+  return SEGMENT_LOOKUP[type] || SEGMENT_UNKNOWN
 }
 
 /**

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -1,9 +1,9 @@
 import SEGMENT_COMPONENTS from './components.json'
 import SEGMENT_LOOKUP from './segment-lookup.json'
 import { SEGMENT_UNKNOWN, SEGMENT_UNKNOWN_VARIANT } from './info'
-import { uniq, differenceWith, isEqual, isEqualWith, isNumber, pickBy } from 'lodash'
+import { uniq, isNumber, pickBy } from 'lodash'
 
-const COMPONENT_GROUPS = {
+export const COMPONENT_GROUPS = {
   LANES: 'lanes',
   MARKINGS: 'markings',
   OBJECTS: 'objects',
@@ -19,7 +19,7 @@ const COMPONENT_GROUPS = {
  * @returns {object|boolean} segmentLookup - returns an object in the shape of:
  *   { details, components: { lanes, objects, vehicles } } or `false` if not found.
  */
-function getSegmentLookup (type, variant) {
+export function getSegmentLookup (type, variant) {
   return SEGMENT_LOOKUP[type] && SEGMENT_LOOKUP[type].details && SEGMENT_LOOKUP[type].details[variant]
 }
 
@@ -31,7 +31,7 @@ function getSegmentLookup (type, variant) {
  * @param {string} id - name of segment component, e.g. "scooter"
  * @returns {object} segmentInfo
  */
-function getSegmentComponentInfo (group, id) {
+export function getSegmentComponentInfo (group, id) {
   return (SEGMENT_COMPONENTS[group] && SEGMENT_COMPONENTS[group][id]) || SEGMENT_UNKNOWN
 }
 
@@ -146,19 +146,6 @@ function mergeVariantGraphics (variantGraphics) {
 }
 
 /**
- * Gets segment data for segment `type`. Safer than reading `type` directly
- * from `SEGMENT_INFO`, because this will return the `SEGMENT_UNKNOWN`
- * placeholder if the type is not found. The unknown segment placeholder
- * allows means bad data, experimental segments, etc. won't break rendering.
- *
- * @param {string} type
- * @returns {Object} segmentInfo
- */
-function getSegmentInfo (type) {
-  return SEGMENT_LOOKUP[type] || SEGMENT_UNKNOWN
-}
-
-/**
  * Due to segments now being broken into components in the new segment data model, `SEGMENT_LOOKUP` will now
  * include any rules and/or segment information for a segment of a specific `type` and `variant`. Rules applied
  * to a segment should be included in the returned `variantInfo` object as well as rules for a specific `variant`.
@@ -166,16 +153,23 @@ function getSegmentInfo (type) {
  * rules the segment has to follow.
  *
  * @param {Object} details - details for segment `type` and of a specific `variant`
- * @param {string} type
+ * @param {Object} segmentRules - rules applied to the segment `type`
  * @returns {Object} variantInfo - object with any rules or segment info overrides
  */
-function applySegmentInfoOverridesAndRules (details, type) {
+export function applySegmentInfoOverridesAndRules (details, type, segmentRules) {
   const { rules, ...segmentInfoOverrides } = details
-  const segmentInfo = getSegmentInfo(type)
-  return { ...segmentInfo.rules, ...rules, ...segmentInfoOverrides }
+  return { ...segmentRules, ...rules, ...segmentInfoOverrides }
 }
 
-function getSegmentSprites (components) {
+/**
+ * Based on the list of `lanes`, `markings`, `objects`, and/or `vehicles` components that makes up
+ * the segment `type` and `variant`, this function creates a graphics object with all the sprite
+ * definitions needed to draw the segment.
+ *
+ * @param {Object} components - all segment components that make up the segment `type` and `variant`
+ * @returns {Object} sprites - all sprite definitions necessary to draw the segment
+ */
+export function getSegmentSprites (components) {
   // 1) Loop through each component group that makes up the segment.
   const sprites = Object.entries(components).reduce((graphicsArray, componentGroup) => {
     const [ group, groupItems ] = componentGroup
@@ -204,78 +198,4 @@ function getSegmentSprites (components) {
 
   // 5) Combine the variant graphics into one graphics definition object.
   return mergeVariantGraphics(sprites)
-}
-
-/**
- * Maps the old segment data model to the new segment data model and returns the graphic sprites necessary
- * to draw the segment as well as any rules to follow, e.g. `minWidth` based on the `type` and `variant`.
- *
- * @param {string} type
- * @param {string} variant
- * @returns {object} variantInfo - returns an object in the shape of { graphics, ...rules }
- */
-function getSegmentVariantInfo (type, variant) {
-  const segmentLookup = getSegmentLookup(type, variant)
-
-  if (!segmentLookup || !segmentLookup.components) {
-    return SEGMENT_UNKNOWN_VARIANT
-  }
-
-  const { components, ...details } = segmentLookup
-  const variantInfo = applySegmentInfoOverridesAndRules(details, type)
-  variantInfo.graphics = getSegmentSprites(components)
-
-  // Assuming a segment has one "lane" component, a segment's elevation can be found using the id
-  // of the first item in the "lane" component group.
-  const lane = getSegmentComponentInfo(COMPONENT_GROUPS.LANES, components.lanes[0].id)
-  variantInfo.elevation = lane.elevation
-
-  return variantInfo
-}
-
-/**
- * Temporary helper method that compares the original segment variant info with the variant info returned
- * by the new data model. If the new variant info contains all the keys from the original variant info, then
- * the variant info is correct.
- *
- * TODO - migrate helper method to become a test suite
- *
- * @param {object} originalVariantInfo
- * @param {object} newVariantInfo
- * @returns {boolean} correct
- */
-function verifyCorrectness (originalVariantInfo, newVariantInfo) {
-  const checkArrayEquality = (origValue, testValue) => {
-    if (Array.isArray(origValue) && Array.isArray(testValue)) {
-      return !differenceWith(origValue, testValue, isEqual).length
-    }
-  }
-
-  return isEqualWith(originalVariantInfo, newVariantInfo, checkArrayEquality)
-}
-
-/**
- * Tests the mapping of the old segment data model to the new segment data model and
- * returns the correct `variantInfo` needed to draw the segment.
- *
- * @param {string} type
- * @param {string} variant
- * @param {object} segmentVariantInfo
- * @returns {object} variantInfo
- */
-export function testSegmentLookup (type, variant, segmentVariantInfo) {
-  // If segment lookup value not defined yet, return original variantInfo.
-  if (!getSegmentLookup(type, variant)) {
-    return segmentVariantInfo
-  }
-
-  const newVariantInfo = getSegmentVariantInfo(type, variant)
-
-  if (verifyCorrectness(segmentVariantInfo, newVariantInfo)) {
-    return newVariantInfo
-  } else {
-    console.log(`Incorrectly mapped segment of type "${type}" and variant "${variant}".`)
-    console.log(segmentVariantInfo, newVariantInfo)
-    return segmentVariantInfo
-  }
 }

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -158,7 +158,7 @@ function mergeVariantGraphics (variantGraphics) {
  */
 export function applySegmentInfoOverridesAndRules (details, segmentRules) {
   const { rules, ...segmentInfoOverrides } = details
-  return { ...segmentRules, ...rules, ...segmentInfoOverrides }
+  return Object.assign({}, segmentRules, rules, segmentInfoOverrides)
 }
 
 /**

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -9,6 +9,9 @@
     "rules": {
       "minWidth": 6
     },
+    "variants": [
+      "sidewalk-density"
+    ],
     "details": {
       "dense": {
         "components": {
@@ -66,6 +69,9 @@
     "owner": "NATURE",
     "zIndex": 22,
     "defaultWidth": 4,
+    "variants": [
+      "tree-type"
+    ],
     "details": {
       "big": {
         "components": {
@@ -116,6 +122,10 @@
     "zIndex": 23,
     "defaultWidth": 5,
     "paletteIcon": "left|sidewalk",
+    "variants": [
+      "orientation",
+      "bike-rack-elevation"
+    ],
     "details": {
       "left|sidewalk-parallel": {
         "components": {
@@ -263,6 +273,9 @@
     "owner": "PEDESTRIAN",
     "zIndex": 24,
     "defaultWidth": 4,
+    "variants": [
+      "bench-orientation"
+    ],
     "details": {
       "left": {
         "components": {
@@ -336,6 +349,9 @@
       "key": "wayfinding-sign",
       "image": "wayfinding-02.jpg"
     },
+    "variants": [
+      "wayfinding-type"
+    ],
     "details": {
       "large": {
         "components": {
@@ -406,6 +422,10 @@
     "zIndex": 19,
     "defaultWidth": 4,
     "paletteIcon": "both|traditional",
+    "variants": [
+      "lamp-orientation",
+      "lamp-type"
+    ],
     "details": {
       "right|modern": {
         "components": {
@@ -641,6 +661,9 @@
     "zIndex": 10,
     "defaultWidth": 4,
     "enableWithFlag": "SEGMENT_UTILITIES",
+    "variants": [
+      "orientation"
+    ],
     "details": {
       "left": {
         "components": {
@@ -697,6 +720,9 @@
     "rules": {
       "minWidth": 8
     },
+    "variants": [
+      "orientation"
+    ],
     "details": {
       "left": {
         "components": {
@@ -747,6 +773,9 @@
     "zIndex": 20,
     "defaultWidth": 2,
     "paletteIcon": "planting-strip",
+    "variants": [
+      "divider-type"
+    ],
     "details": {
       "planting-strip": {
         "name": "Planting strip",
@@ -1032,6 +1061,10 @@
     "rules": {
       "minWidth": 4
     },
+    "variants": [
+      "direction",
+      "bike-asphalt"
+    ],
     "details": {
       "inbound|regular": {
         "components": {
@@ -1193,6 +1226,11 @@
     "defaultWidth": 5,
     "enableWithFlag": "SEGMENT_SCOOTERS",
     "paletteIcon": "right|sidewalk|empty",
+    "variants": [
+      "orientation",
+      "scooter-elevation",
+      "scooter-riders"
+    ],
     "details": {
       "left|sidewalk|empty": {
         "components": {
@@ -1481,6 +1519,10 @@
     "rules": {
       "minWidth": 5
     },
+    "variants": [
+      "direction",
+      "bike-asphalt"
+    ],
     "details": {
       "inbound|regular": {
         "components": {
@@ -1678,6 +1720,9 @@
       "minWidth": 7,
       "maxWidth": 10
     },
+    "variants": [
+      "orientation"
+    ],
     "details": {
       "left": {
         "components": {
@@ -1746,6 +1791,9 @@
     "rules": {
       "minWidth": 10
     },
+    "variants": [
+      "orientation"
+    ],
     "details": {
       "left": {
         "components": {
@@ -1799,6 +1847,11 @@
       "minWidth": 7,
       "maxWidth": 10
     },
+    "variants": [
+      "flex-type",
+      "direction",
+      "orientation"
+    ],
     "details": {
       "taxi|inbound|left": {
         "name": "Taxi loading zone",
@@ -2048,6 +2101,10 @@
     "owner": "FLEX",
     "zIndex": 30,
     "defaultWidth": 4,
+    "variants": [
+      "waiting-area",
+      "orientation"
+    ],
     "details": {
       "sparse|left": {
         "components": {
@@ -2153,6 +2210,10 @@
       "minWidth": 7,
       "maxWidth": 10
     },
+    "variants": [
+      "parking-lane-direction",
+      "parking-lane-orientation"
+    ],
     "details": {
       "inbound|left": {
         "components": {
@@ -2570,6 +2631,10 @@
       "minWidth": 8,
       "maxWidth": 11.9
     },
+    "variants": [
+      "direction",
+      "car-type"
+    ],
     "details": {
       "inbound|car": {
         "components": {
@@ -2773,6 +2838,10 @@
       "minWidth": 9,
       "maxWidth": 12
     },
+    "variants": [
+      "direction",
+      "turn-lane-orientation"
+    ],
     "details": {
       "inbound|left": {
         "components": {
@@ -3175,6 +3244,10 @@
       "minWidth": 10,
       "maxWidth": 13
     },
+    "variants": [
+      "direction",
+      "bus-asphalt"
+    ],
     "details": {
       "inbound|regular": {
         "components": {
@@ -3384,6 +3457,10 @@
       "minWidth": 10,
       "maxWidth": 14
     },
+    "variants": [
+      "direction",
+      "public-transit-asphalt"
+    ],
     "details": {
       "inbound|regular": {
         "components": {
@@ -3581,6 +3658,10 @@
       "minWidth": 10,
       "maxWidth": 14
     },
+    "variants": [
+      "direction",
+      "public-transit-asphalt"
+    ],
     "details": {
       "inbound|regular": {
         "components": {
@@ -3778,6 +3859,10 @@
     "rules": {
       "minWidth": 9
     },
+    "variants": [
+      "orientation",
+      "transit-shelter-elevation"
+    ],
     "details": {
       "left|street-level": {
         "components": {
@@ -3901,6 +3986,9 @@
     "rules": {
       "minWidth": 14
     },
+    "variants": [
+      ""
+    ],
     "details": {
       "": {
         "components": {

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -1,1748 +1,4 @@
 {
-  "scooter": {
-    "name": "Electric scooter",
-    "nameKey": "scooter",
-    "owner": "BIKE",
-    "zIndex": 16,
-    "enableWithFlag": "SEGMENT_SCOOTERS",
-    "defaultWidth": 5,
-    "rules": {
-      "minWidth": 4
-    },
-    "details": {
-      "inbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|green": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|green": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|red": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|red": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "scooter-drop-zone": {
-    "name": "Scooter drop zone",
-    "nameKey": "scooter-drop-zone",
-    "owner": "FLEX",
-    "zIndex": 21,
-    "defaultWidth": 5,
-    "enableWithFlag": "SEGMENT_SCOOTERS",
-    "paletteIcon": "right|sidewalk|empty",
-    "details": {
-      "left|sidewalk|empty": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "empty",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "right|sidewalk|empty": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "empty",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "left|sidewalk|sparse": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "sparse",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "right|sidewalk|sparse": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "sparse",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "left|road|empty": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "empty",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "right|road|empty": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "empty",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "left|road|sparse": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "sparse",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "right|road|sparse": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left-half"
-            },
-            {
-              "id": "markings--lane-right-half"
-            },
-            {
-              "id": "markings--lane-horiz"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "scooter",
-              "variants": {
-                "riders|orientation": [
-                  "sparse",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "flex-zone": {
-    "name": "Flex zone",
-    "nameKey": "flex-zone",
-    "owner": "FLEX",
-    "zIndex": 15,
-    "defaultWidth": 7,
-    "rules": {
-      "minWidth": 7,
-      "maxWidth": 10
-    },
-    "details": {
-      "taxi|inbound|left": {
-        "name": "Taxi loading zone",
-        "nameKey": "taxi-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-right"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "taxi",
-              "variants": {
-                "direction|orientation": [
-                  "inbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "taxi|inbound|right": {
-        "name": "Taxi loading zone",
-        "nameKey": "taxi-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "taxi",
-              "variants": {
-                "direction|orientation": [
-                  "inbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "taxi|outbound|left": {
-        "name": "Taxi loading zone",
-        "nameKey": "taxi-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-right"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "taxi",
-              "variants": {
-                "direction|orientation": [
-                  "outbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "taxi|outbound|right": {
-        "name": "Taxi loading zone",
-        "nameKey": "taxi-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "taxi",
-              "variants": {
-                "direction|orientation": [
-                  "outbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "rideshare|inbound|left": {
-        "name": "Rideshare loading zone",
-        "nameKey": "rideshare-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-right"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "rideshare",
-              "variants": {
-                "direction|orientation": [
-                  "inbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "rideshare|inbound|right": {
-        "name": "Rideshare loading zone",
-        "nameKey": "rideshare-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "rideshare",
-              "variants": {
-                "direction|orientation": [
-                  "inbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "rideshare|outbound|left": {
-        "name": "Rideshare loading zone",
-        "nameKey": "rideshare-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-right"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "rideshare",
-              "variants": {
-                "direction|orientation": [
-                  "outbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "rideshare|outbound|right": {
-        "name": "Rideshare loading zone",
-        "nameKey": "rideshare-pick-up",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "rideshare",
-              "variants": {
-                "direction|orientation": [
-                  "outbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "flex-zone-curb": {
-    "name": "Waiting area",
-    "nameKey": "flex-zone-curb",
-    "owner": "FLEX",
-    "zIndex": 30,
-    "defaultWidth": 4,
-    "details": {
-      "sparse|left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "pickup-sign",
-              "variants": {
-                "orientation": "right"
-              }
-            },
-            {
-              "id": "person-waiting",
-              "variants": {
-                "orientation": "right"
-              }
-            }
-          ]
-        }
-      },
-      "sparse|right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "pickup-sign",
-              "variants": {
-                "orientation": "left"
-              }
-            },
-            {
-              "id": "person-waiting",
-              "variants": {
-                "orientation": "left"
-              }
-            }
-          ]
-        }
-      },
-      "empty|left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "pickup-sign",
-              "variants": {
-                "orientation": "right"
-              }
-            }
-          ]
-        }
-      },
-      "empty|right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "pickup-sign",
-              "variants": {
-                "orientation": "left"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "train": {
-    "name": "“Inception” train",
-    "nameKey": "inception-train",
-    "owner": "TRANSIT",
-    "zIndex": 10,
-    "defaultWidth": 14,
-    "enableWithFlag": "SEGMENT_INCEPTION_TRAIN",
-    "description": {
-      "key": "inception-train",
-      "image": "train.jpg"
-    },
-    "rules": {
-      "minWidth": 14
-    },
-    "details": {
-      "": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "train",
-              "variants": {
-                "type": "default"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "utilities": {
-    "name": "Utility pole",
-    "nameKey": "utility-pole",
-    "owner": "NONE",
-    "zIndex": 10,
-    "defaultWidth": 4,
-    "enableWithFlag": "SEGMENT_UTILITIES",
-    "details": {
-      "left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "utility-pole",
-              "variants": {
-                "orientation": "left"
-              }
-            }
-          ]
-        }
-      },
-      "right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "utility-pole",
-              "variants": {
-                "orientation": "right"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "bike-lane": {
-    "name": "Bike lane",
-    "nameKey": "bike-lane",
-    "owner": "BIKE",
-    "zIndex": 16,
-    "defaultWidth": 6,
-    "description": {
-      "key": "bike-lane",
-      "image": "bike-lane-02.jpg"
-    },
-    "rules": {
-      "minWidth": 5
-    },
-    "details": {
-      "inbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-01",
-                  "inbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-01",
-                  "outbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|green": {
-        "description": {
-          "key": "colored-bike-lane",
-          "image": "bike-lane-colored-01.jpg"
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-01",
-                  "inbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|green": {
-        "description": {
-          "key": "colored-bike-lane",
-          "image": "bike-lane-colored-01.jpg"
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-01",
-                  "outbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|red": {
-        "description": {
-          "key": "colored-bike-lane",
-          "image": "bike-lane-colored-01.jpg"
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-01",
-                  "inbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|red": {
-        "description": {
-          "key": "colored-bike-lane",
-          "image": "bike-lane-colored-01.jpg"
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-01",
-                  "outbound"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "drive-lane": {
-    "name": "Drive lane",
-    "nameKey": "drive-lane",
-    "owner": "CAR",
-    "zIndex": 14,
-    "defaultWidth": 10,
-    "rules": {
-      "minWidth": 8,
-      "maxWidth": 11.9
-    },
-    "details": {
-      "inbound|car": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|car": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|sharrow": {
-        "name": "Sharrow",
-        "nameKey": "sharrow",
-        "rules": {
-          "minWidth": 12,
-          "maxWidth": 14
-        },
-        "defaultWidth": 14,
-        "description": {
-          "key": "sharrow",
-          "image": "sharrow-01.jpg"
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--sharrow-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction": "inbound"
-              }
-            },
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-02",
-                  "inbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|sharrow": {
-        "name": "Sharrow",
-        "nameKey": "sharrow",
-        "rules": {
-          "minWidth": 12,
-          "maxWidth": 14
-        },
-        "defaultWidth": 14,
-        "description": {
-          "key": "sharrow",
-          "image": "sharrow-01.jpg"
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--sharrow-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction": "outbound"
-              }
-            },
-            {
-              "id": "bike",
-              "variants": {
-                "type|direction": [
-                  "biker-02",
-                  "outbound"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|truck": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "truck",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|truck": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "truck",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "turn-lane": {
-    "name": "Turn lane",
-    "nameKey": "turn-lane",
-    "owner": "CAR",
-    "zIndex": 13,
-    "defaultWidth": 10,
-    "rules": {
-      "minWidth": 9,
-      "maxWidth": 12
-    },
-    "details": {
-      "inbound|left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--left-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "inbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|left-straight": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--left-straight-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "inbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|straight": {
-        "name": "No turn lane",
-        "nameKey": "turn-lane-straight",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|right-straight": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--right-straight-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "inbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--right-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "inbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|both": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--both-inbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "inbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "inbound|shared": {
-        "name": "Center turn lane",
-        "nameKey": "turn-lane-center",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--shared-inbound"
-            },
-            {
-              "id": "markings--center-lane-left"
-            },
-            {
-              "id": "markings--center-lane-right"
-            }
-          ]
-        }
-      },
-      "outbound|left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--left-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "outbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|left-straight": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--left-straight-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "outbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|straight": {
-        "name": "No turn lane",
-        "nameKey": "turn-lane-straight",
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--straight-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|right-straight": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--right-straight-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "outbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--right-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "outbound",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|both": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--both-outbound"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "car",
-              "variants": {
-                "direction|turn-orientation": [
-                  "outbound",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "outbound|shared": {
-        "name": "Center turn lane",
-        "nameKey": "turn-lane-center",
-        "rules": {
-          "minWidth": 10,
-          "maxWidth": 16
-        },
-        "defaultWidth": 12,
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--shared-outbound"
-            },
-            {
-              "id": "markings--center-lane-left"
-            },
-            {
-              "id": "markings--center-lane-right"
-            }
-          ]
-        }
-      }
-    }
-  },
-  "food-truck": {
-    "name": "Food truck",
-    "nameKey": "foodtruck",
-    "owner": "FLEX",
-    "zIndex": 20,
-    "defaultWidth": 10,
-    "rules": {
-      "minWidth": 10
-    },
-    "details": {
-      "left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "food-truck",
-              "variants": {
-                "orientation": "left"
-              }
-            }
-          ]
-        }
-      },
-      "right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "food-truck",
-              "variants": {
-                "orientation": "right"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
   "sidewalk": {
     "name": "Sidewalk",
     "nameKey": "sidewalk",
@@ -2378,6 +634,56 @@
       }
     }
   },
+  "utilities": {
+    "name": "Utility pole",
+    "nameKey": "utility-pole",
+    "owner": "NONE",
+    "zIndex": 10,
+    "defaultWidth": 4,
+    "enableWithFlag": "SEGMENT_UTILITIES",
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "utility-pole",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "utility-pole",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
   "parklet": {
     "name": "Parklet",
     "nameKey": "parklet",
@@ -2427,469 +733,6 @@
               "id": "parklet",
               "variants": {
                 "orientation": "right"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "bikeshare": {
-    "name": "Bikeshare station",
-    "nameKey": "bikeshare-station",
-    "owner": "FLEX",
-    "zIndex": 21,
-    "defaultWidth": 7,
-    "rules": {
-      "minWidth": 7,
-      "maxWidth": 10
-    },
-    "details": {
-      "left": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left"
-            },
-            {
-              "id": "markings--lane-right"
-            }
-          ],
-          "objects": [
-            {
-              "id": "bikeshare",
-              "variants": {
-                "orientation": "left"
-              }
-            }
-          ]
-        }
-      },
-      "right": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--lane-left"
-            },
-            {
-              "id": "markings--lane-right"
-            }
-          ],
-          "objects": [
-            {
-              "id": "bikeshare",
-              "variants": {
-                "orientation": "right"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "streetcar": {
-    "name": "Streetcar",
-    "nameKey": "streetcar",
-    "owner": "TRANSIT",
-    "zIndex": 15,
-    "defaultWidth": 12,
-    "rules": {
-      "minWidth": 10,
-      "maxWidth": 14
-    },
-    "details": {
-      "inbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-01"
-            },
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "streetcar",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "regular"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-01"
-            },
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "streetcar",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|colored": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "streetcar",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|colored": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "streetcar",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|grass": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "objects": [
-            {
-              "id": "planting-strip",
-              "variants": {
-                "type": "grass"
-              }
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "streetcar",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|grass": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "objects": [
-            {
-              "id": "planting-strip",
-              "variants": {
-                "type": "grass"
-              }
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "streetcar",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "light-rail": {
-    "name": "Light rail",
-    "nameKey": "light-rail",
-    "owner": "TRANSIT",
-    "zIndex": 15,
-    "defaultWidth": 12,
-    "rules": {
-      "minWidth": 10,
-      "maxWidth": 14
-    },
-    "details": {
-      "inbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "gray"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "light-rail",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|regular": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "gray"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "light-rail",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|colored": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "light-rail",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|colored": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "red"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "light-rail",
-              "variants": {
-                "direction": "outbound"
-              }
-            }
-          ]
-        }
-      },
-      "inbound|grass": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "planting-strip",
-              "variants": {
-                "type": "grass"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-inbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "light-rail",
-              "variants": {
-                "direction": "inbound"
-              }
-            }
-          ]
-        }
-      },
-      "outbound|grass": {
-        "components": {
-          "lanes": [
-            {
-              "id": "asphalt",
-              "variants": {
-                "color": "green"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "planting-strip",
-              "variants": {
-                "type": "grass"
-              }
-            }
-          ],
-          "markings": [
-            {
-              "id": "markings--streetcar-track-02"
-            },
-            {
-              "id": "markings--straight-outbound-light"
-            }
-          ],
-          "vehicles": [
-            {
-              "id": "light-rail",
-              "variants": {
-                "direction": "outbound"
               }
             }
           ]
@@ -3179,134 +1022,15 @@
       }
     }
   },
-  "transit-shelter": {
-    "name": "Transit shelter",
-    "nameKey": "transit-shelter",
-    "owner": "TRANSIT",
-    "zIndex": 20,
-    "defaultWidth": 9,
-    "paletteIcon": "right|light-rail",
+  "scooter": {
+    "name": "Electric scooter",
+    "nameKey": "scooter",
+    "owner": "BIKE",
+    "zIndex": 16,
+    "enableWithFlag": "SEGMENT_SCOOTERS",
+    "defaultWidth": 5,
     "rules": {
-      "minWidth": 9
-    },
-    "details": {
-      "left|street-level": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "transit-shelter",
-              "variants": {
-                "type|orientation": [
-                  "transit-shelter-01",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "right|street-level": {
-        "components": {
-          "lanes": [
-            {
-              "id": "sidewalk",
-              "variants": {
-                "density": "empty"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "transit-shelter",
-              "variants": {
-                "type|orientation": [
-                  "transit-shelter-01",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "left|light-rail": {
-        "description": {
-          "key": "transit-shelter-elevated",
-          "image": "transit-station-elevated.jpg"
-        },
-        "rules": {
-          "minWidth": 8
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "raised-sidewalk",
-              "variants": {
-                "type": "default"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "transit-shelter",
-              "variants": {
-                "type|orientation": [
-                  "transit-shelter-02",
-                  "left"
-                ]
-              }
-            }
-          ]
-        }
-      },
-      "right|light-rail": {
-        "description": {
-          "key": "transit-shelter-elevated",
-          "image": "transit-station-elevated.jpg"
-        },
-        "rules": {
-          "minWidth": 8
-        },
-        "components": {
-          "lanes": [
-            {
-              "id": "raised-sidewalk",
-              "variants": {
-                "type": "default"
-              }
-            }
-          ],
-          "objects": [
-            {
-              "id": "transit-shelter",
-              "variants": {
-                "type|orientation": [
-                  "transit-shelter-02",
-                  "right"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    }
-  },
-  "bus-lane": {
-    "name": "Bus lane",
-    "nameKey": "bus-lane",
-    "owner": "TRANSIT",
-    "zIndex": 15,
-    "defaultWidth": 12,
-    "rules": {
-      "minWidth": 10,
-      "maxWidth": 13
+      "minWidth": 4
     },
     "details": {
       "inbound|regular": {
@@ -3326,7 +1050,7 @@
           ],
           "vehicles": [
             {
-              "id": "bus",
+              "id": "scooter",
               "variants": {
                 "direction": "inbound"
               }
@@ -3351,7 +1075,7 @@
           ],
           "vehicles": [
             {
-              "id": "bus",
+              "id": "scooter",
               "variants": {
                 "direction": "outbound"
               }
@@ -3359,7 +1083,57 @@
           ]
         }
       },
-      "inbound|colored": {
+      "inbound|green": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|green": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|red": {
         "components": {
           "lanes": [
             {
@@ -3376,7 +1150,7 @@
           ],
           "vehicles": [
             {
-              "id": "bus",
+              "id": "scooter",
               "variants": {
                 "direction": "inbound"
               }
@@ -3384,7 +1158,7 @@
           ]
         }
       },
-      "outbound|colored": {
+      "outbound|red": {
         "components": {
           "lanes": [
             {
@@ -3401,22 +1175,162 @@
           ],
           "vehicles": [
             {
-              "id": "bus",
+              "id": "scooter",
               "variants": {
                 "direction": "outbound"
               }
             }
           ]
         }
+      }
+    }
+  },
+  "scooter-drop-zone": {
+    "name": "Scooter drop zone",
+    "nameKey": "scooter-drop-zone",
+    "owner": "FLEX",
+    "zIndex": 21,
+    "defaultWidth": 5,
+    "enableWithFlag": "SEGMENT_SCOOTERS",
+    "paletteIcon": "right|sidewalk|empty",
+    "details": {
+      "left|sidewalk|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
       },
-      "inbound|shared": {
-        "name": "Shared bus/bike lane",
-        "nameKey": "bus-lane-shared",
-        "defaultWidth": 14,
-        "rules": {
-          "minWidth": 12,
-          "maxWidth": 14
-        },
+      "right|sidewalk|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|sidewalk|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|sidewalk|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|road|empty": {
         "components": {
           "lanes": [
             {
@@ -3428,28 +1342,167 @@
           ],
           "markings": [
             {
-              "id": "markings--sharrow-inbound"
+              "id": "markings--lane-left-half"
             },
             {
-              "id": "markings--lane-left"
+              "id": "markings--lane-right-half"
             },
             {
-              "id": "markings--lane-right"
+              "id": "markings--lane-horiz"
             }
           ],
           "vehicles": [
             {
-              "id": "bus",
+              "id": "scooter",
               "variants": {
-                "direction": "inbound"
+                "riders|orientation": [
+                  "empty",
+                  "left"
+                ]
               }
+            }
+          ]
+        }
+      },
+      "right|road|empty": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
             },
             {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "empty",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|road|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|road|sparse": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left-half"
+            },
+            {
+              "id": "markings--lane-right-half"
+            },
+            {
+              "id": "markings--lane-horiz"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "scooter",
+              "variants": {
+                "riders|orientation": [
+                  "sparse",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "bike-lane": {
+    "name": "Bike lane",
+    "nameKey": "bike-lane",
+    "owner": "BIKE",
+    "zIndex": 16,
+    "defaultWidth": 6,
+    "description": {
+      "key": "bike-lane",
+      "image": "bike-lane-02.jpg"
+    },
+    "rules": {
+      "minWidth": 5
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
               "id": "bike",
-              "offsetX": 30,
               "variants": {
                 "type|direction": [
-                  "biker-02",
+                  "biker-01",
                   "inbound"
                 ]
               }
@@ -3457,14 +1510,7 @@
           ]
         }
       },
-      "outbound|shared": {
-        "name": "Shared bus/bike lane",
-        "nameKey": "bus-lane-shared",
-        "defaultWidth": 14,
-        "rules": {
-          "minWidth": 12,
-          "maxWidth": 14
-        },
+      "outbound|regular": {
         "components": {
           "lanes": [
             {
@@ -3476,8 +1522,174 @@
           ],
           "markings": [
             {
-              "id": "markings--sharrow-outbound"
-            },
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-01",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|green": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-01",
+                  "inbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|green": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-01",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|red": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-01",
+                  "inbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|red": {
+        "description": {
+          "key": "colored-bike-lane",
+          "image": "bike-lane-colored-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-01",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "bikeshare": {
+    "name": "Bikeshare station",
+    "nameKey": "bikeshare-station",
+    "owner": "FLEX",
+    "zIndex": 21,
+    "defaultWidth": 7,
+    "rules": {
+      "minWidth": 7,
+      "maxWidth": 10
+    },
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
             {
               "id": "markings--lane-left"
             },
@@ -3485,21 +1697,445 @@
               "id": "markings--lane-right"
             }
           ],
+          "objects": [
+            {
+              "id": "bikeshare",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "objects": [
+            {
+              "id": "bikeshare",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "food-truck": {
+    "name": "Food truck",
+    "nameKey": "foodtruck",
+    "owner": "FLEX",
+    "zIndex": 20,
+    "defaultWidth": 10,
+    "rules": {
+      "minWidth": 10
+    },
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
           "vehicles": [
             {
-              "id": "bus",
+              "id": "food-truck",
               "variants": {
-                "direction": "outbound"
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "food-truck",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "flex-zone": {
+    "name": "Flex zone",
+    "nameKey": "flex-zone",
+    "owner": "FLEX",
+    "zIndex": 15,
+    "defaultWidth": 7,
+    "rules": {
+      "minWidth": 7,
+      "maxWidth": 10
+    },
+    "details": {
+      "taxi|inbound|left": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "taxi|inbound|right": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "taxi|outbound|left": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "taxi|outbound|right": {
+        "name": "Taxi loading zone",
+        "nameKey": "taxi-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "taxi",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|inbound|left": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|inbound|right": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|outbound|left": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "rideshare|outbound|right": {
+        "name": "Rideshare loading zone",
+        "nameKey": "rideshare-pick-up",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--lane-left"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "rideshare",
+              "variants": {
+                "direction|orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "flex-zone-curb": {
+    "name": "Waiting area",
+    "nameKey": "flex-zone-curb",
+    "owner": "FLEX",
+    "zIndex": 30,
+    "defaultWidth": 4,
+    "details": {
+      "sparse|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "right"
               }
             },
             {
-              "id": "bike",
-              "offsetX": -30,
+              "id": "person-waiting",
               "variants": {
-                "type|direction": [
-                  "biker-02",
-                  "outbound"
-                ]
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      },
+      "sparse|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "left"
+              }
+            },
+            {
+              "id": "person-waiting",
+              "variants": {
+                "orientation": "left"
+              }
+            }
+          ]
+        }
+      },
+      "empty|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "right"
+              }
+            }
+          ]
+        }
+      },
+      "empty|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "pickup-sign",
+              "variants": {
+                "orientation": "left"
               }
             }
           ]
@@ -3917,6 +2553,1370 @@
                   "angled-rear-right",
                   "right"
                 ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "drive-lane": {
+    "name": "Drive lane",
+    "nameKey": "drive-lane",
+    "owner": "CAR",
+    "zIndex": 14,
+    "defaultWidth": 10,
+    "rules": {
+      "minWidth": 8,
+      "maxWidth": 11.9
+    },
+    "details": {
+      "inbound|car": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|car": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|sharrow": {
+        "name": "Sharrow",
+        "nameKey": "sharrow",
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "defaultWidth": 14,
+        "description": {
+          "key": "sharrow",
+          "image": "sharrow-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "inbound"
+              }
+            },
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "inbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|sharrow": {
+        "name": "Sharrow",
+        "nameKey": "sharrow",
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "defaultWidth": 14,
+        "description": {
+          "key": "sharrow",
+          "image": "sharrow-01.jpg"
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "outbound"
+              }
+            },
+            {
+              "id": "bike",
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|truck": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "truck",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|truck": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "truck",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "turn-lane": {
+    "name": "Turn lane",
+    "nameKey": "turn-lane",
+    "owner": "CAR",
+    "zIndex": 13,
+    "defaultWidth": 10,
+    "rules": {
+      "minWidth": 9,
+      "maxWidth": 12
+    },
+    "details": {
+      "inbound|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|left-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-straight-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|straight": {
+        "name": "No turn lane",
+        "nameKey": "turn-lane-straight",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|right-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-straight-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|both": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--both-inbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "inbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "inbound|shared": {
+        "name": "Center turn lane",
+        "nameKey": "turn-lane-center",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--shared-inbound"
+            },
+            {
+              "id": "markings--center-lane-left"
+            },
+            {
+              "id": "markings--center-lane-right"
+            }
+          ]
+        }
+      },
+      "outbound|left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|left-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--left-straight-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|straight": {
+        "name": "No turn lane",
+        "nameKey": "turn-lane-straight",
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|right-straight": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-straight-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--right-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|both": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--both-outbound"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "car",
+              "variants": {
+                "direction|turn-orientation": [
+                  "outbound",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|shared": {
+        "name": "Center turn lane",
+        "nameKey": "turn-lane-center",
+        "rules": {
+          "minWidth": 10,
+          "maxWidth": 16
+        },
+        "defaultWidth": 12,
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--shared-outbound"
+            },
+            {
+              "id": "markings--center-lane-left"
+            },
+            {
+              "id": "markings--center-lane-right"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "bus-lane": {
+    "name": "Bus lane",
+    "nameKey": "bus-lane",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 13
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|shared": {
+        "name": "Shared bus/bike lane",
+        "nameKey": "bus-lane-shared",
+        "defaultWidth": 14,
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-inbound"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            },
+            {
+              "id": "bike",
+              "offsetX": 30,
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "inbound"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "outbound|shared": {
+        "name": "Shared bus/bike lane",
+        "nameKey": "bus-lane-shared",
+        "defaultWidth": 14,
+        "rules": {
+          "minWidth": 12,
+          "maxWidth": 14
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--sharrow-outbound"
+            },
+            {
+              "id": "markings--lane-left"
+            },
+            {
+              "id": "markings--lane-right"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            },
+            {
+              "id": "bike",
+              "offsetX": -30,
+              "variants": {
+                "type|direction": [
+                  "biker-02",
+                  "outbound"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "streetcar": {
+    "name": "Streetcar",
+    "nameKey": "streetcar",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 14
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-01"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-01"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "streetcar",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "light-rail": {
+    "name": "Light rail",
+    "nameKey": "light-rail",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 14
+    },
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "gray"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "gray"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|colored": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|grass": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "green"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "planting-strip",
+              "variants": {
+                "type": "grass"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--streetcar-track-02"
+            },
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "light-rail",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "transit-shelter": {
+    "name": "Transit shelter",
+    "nameKey": "transit-shelter",
+    "owner": "TRANSIT",
+    "zIndex": 20,
+    "defaultWidth": 9,
+    "paletteIcon": "right|light-rail",
+    "rules": {
+      "minWidth": 9
+    },
+    "details": {
+      "left|street-level": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-01",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|street-level": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "density": "empty"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-01",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "left|light-rail": {
+        "description": {
+          "key": "transit-shelter-elevated",
+          "image": "transit-station-elevated.jpg"
+        },
+        "rules": {
+          "minWidth": 8
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "raised-sidewalk",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-02",
+                  "left"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "right|light-rail": {
+        "description": {
+          "key": "transit-shelter-elevated",
+          "image": "transit-station-elevated.jpg"
+        },
+        "rules": {
+          "minWidth": 8
+        },
+        "components": {
+          "lanes": [
+            {
+              "id": "raised-sidewalk",
+              "variants": {
+                "type": "default"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "transit-shelter",
+              "variants": {
+                "type|orientation": [
+                  "transit-shelter-02",
+                  "right"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "train": {
+    "name": "“Inception” train",
+    "nameKey": "inception-train",
+    "owner": "TRANSIT",
+    "zIndex": 10,
+    "defaultWidth": 14,
+    "enableWithFlag": "SEGMENT_INCEPTION_TRAIN",
+    "description": {
+      "key": "inception-train",
+      "image": "train.jpg"
+    },
+    "rules": {
+      "minWidth": 14
+    },
+    "details": {
+      "": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "train",
+              "variants": {
+                "type": "default"
               }
             }
           ]

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -1,4 +1,3 @@
-import { testSegmentLookup } from './segment-dict'
 import { images } from '../app/load_resources'
 import { t } from '../locales/locale'
 import { saveStreetToServerIfNecessary } from '../streets/data_model'
@@ -217,9 +216,6 @@ function getGroundLevelOffset (elevation) {
 export function drawSegmentContents (ctx, type, variantString, actualWidth, offsetLeft, groundBaseline, randSeed, multiplier, dpi) {
   const variantInfo = getSegmentVariantInfo(type, variantString)
   const graphics = variantInfo.graphics
-
-  // Testing mapping segment to new segment data model.
-  testSegmentLookup(type, variantString, variantInfo)
 
   // TODO: refactor this variable
   const segmentWidth = actualWidth * TILE_SIZE


### PR DESCRIPTION
- Moves the `getSegmentInfo` and `getSegmentVariantInfo` functions from `segment-dict.js` into `info.js` and replaces the old functions with the corresponding names
- Updates `getAllSegmentInfo` and `getAllSegmentInfoArray` to use `SEGMENT_LOOKUP`
- Separates getting sprite definitions logic from `components` list into its own function called `getSegmentSprites`
- Updates `SEGMENT_LOOKUP` to include `variants` array which is used to render the `<Variants />` component
- Adds tests for `segment-dict` functions and include test to verify correctness of mapping the old segment data model to the new segment data model

Resolves #1257 