### PR TITLE
Custom stylized checkbox

### DIFF
--- a/assets/scripts/dialogs/FeatureFlagDialog.jsx
+++ b/assets/scripts/dialogs/FeatureFlagDialog.jsx
@@ -41,9 +41,8 @@ class FeatureFlagDialog extends React.Component {
             }}
             checked={this.props.flags[id].value}
             disabled={deets.enabled === false}
-            labelClassName={labelClassName}
           >
-            {deets.label}
+            <span className={labelClassName}>{deets.label}</span>
           </Checkbox>
         </li>
       )

--- a/assets/scripts/dialogs/FeatureFlagDialog.jsx
+++ b/assets/scripts/dialogs/FeatureFlagDialog.jsx
@@ -8,6 +8,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Dialog from './Dialog'
+import Checkbox from '../ui/Checkbox'
 import FEATURE_FLAGS from '../../../app/data/flags'
 import { setFeatureFlag } from '../store/actions/flags'
 import './FeatureFlagDialog.scss'
@@ -23,32 +24,27 @@ class FeatureFlagDialog extends React.Component {
       const id = item[0]
       const deets = item[1]
       const htmlLabel = `feature-flag__input--${id.toLowerCase().replace(/_/g, '-')}`
-      const labelClassNames = []
 
       // Bail if a defined flag is not in the store (e.g. in tests with mock stores)
       if (!this.props.flags[id]) return
 
+      // If the setting has changed, display it differently
       const isNotDefault = deets.defaultValue !== this.props.flags[id].value
-
-      if (deets.enabled === false) {
-        labelClassNames.push('feature-flag-label-disabled')
-      }
-      if (isNotDefault) {
-        labelClassNames.push('feature-flag-label-modified')
-      }
+      const labelClassName = isNotDefault ? 'feature-flag-label-modified' : ''
 
       return (
         <li key={id}>
-          <input
-            type="checkbox"
+          <Checkbox
+            id={htmlLabel}
             onChange={(event) => {
               this.props.setFeatureFlag(id, event.target.checked)
             }}
             checked={this.props.flags[id].value}
-            id={htmlLabel}
             disabled={deets.enabled === false}
-          />
-          <label htmlFor={htmlLabel} className={labelClassNames.join(' ')}>{deets.label}</label>
+            labelClassName={labelClassName}
+          >
+            {deets.label}
+          </Checkbox>
         </li>
       )
     })

--- a/assets/scripts/dialogs/FeatureFlagDialog.scss
+++ b/assets/scripts/dialogs/FeatureFlagDialog.scss
@@ -12,22 +12,10 @@
 .feature-flag-dialog ul li {
   margin: 0;
   margin-bottom: 0.25em;
-  padding-left: 20px;
-  text-indent: -20px;
-}
-
-.feature-flag-dialog ul input {
-  width: 20px;
-  margin-left: 0;
-  margin-right: 0;
 }
 
 .feature-flag-dialog p {
   text-align: center;
-}
-
-.feature-flag-label-disabled {
-  color: #b0baba;
 }
 
 .feature-flag-label-modified {

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FormattedMessage, FormattedHTMLMessage, injectIntl, intlShape } from 'react-intl'
 import Dialog from './Dialog'
+import Checkbox from '../ui/Checkbox'
 import { trackEvent } from '../app/event_tracking'
 import { getStreetImage } from '../streets/image'
 import { setSettings } from '../store/actions/settings'
@@ -223,46 +224,34 @@ class SaveAsImageDialog extends React.Component {
             </header>
             <div className="dialog-content">
               <p>
-                <input
-                  type="checkbox"
+                <Checkbox
                   onChange={this.onChangeOptionSegmentNames}
                   checked={this.props.segmentNames}
-                  id="save-as-image-segment-names"
-                />
-                <label htmlFor="save-as-image-segment-names">
+                >
                   <FormattedMessage id="dialogs.save.option-labels" defaultMessage="Segment names and widths" />
-                </label>
+                </Checkbox>
 
-                <input
-                  type="checkbox"
+                <Checkbox
                   onChange={this.onChangeOptionStreetName}
                   checked={this.props.streetName}
-                  id="save-as-image-street-name"
-                />
-                <label htmlFor="save-as-image-street-name">
+                >
                   <FormattedMessage id="dialogs.save.option-name" defaultMessage="Street name" />
-                </label>
+                </Checkbox>
 
-                <input
-                  type="checkbox"
+                <Checkbox
                   onChange={this.onChangeOptionTransparentSky}
                   checked={this.props.transparentSky}
-                  id="save-as-image-transparent-sky"
-                />
-                <label htmlFor="save-as-image-transparent-sky">
+                >
                   <FormattedMessage id="dialogs.save.option-sky" defaultMessage="Transparent sky" />
-                </label>
+                </Checkbox>
 
-                <input
-                  type="checkbox"
+                <Checkbox
                   onChange={this.onChangeOptionWatermark}
                   checked={this.props.watermark}
                   disabled={!this.props.allowControlWatermark}
-                  id="save-as-image-watermark"
-                />
-                <label htmlFor="save-as-image-watermark">
+                >
                   <FormattedMessage id="dialogs.save.option-watermark" defaultMessage="Watermark" />
-                </label>
+                </Checkbox>
               </p>
               {this.props.allowCustomDpi &&
                 <p>

--- a/assets/scripts/dialogs/SaveAsImageDialog.scss
+++ b/assets/scripts/dialogs/SaveAsImageDialog.scss
@@ -7,27 +7,25 @@
 
   p {
     text-align: center;
+    font-size: 15px;
   }
 
-  input[type="checkbox"] {
+  .checkbox-item {
+    display: inline-block;
     margin-left: 20px;
-    font-size: 25px;
-    user-select: none;
   }
 
-  [dir="rtl"] & input[type="checkbox"] {
-    margin-left: 5px;
+  .checkbox-item:first-of-type {
+    margin-left: 0;
+  }
+
+  [dir="rtl"] & .checkbox-item {
+    margin-left: 0;
     margin-right: 20px;
   }
 
-  label {
-    font-size: 16px;
-    padding-left: 1px;
-    user-select: none;
-  }
-
-  input[disabled] + label {
-    color: $control-disabled-colour;
+  [dir="rtl"] & .checkbox-item:first-of-type {
+    margin-right: 0;
   }
 
   footer {

--- a/assets/scripts/ui/Checkbox.jsx
+++ b/assets/scripts/ui/Checkbox.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { ICON_CHECK } from '../ui/icons'
+import './Checkbox.scss'
+
+let idCounter = 0
+
+function Checkbox (props) {
+  const id = props.id || `checkbox-id-${idCounter++}`
+  const [ isChecked, setChecked ] = useState(props.checked)
+  const handleChange = (event) => {
+    setChecked(!isChecked)
+    props.onChange(event)
+  }
+
+  return (
+    <div className="checkbox-item">
+      <input
+        type="checkbox"
+        id={id}
+        checked={isChecked}
+        value={props.value}
+        disabled={props.disabled}
+        onChange={handleChange}
+      />
+      <label htmlFor={id} className={props.labelClassName}>
+        {props.children}
+      </label>
+      <FontAwesomeIcon icon={ICON_CHECK} />
+    </div>
+  )
+}
+
+Checkbox.propTypes = {
+  children: PropTypes.node,
+  checked: PropTypes.bool,
+  value: PropTypes.string,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func,
+  id: PropTypes.string,
+  labelClassName: PropTypes.string
+}
+
+Checkbox.defaultProps = {
+  checked: false,
+  disabled: false,
+  onChange: () => {},
+  labelClassName: ''
+}
+
+export default Checkbox

--- a/assets/scripts/ui/Checkbox.jsx
+++ b/assets/scripts/ui/Checkbox.jsx
@@ -1,14 +1,59 @@
+/**
+ * Custom stylized checkbox component, so we control the look and
+ * feel instead of relying on browser's default styles.
+ */
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ICON_CHECK } from '../ui/icons'
 import './Checkbox.scss'
 
+// This stores an incrementing number for unique IDs.
 let idCounter = 0
 
+Checkbox.propTypes = {
+  // Child nodes are wrapped in <label> when rendered.
+  children: PropTypes.node.isRequired,
+
+  // Initial checked state of the input.
+  checked: PropTypes.bool,
+
+  // Whether or not the input is disabled. Unlike vanilla HTML, this component
+  // also changes the appearance of labels of disabled checkboxes.
+  disabled: PropTypes.bool,
+
+  // The value of a checkbox input can be optionally set.
+  // By default, browsers set checked inputs to have a string value of "on".
+  value: PropTypes.string,
+
+  // The handler function that's called when the value of the input changes.
+  onChange: PropTypes.func,
+
+  // An `id` is associates a `label` with an `input` element. If you don't
+  // provide one, the component automatically generates a unique ID. IDs
+  // are meant "for internal use only".
+  id: PropTypes.string
+}
+
+Checkbox.defaultProps = {
+  checked: false,
+  disabled: false,
+  onChange: () => {}
+}
+
 function Checkbox (props) {
+  // An `id` is required to associate a `label` with an `input` element.
+  // You can provide one manually in props, otherwise, this component
+  // will generate a unique ID on each render.
   const id = props.id || `checkbox-id-${idCounter++}`
+
+  // This is a controlled component. The `useState` hook maintains
+  // this component's internal state, and sets the initial state
+  // based on the `checked` prop (which is `false` by default).
   const [ isChecked, setChecked ] = useState(props.checked)
+
+  // When the value is changed, we update the state, and we also call
+  // any `onChange` handler that is provided by the parent via props.
   const handleChange = (event) => {
     setChecked(!isChecked)
     props.onChange(event)
@@ -24,29 +69,13 @@ function Checkbox (props) {
         disabled={props.disabled}
         onChange={handleChange}
       />
-      <label htmlFor={id} className={props.labelClassName}>
+      <label htmlFor={id}>
         {props.children}
       </label>
+      {/* The visual state of this checkbox is affected by the value of the input, via CSS. */}
       <FontAwesomeIcon icon={ICON_CHECK} />
     </div>
   )
-}
-
-Checkbox.propTypes = {
-  children: PropTypes.node.isRequired,
-  checked: PropTypes.bool,
-  value: PropTypes.string,
-  disabled: PropTypes.bool,
-  onChange: PropTypes.func,
-  id: PropTypes.string,
-  labelClassName: PropTypes.string
-}
-
-Checkbox.defaultProps = {
-  checked: false,
-  disabled: false,
-  onChange: () => {},
-  labelClassName: ''
 }
 
 export default Checkbox

--- a/assets/scripts/ui/Checkbox.jsx
+++ b/assets/scripts/ui/Checkbox.jsx
@@ -33,7 +33,7 @@ function Checkbox (props) {
 }
 
 Checkbox.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.node.isRequired,
   checked: PropTypes.bool,
   value: PropTypes.string,
   disabled: PropTypes.bool,

--- a/assets/scripts/ui/Checkbox.scss
+++ b/assets/scripts/ui/Checkbox.scss
@@ -1,28 +1,28 @@
 // UI color ramp
-$color-1: #b2c1db;
-$color-2: #0d98e6;
-$color-3: #1daeff;
+$color-1: #a6b2c8;
+$color-2: #55a2ae;
 
 // Special colors
-$disabled-color: #b0baba;
+$disabled-color: #a6b2c8;
 
 // Colors for stylized checkbox input
 $input-default-border-color: $color-1;
 $input-unchecked-background-color: transparent;
 $input-checked-border-color: $color-1;
 $input-checked-background-color: white;
-$input-hover-border-color: $color-3;
+$input-hover-border-color: $color-2;
 $input-active-border-color: $color-2;
 $input-active-background-color: $color-2;
+$input-disabled-border-color: $disabled-color;
 
 // Colors for checkmark icon
-$checkmark-checked-color: $color-3;
+$checkmark-checked-color: $color-2;
 $checkmark-active-color: white;
 $checkmark-disabled-color: $disabled-color;
 
 // Colors for label
 $label-disabled-text-color: $disabled-color;
-$label-outline-color: $color-3;
+$label-outline-color: $color-2;
 
 .checkbox-item {
   position: relative;
@@ -38,7 +38,7 @@ $label-outline-color: $color-3;
     display: inline-block;
     position: relative;
     margin-left: 1.3em;
-    padding: 0 0.2em;
+    padding: 0 2px; /* Breathing room around outline property */
     cursor: pointer;
   }
 
@@ -48,7 +48,7 @@ $label-outline-color: $color-3;
     display: block;
     position: absolute;
     left: -1.2em;
-    top: 0.2em;
+    top: 0.25em;
     height: 1em;
     width: 1em;
     background-color: $input-unchecked-background-color;
@@ -81,11 +81,16 @@ $label-outline-color: $color-3;
     border-color: $input-active-border-color;
   }
 
+  /* Stylized checkbox, when disabled */
+  input:disabled + label::before {
+    border-color: $input-disabled-border-color;
+  }
+
   /* Checkmark */
   input ~ svg {
     position: absolute;
     left: 0.1em;
-    top: 0.2em;
+    top: 0.25em;
     opacity: 0;
     color: transparent;
     pointer-events: none;
@@ -119,5 +124,6 @@ $label-outline-color: $color-3;
   /* Label, when input is disabled */
   input:disabled ~ label {
     color: $label-disabled-text-color;
+    cursor: default;
   }
 }

--- a/assets/scripts/ui/Checkbox.scss
+++ b/assets/scripts/ui/Checkbox.scss
@@ -1,0 +1,123 @@
+// UI color ramp
+$color-1: #b2c1db;
+$color-2: #0d98e6;
+$color-3: #1daeff;
+
+// Special colors
+$disabled-color: #b0baba;
+
+// Colors for stylized checkbox input
+$input-default-border-color: $color-1;
+$input-unchecked-background-color: transparent;
+$input-checked-border-color: $color-1;
+$input-checked-background-color: white;
+$input-hover-border-color: $color-3;
+$input-active-border-color: $color-2;
+$input-active-background-color: $color-2;
+
+// Colors for checkmark icon
+$checkmark-checked-color: $color-3;
+$checkmark-active-color: white;
+$checkmark-disabled-color: $disabled-color;
+
+// Colors for label
+$label-disabled-text-color: $disabled-color;
+$label-outline-color: $color-3;
+
+.checkbox-item {
+  position: relative;
+
+  /* Hides the original input element from view, but not from DOM */
+  input {
+    position: absolute;
+    left: -9999em;
+  }
+
+  /* Positions the label */
+  label {
+    display: inline-block;
+    position: relative;
+    margin-left: 1.3em;
+    padding: 0 0.2em;
+    cursor: pointer;
+  }
+
+  /* Creates a stylized checkbox for visual display only */
+  label::before {
+    content: '';
+    display: block;
+    position: absolute;
+    left: -1.2em;
+    top: 0.2em;
+    height: 1em;
+    width: 1em;
+    background-color: $input-unchecked-background-color;
+    border-radius: 2px;
+    border: 1px solid $input-default-border-color;
+    color: inherit;
+  }
+
+  /* Stylized checkbox, when checked */
+  input:checked ~ label::before {
+    background-color: $input-checked-background-color;
+    border-color: $input-checked-border-color;
+  }
+
+  /* Stylized checkbox, when active (during click) */
+  input:active:not(:disabled) ~ label::before {
+    background-color: $input-active-border-color;
+    border-color: $input-active-border-color;
+  }
+
+  /* Stylized checkbox, when focused or hovered */
+  input:focus:not(:disabled) ~ label::before,
+  input:hover:not(:disabled) ~ label::before {
+    border: 1px solid $input-hover-border-color;
+  }
+
+  /* Stylized checkbox, when checked, and focused or hovered */
+  input:focus:checked:not(:disabled) + label::before,
+  input:hover:checked:not(:disabled) + label::before {
+    border-color: $input-active-border-color;
+  }
+
+  /* Checkmark */
+  input ~ svg {
+    position: absolute;
+    left: 0.1em;
+    top: 0.2em;
+    opacity: 0;
+    color: transparent;
+    pointer-events: none;
+
+    /* Use scale to affect the size because FontAwesome applies its own
+       width and height CSS values that interfere with overrides */
+    transform: scale(0.75);
+  }
+
+  /* Checkmark, when checked */
+  input:checked ~ svg {
+    color: $checkmark-checked-color;
+    opacity: 1;
+  }
+
+  /* Checkmark, when active (during click) */
+  input:active ~ svg {
+    color: $checkmark-active-color;
+  }
+
+  /* Checkmark, when input disabled */
+  input:checked:disabled ~ svg {
+    color: $checkmark-disabled-color;
+  }
+
+  /* Label, when input is focused */
+  input:focus ~ label {
+    outline: 1px dotted $label-outline-color;
+  }
+
+  /* Label, when input is disabled */
+  input:disabled ~ label {
+    color: $label-disabled-text-color;
+  }
+}

--- a/assets/scripts/ui/__tests__/Checkbox.test.js
+++ b/assets/scripts/ui/__tests__/Checkbox.test.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+import React from 'react'
+import { fireEvent, cleanup, render } from 'react-testing-library'
+import Checkbox from '../Checkbox'
+
+describe('Checkbox', () => {
+  afterEach(cleanup)
+
+  it('renders default snapshot', () => {
+    const wrapper = render(<Checkbox>foo</Checkbox>)
+    expect(wrapper.asFragment()).toMatchSnapshot()
+  })
+
+  it('renders snapshot with all props', () => {
+    const wrapper = render(
+      <Checkbox
+        checked
+        disabled
+        value="bar"
+        id="baz"
+        labelClassName="qux"
+        onChange={jest.fn()}
+      >
+        foo
+      </Checkbox>
+    )
+
+    expect(wrapper.asFragment()).toMatchSnapshot()
+  })
+
+  it('handles click', () => {
+    const handleChange = jest.fn()
+    const { getByText } = render(<Checkbox onChange={handleChange}>foo</Checkbox>)
+    fireEvent.click(getByText('foo'))
+    expect(handleChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/assets/scripts/ui/__tests__/Checkbox.test.js
+++ b/assets/scripts/ui/__tests__/Checkbox.test.js
@@ -18,7 +18,6 @@ describe('Checkbox', () => {
         disabled
         value="bar"
         id="baz"
-        labelClassName="qux"
         onChange={jest.fn()}
       >
         foo

--- a/assets/scripts/ui/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/assets/scripts/ui/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -11,7 +11,6 @@ exports[`Checkbox renders default snapshot 1`] = `
       value=""
     />
     <label
-      class=""
       for="checkbox-id-0"
     >
       foo
@@ -36,7 +35,6 @@ exports[`Checkbox renders snapshot with all props 1`] = `
       value="bar"
     />
     <label
-      class="qux"
       for="baz"
     >
       foo

--- a/assets/scripts/ui/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/assets/scripts/ui/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Checkbox renders default snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="checkbox-item"
+  >
+    <input
+      id="checkbox-id-0"
+      type="checkbox"
+      value=""
+    />
+    <label
+      class=""
+      for="checkbox-id-0"
+    >
+      foo
+    </label>
+    <svg
+      class="svg-inline--fa fa-check"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Checkbox renders snapshot with all props 1`] = `
+<DocumentFragment>
+  <div
+    class="checkbox-item"
+  >
+    <input
+      checked=""
+      disabled=""
+      id="baz"
+      type="checkbox"
+      value="bar"
+    />
+    <label
+      class="qux"
+      for="baz"
+    >
+      foo
+    </label>
+    <svg
+      class="svg-inline--fa fa-check"
+    />
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
This is a stylized checkbox component! I've wanted to get this done for so long. After several aborted efforts over the years, here's one I finally feel really great about.

Primary goals:

- Automatically associates `<label>` with `<input>` elements without having to write the HTML by hand.
- Component controls its own state out of the box.
- Input elements are style-able with CSS so that appearance can be standardized across platforms/OS/browsers. (and themeable!)
- Checkboxes should automatically look "right" no matter what the font size is. (However, vertical alignment may need to be tweaked depending on the actual font, because fonts have different heights/line spacing, even at the same nominal font size.)

![Jun-29-2019 12-50-34](https://user-images.githubusercontent.com/2553268/60387111-b0828500-9a6c-11e9-9630-38d3fe089098.gif)

![Jun-29-2019 12-51-28](https://user-images.githubusercontent.com/2553268/60387112-b0828500-9a6c-11e9-91fe-ce7ec60021f9.gif)
