### PR TITLE
WelcomePanel refactor

### DIFF
--- a/assets/scripts/app/WelcomePanel.jsx
+++ b/assets/scripts/app/WelcomePanel.jsx
@@ -2,13 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
-
-import {
-  NEW_STREET_DEFAULT,
-  NEW_STREET_EMPTY,
-  onNewStreetDefaultClick,
-  onNewStreetEmptyClick
-} from '../streets/creation'
 import StreetName from '../streets/StreetName'
 import { isSignedIn } from '../users/authentication'
 import { registerKeypress, deregisterKeypress } from './keypress'
@@ -16,8 +9,8 @@ import { MODES, getMode } from './mode'
 import { goNewStreet } from './routing'
 import Avatar from '../users/Avatar'
 import { showStreetNameCanvas, hideStreetNameCanvas } from '../store/actions/ui'
-import { getLastStreet } from '../store/actions/street'
 import CloseButton from '../ui/CloseButton'
+import WelcomeNewStreet from './WelcomePanel/NewStreet'
 
 import './WelcomePanel.scss'
 
@@ -33,41 +26,23 @@ export class WelcomePanel extends React.Component {
     touch: PropTypes.bool,
     readOnly: PropTypes.bool,
     everythingLoaded: PropTypes.bool,
-    newStreetPreference: PropTypes.number,
-    priorLastStreetId: PropTypes.string,
     street: PropTypes.object,
     showStreetNameCanvas: PropTypes.func,
-    hideStreetNameCanvas: PropTypes.func,
-    getLastStreet: PropTypes.func
+    hideStreetNameCanvas: PropTypes.func
   }
 
   static defaultProps = {
     touch: false,
     readOnly: false,
-    everythingLoaded: false,
-    priorLastStreetId: null
+    everythingLoaded: false
   }
 
   constructor (props) {
     super(props)
 
-    // If welcomeType is WELCOME_NEW_STREET, there is an additional state
-    // property that determines which of the new street modes is selected
-    let selectedNewStreetType
-    switch (props.newStreetPreference) {
-      case NEW_STREET_EMPTY:
-        selectedNewStreetType = 'new-street-empty'
-        break
-      case NEW_STREET_DEFAULT:
-      default:
-        selectedNewStreetType = 'new-street-default'
-        break
-    }
-
     this.state = {
       welcomeType: null,
-      welcomeDismissed: this.getSettingsWelcomeDismissed(),
-      selectedNewStreetType: selectedNewStreetType
+      welcomeDismissed: this.getSettingsWelcomeDismissed()
     }
   }
 
@@ -158,14 +133,6 @@ export class WelcomePanel extends React.Component {
   onClickGoNewStreet = (event) => {
     this.setSettingsWelcomeDismissed()
     goNewStreet(true)
-  }
-
-  // The following handler is only used with the WELCOME_NEW_STREET mode.
-  // It handles changing the "checked" state of the input buttons.
-  onChangeNewStreetType = (event) => {
-    this.setState({
-      selectedNewStreetType: event.target.id
-    })
   }
 
   render () {
@@ -264,65 +231,7 @@ export class WelcomePanel extends React.Component {
 
         break
       case WELCOME_NEW_STREET:
-        welcomeContent = (
-          <div className="welcome-panel-content new-street">
-            <h1>
-              <FormattedMessage id="dialogs.new-street.heading" defaultMessage="Here’s your new street." />
-            </h1>
-            <ul>
-              <li>
-                <input
-                  type="radio"
-                  name="new-street"
-                  id="new-street-default"
-                  checked={this.state.selectedNewStreetType === 'new-street-default' || !this.state.selectedNewStreetType}
-                  onChange={this.onChangeNewStreetType}
-                  onClick={onNewStreetDefaultClick}
-                />
-                <label htmlFor="new-street-default">
-                  <FormattedMessage id="dialogs.new-street.default" defaultMessage="Start with an example street" />
-                </label>
-              </li>
-              <li>
-                <input
-                  type="radio"
-                  name="new-street"
-                  id="new-street-empty"
-                  checked={this.state.selectedNewStreetType === 'new-street-empty'}
-                  onChange={this.onChangeNewStreetType}
-                  onClick={onNewStreetEmptyClick}
-                />
-                <label htmlFor="new-street-empty">
-                  <FormattedMessage id="dialogs.new-street.empty" defaultMessage="Start with an empty street" />
-                </label>
-              </li>
-              {(() => {
-                // Display this button only if there is a previous street to copy
-                // from that is not the same as the current street
-                if (this.props.priorLastStreetId && this.props.priorLastStreetId !== this.props.street.id) {
-                  return (
-                    <li>
-                      <input
-                        type="radio"
-                        name="new-street"
-                        id="new-street-last"
-                        checked={this.state.selectedNewStreetType === 'new-street-last'}
-                        onChange={this.onChangeNewStreetType}
-                        onClick={this.props.getLastStreet}
-                      />
-                      <label htmlFor="new-street-last">
-                        <FormattedMessage id="dialogs.new-street.last" defaultMessage="Start with a copy of last street" />
-                      </label>
-                    </li>
-                  )
-                }
-
-                return null
-              })()}
-            </ul>
-          </div>
-        )
-
+        welcomeContent = <WelcomeNewStreet />
         break
       default:
         welcomeContent = null
@@ -358,8 +267,7 @@ function mapStateToProps (state) {
 
 const mapDispatchToProps = {
   hideStreetNameCanvas,
-  showStreetNameCanvas,
-  getLastStreet
+  showStreetNameCanvas
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(WelcomePanel)

--- a/assets/scripts/app/WelcomePanel.scss
+++ b/assets/scripts/app/WelcomePanel.scss
@@ -14,10 +14,6 @@ $welcome-panel-box-shadow: $medium-box-shadow;
   text-align: center;
   user-select: none;
   pointer-events: none;
-
-  &:not(.visible) {
-    display: none;
-  }
 }
 
 .welcome-panel {

--- a/assets/scripts/app/WelcomePanel/FirstTimeExistingStreet.jsx
+++ b/assets/scripts/app/WelcomePanel/FirstTimeExistingStreet.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
+import StreetName from '../../streets/StreetName'
+import Avatar from '../../users/Avatar'
+import { goNewStreet } from '../routing'
+import { setSettingsWelcomeDismissed } from '../WelcomePanel'
+
+FirstTimeExistingStreet.propTypes = {
+  street: PropTypes.object.isRequired
+}
+
+function FirstTimeExistingStreet (props) {
+  const street = props.street
+
+  return (
+    <div className="welcome-panel-content first-time-existing-street">
+      <h1>
+        <FormattedMessage
+          id="dialogs.welcome.heading"
+          defaultMessage="Welcome to Streetmix."
+        />
+      </h1>
+      {/* Enclose child elements in a paragraph-like <div> to get around
+          React's warning that <div> elements from StreetName and
+          Avatar components cannot exist inside a <p> */}
+      <div className="paragraph">
+        {/* Display street creator if creatorId is available. */}
+        {(street.creatorId) ? (
+          <FormattedMessage
+            id="dialogs.welcome.existing.intro"
+            defaultMessage="This is {streetName} made by {creator}."
+            values={{
+              streetName: <StreetName name={street.name} />,
+              creator: (
+                <React.Fragment>
+                  <Avatar userId={street.creatorId} /> {street.creatorId}
+                </React.Fragment>
+              )
+            }}
+          />
+        ) : (
+          <FormattedMessage
+            id="dialogs.welcome.existing.intro-without-creator"
+            defaultMessage="This is {streetName}."
+            values={{
+              streetName: <StreetName name={street.name} />
+            }}
+          />
+        )}
+      </div>
+      <p className="important">
+        <FormattedMessage
+          id="dialogs.welcome.existing.instruct"
+          defaultMessage="Remix it by moving some segments around, or {startYourOwnStreet}."
+          values={{
+            startYourOwnStreet: (
+              <button onClick={onClickGoNewStreet}>
+                <FormattedMessage
+                  id="dialogs.welcome.existing.instruct-start-own-street"
+                  defaultMessage="Start your own street"
+                />
+              </button>
+            )
+          }}
+        />
+      </p>
+    </div>
+  )
+}
+
+function mapStateToProps (state) {
+  return {
+    street: state.street
+  }
+}
+
+export default connect(mapStateToProps)(FirstTimeExistingStreet)
+
+function onClickGoNewStreet (event) {
+  setSettingsWelcomeDismissed()
+  goNewStreet(true)
+}

--- a/assets/scripts/app/WelcomePanel/FirstTimeNewStreet.jsx
+++ b/assets/scripts/app/WelcomePanel/FirstTimeNewStreet.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
+
+FirstTimeNewStreet.propTypes = {
+  touch: PropTypes.bool
+}
+
+FirstTimeNewStreet.defaultProps = {
+  touch: false
+}
+
+function FirstTimeNewStreet (props) {
+  return (
+    <div className="welcome-panel-content first-time-new-street">
+      <h1>
+        <FormattedMessage
+          id="dialogs.welcome.heading"
+          defaultMessage="Welcome to Streetmix."
+        />
+      </h1>
+      <p>
+        <FormattedMessage
+          id="dialogs.welcome.new.intro"
+          defaultMessage="Design, remix, and share your neighborhood street.
+            Add trees or bike paths, widen sidewalks or traffic lanes, learn
+            how your decisions can impact your community."
+        />
+      </p>
+      <p className="important">
+        <FormattedMessage
+          id="dialogs.welcome.new.instruct"
+          defaultMessage="Start by moving some segments around with {pointer}."
+          values={{
+            pointer: (props.touch)
+              ? (
+                <FormattedMessage
+                  id="dialogs.welcome.new.instruct-pointer-finger"
+                  defaultMessage="your finger"
+                />
+              ) : (
+                <FormattedMessage
+                  id="dialogs.welcome.new.instruct-pointer-mouse"
+                  defaultMessage="your mouse"
+                />
+              )
+          }}
+        />
+      </p>
+    </div>
+  )
+}
+
+function mapStateToProps (state) {
+  return {
+    touch: state.system.touch
+  }
+}
+
+export default connect(mapStateToProps)(FirstTimeNewStreet)

--- a/assets/scripts/app/WelcomePanel/NewStreet.jsx
+++ b/assets/scripts/app/WelcomePanel/NewStreet.jsx
@@ -1,0 +1,125 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { FormattedMessage } from 'react-intl'
+import {
+  NEW_STREET_DEFAULT,
+  NEW_STREET_EMPTY,
+  onNewStreetDefaultClick,
+  onNewStreetEmptyClick
+} from '../../streets/creation'
+import { getLastStreet } from '../../store/actions/street'
+
+NewStreet.propTypes = {
+  newStreetPreference: PropTypes.number,
+  priorLastStreetId: PropTypes.string,
+  street: PropTypes.object,
+  getLastStreet: PropTypes.func
+}
+
+NewStreet.defaultProps = {
+  priorLastStreetId: null
+}
+
+function NewStreet (props) {
+  // If welcomeType is WELCOME_NEW_STREET, there is an additional state
+  // property that determines which of the new street modes is selected
+  let selectedNewStreetType
+  switch (props.newStreetPreference) {
+    case NEW_STREET_EMPTY:
+      selectedNewStreetType = 'new-street-empty'
+      break
+    case NEW_STREET_DEFAULT:
+    default:
+      selectedNewStreetType = 'new-street-default'
+      break
+  }
+
+  const [ state, setState ] = useState({ selectedNewStreetType })
+
+  // Handles changing the "checked" state of the input buttons.
+  function onChangeNewStreetType (event) {
+    setState({
+      selectedNewStreetType: event.target.id
+    })
+  }
+
+  return (
+    <div className="welcome-panel-content new-street">
+      <h1>
+        <FormattedMessage
+          id="dialogs.new-street.heading"
+          defaultMessage="Here’s your new street."
+        />
+      </h1>
+      <ul>
+        <li>
+          <input
+            type="radio"
+            name="new-street"
+            id="new-street-default"
+            checked={state.selectedNewStreetType === 'new-street-default' || !state.selectedNewStreetType}
+            onChange={onChangeNewStreetType}
+            onClick={onNewStreetDefaultClick}
+          />
+          <label htmlFor="new-street-default">
+            <FormattedMessage
+              id="dialogs.new-street.default"
+              defaultMessage="Start with an example street"
+            />
+          </label>
+        </li>
+        <li>
+          <input
+            type="radio"
+            name="new-street"
+            id="new-street-empty"
+            checked={state.selectedNewStreetType === 'new-street-empty'}
+            onChange={onChangeNewStreetType}
+            onClick={onNewStreetEmptyClick}
+          />
+          <label htmlFor="new-street-empty">
+            <FormattedMessage
+              id="dialogs.new-street.empty"
+              defaultMessage="Start with an empty street"
+            />
+          </label>
+        </li>
+        {/* Display this button only if there is a previous street to copy
+            from that is not the same as the current street */}
+        {(props.priorLastStreetId && props.priorLastStreetId !== props.street.id) && (
+          <li>
+            <input
+              type="radio"
+              name="new-street"
+              id="new-street-last"
+              checked={state.selectedNewStreetType === 'new-street-last'}
+              onChange={onChangeNewStreetType}
+              onClick={props.getLastStreet}
+            />
+            <label htmlFor="new-street-last">
+              <FormattedMessage
+                id="dialogs.new-street.last"
+                defaultMessage="Start with a copy of last street"
+              />
+            </label>
+          </li>
+        )}
+      </ul>
+    </div>
+  )
+}
+
+function mapStateToProps (state) {
+  return {
+    newStreetPreference: state.settings.newStreetPreference,
+    priorLastStreetId: state.settings.priorLastStreetId,
+    street: state.street
+  }
+}
+
+const mapDispatchToProps = {
+  getLastStreet
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(NewStreet)

--- a/assets/scripts/app/__tests__/WelcomePanel.test.js
+++ b/assets/scripts/app/__tests__/WelcomePanel.test.js
@@ -10,8 +10,8 @@ import apiClient from '../../util/api'
 import { everythingLoaded } from '../../store/actions/app'
 
 jest.mock('../mode')
+jest.mock('../keypress')
 jest.mock('../../users/authentication')
-jest.mock('../../users/settings')
 
 describe('WelcomePanel', () => {
   let apiMock

--- a/assets/scripts/app/initialization.js
+++ b/assets/scripts/app/initialization.js
@@ -136,8 +136,6 @@ function onEverythingLoaded () {
   showConsoleMessage()
 
   store.dispatch(everythingLoaded())
-  // TODO: Only the WelcomePanel needs this event; refactor it out.
-  window.dispatchEvent(new window.CustomEvent('stmx:everything_loaded'))
 
   if (debug.forceLiveUpdate) {
     scheduleNextLiveUpdateCheck()

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -416,7 +416,6 @@ export function fetchLastStreet () {
 }
 
 function cancelReceiveLastStreet () {
-  document.querySelector('#new-street-default').checked = true
   makeDefaultStreet()
 }
 


### PR DESCRIPTION
The `<WelcomePanel />` component is very large. It has three different view states (not counting the "display nothing" state), each of which has subtly different logic and dependencies. By splitting each of the display states into separate view components, we can extract out all the portions of the original mega-component that isn't shared between the different view states.

Furthermore, I remove the `visible` state variable, and the use of the `stmx:everything_loaded` event to tell `<WelcomePanel />` when to display. By refactoring the rendering lifecycle of the component, it fixes an existing test that always passes.