### PR TITLE
fix: use correct react-intl class to format html on error page

### DIFF
--- a/assets/scripts/app/BlockingError.jsx
+++ b/assets/scripts/app/BlockingError.jsx
@@ -212,7 +212,7 @@ export class BlockingError extends React.Component {
         description =
           <React.Fragment>
             <FormattedMessage id="error.auth-api-problem-description" defaultMessage="There was a problem with authentication." />
-            &nbsp;&nbsp;{pleaseLetUsKnow}
+            &nbsp;{pleaseLetUsKnow}
             <br />
             {homeButton}
           </React.Fragment>

--- a/assets/scripts/app/BlockingError.jsx
+++ b/assets/scripts/app/BlockingError.jsx
@@ -44,7 +44,7 @@ export class BlockingError extends React.Component {
       <button onClick={goNewStreet}>
         <FormattedMessage id="error.button.try-again" defaultMessage="Try again" />
       </button>
-    const pleaseLetUsKnow = <FormattedMessage
+    const pleaseLetUsKnow = <FormattedHTMLMessage
       id="error.please-try-again"
       defaultMessage="Please try again later or let us know via <a target='_blank' rel='noopener noreferrer' href='{email}'>email</a> or <a target='_blank' rel='noopener noreferrer' href='{tweet}'>Twitter</a>."
       values={{
@@ -212,7 +212,7 @@ export class BlockingError extends React.Component {
         description =
           <React.Fragment>
             <FormattedMessage id="error.auth-api-problem-description" defaultMessage="There was a problem with authentication." />
-            {pleaseLetUsKnow}
+            &nbsp;&nbsp;{pleaseLetUsKnow}
             <br />
             {homeButton}
           </React.Fragment>
@@ -268,7 +268,7 @@ export class BlockingError extends React.Component {
         description =
           <React.Fragment>
             <FormattedMessage id="error.generic-error-description" defaultMessage="We’re sorry – something went wrong." />
-            {pleaseLetUsKnow}
+            &nbsp;{pleaseLetUsKnow}
             <br />
             {homeButton}
           </React.Fragment>


### PR DESCRIPTION
<img width="1036" alt="Screen Shot 2019-08-06 at 8 42 08 AM" src="https://user-images.githubusercontent.com/15174372/62540657-1ad5d480-b826-11e9-9c8d-5959c364ffd2.png">

Small fix to formatting on our error page