### PR TITLE
perf: Tweak cloud positioning.

### DIFF
--- a/assets/scripts/app/SkyBackground.jsx
+++ b/assets/scripts/app/SkyBackground.jsx
@@ -6,6 +6,9 @@ import { getEnvirons, makeCSSGradientDeclaration } from '../streets/environs'
 import { DEFAULT_ENVIRONS } from '../streets/constants'
 import './SkyBackground.scss'
 
+const REAR_CLOUD_PARALLAX_SPEED = 0.25
+const FRONT_CLOUD_PARALLAX_SPEED = 0.5
+
 export class SkyBackground extends React.PureComponent {
   static propTypes = {
     scrollPos: PropTypes.number,
@@ -45,20 +48,12 @@ export class SkyBackground extends React.PureComponent {
     }, 0)
   }
 
-  transformSkyBackground = (isFront, scrollPos) => {
-    let style = ''
-
-    if (isFront) {
-      const frontPos = -scrollPos * 0.5
-      style = 'translateX(' + frontPos + 'px)'
-    } else {
-      const rearPos = -scrollPos * 0.25
-      style = 'translateX(' + rearPos + 'px)'
-    }
+  getCloudPosition = (isFront, scrollPos) => {
+    const speed = isFront ? FRONT_CLOUD_PARALLAX_SPEED : REAR_CLOUD_PARALLAX_SPEED
+    const pos = scrollPos * speed
 
     return {
-      WebkitTransform: style,
-      transform: style
+      backgroundPosition: `-${pos}px 0`
     }
   }
 
@@ -71,11 +66,11 @@ export class SkyBackground extends React.PureComponent {
       height: `${height}px`
     }
     const frontCloudStyle = {
-      ...this.transformSkyBackground(true, scrollPos),
+      ...this.getCloudPosition(true, scrollPos),
       opacity: environs.cloudOpacity || null
     }
     const rearCloudStyle = {
-      ...this.transformSkyBackground(false, scrollPos),
+      ...this.getCloudPosition(false, scrollPos),
       opacity: environs.cloudOpacity || null
     }
 

--- a/assets/scripts/app/SkyBackground.scss
+++ b/assets/scripts/app/SkyBackground.scss
@@ -3,7 +3,7 @@
 .street-section-sky {
   position: absolute;
   left: 0;
-  right: -2000px; // TODO hack - this makes the sky wide enough for 400' streets - sky scrolls with the street
+  right: 0;
   top: -70px; // Space for scrolling down when gallery open
   pointer-events: none;
   opacity: 1;

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -193,7 +193,8 @@ class StreetView extends React.Component {
       const scrollIndicators = this.calculateScrollIndicators()
 
       this.setState({
-        ...scrollIndicators
+        ...scrollIndicators,
+        scrollPos: this.getStreetScrollPosition()
       })
     })
   }
@@ -271,6 +272,10 @@ class StreetView extends React.Component {
     })
   }
 
+  getStreetScrollPosition = () => {
+    return (this.streetSectionEl.current && this.streetSectionEl.current.scrollLeft) || 0
+  }
+
   /**
    * Updates a segment or building's CSS `perspective-origin` property according
    * to its current position in the street and on the screen, which is used
@@ -284,7 +289,7 @@ class StreetView extends React.Component {
     if (!el) return
 
     const pos = getElAbsolutePos(el)
-    const scrollPos = (this.streetSectionEl.current && this.streetSectionEl.current.scrollLeft) || 0
+    const scrollPos = this.getStreetScrollPosition()
     const perspective = -(pos[0] - scrollPos - (this.props.system.viewportWidth / 2))
 
     el.style.webkitPerspectiveOrigin = (perspective / 2) + 'px 50%'
@@ -325,7 +330,7 @@ class StreetView extends React.Component {
           </section>
         </section>
         <SkyBackground
-          scrollPos={this.streetSectionEl.current && this.streetSectionEl.current.scrollLeft}
+          scrollPos={this.state.scrollPos}
           height={this.state.skyHeight}
         />
         <ScrollIndicators

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -8,7 +8,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { throttle } from 'lodash'
 import StreetEditable from './StreetEditable'
 import StreetViewDirt from './StreetViewDirt'
 import SkyBackground from './SkyBackground'
@@ -183,17 +182,21 @@ class StreetView extends React.Component {
   }
 
   /**
-   * Event handler for street scrolling. Throttled to update at 60fps.
+   * Event handler for street scrolling.
    */
-  handleStreetScroll = throttle((event) => {
+  handleStreetScroll = (event) => {
     infoBubble.suppress()
 
-    const scrollIndicators = this.calculateScrollIndicators()
+    // Place all scroll-based positioning effects inside of a "raf"
+    // callback for better performance.
+    window.requestAnimationFrame(() => {
+      const scrollIndicators = this.calculateScrollIndicators()
 
-    this.setState({
-      ...scrollIndicators
+      this.setState({
+        ...scrollIndicators
+      })
     })
-  }, 16)
+  }
 
   /**
    * Based on street width and scroll position, determine how many

--- a/assets/scripts/app/__tests__/__snapshots__/SkyBackground.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/SkyBackground.test.js.snap
@@ -38,9 +38,8 @@ exports[`SkyBackground renders 1`] = `
     className="rear-clouds"
     style={
       Object {
-        "WebkitTransform": "translateX(0px)",
+        "backgroundPosition": "-0px 0",
         "opacity": null,
-        "transform": "translateX(0px)",
       }
     }
   />
@@ -48,9 +47,8 @@ exports[`SkyBackground renders 1`] = `
     className="front-clouds"
     style={
       Object {
-        "WebkitTransform": "translateX(0px)",
+        "backgroundPosition": "-0px 0",
         "opacity": null,
-        "transform": "translateX(0px)",
       }
     }
   />


### PR DESCRIPTION
Resolves #1029, but not quite in the way I had originally expected.

The cause of the "scroll-linked positioning effect" warning in Firefox is that we put some rendering calls inside of an `onScroll` handler, and the thing I didn't realize is that we don't actually update the cloud position on the scroll event itself. (We do some other work, and that's what Firefox was complaining about.) This PR removes the warning by placing all the render work inside of a `requestAnimationFrame` call. (A previous attempt at throttling the handler was a crude one, and didn't trick Firefox at all.)

The way the cloud positioning worked is that it would re-render whenever the street's `scrollLeft` property updated, and that was never being throttled in any way. Now, we copy that value inside of the `onScroll` -> `requestAnimationFrame`, so that ideally, cloud positioning is optimized.

Another improvement here is to no longer make the cloud background an arbritary 2000 pixels wide. This was initially done to make the cloud element wide enough for the maximum width of a street, and the CSS transform was applied to the element position itself. Now we fix the element to the viewport width, and transform the CSS background position, which gives the same effect, without having to create a super-large DOM element.

A quick performance check during scroll shows that we do seem to resolve some jank:

Before: (Notice the red indicators of jank on the timeline)
<img width="453" alt="Screenshot 2019-07-22 18 42 11" src="https://user-images.githubusercontent.com/2553268/61670432-a17ca480-acb1-11e9-9eba-71c788ca0906.png">

After: (Notice higher/more consistent FPS - the green graph)
<img width="448" alt="Screenshot 2019-07-22 18 41 12" src="https://user-images.githubusercontent.com/2553268/61670431-a17ca480-acb1-11e9-9631-e991e880132d.png">


