### PR TITLE
refactor: replace pseudo-random number generator

### DIFF
--- a/assets/scripts/palette/Palette.jsx
+++ b/assets/scripts/palette/Palette.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 import Scrollable from '../ui/Scrollable'
 import SegmentForPalette from '../segments/SegmentForPalette'
 import { getAllSegmentInfoArray } from '../segments/info'
+import { generateRandSeed } from '../util/random'
 import './Palette.scss'
 
 class Palette extends React.PureComponent {
@@ -24,6 +25,10 @@ class Palette extends React.PureComponent {
     super(props)
 
     this.scrollable = React.createRef()
+
+    this.state = {
+      randSeed: generateRandSeed()
+    }
   }
 
   /**
@@ -76,6 +81,7 @@ class Palette extends React.PureComponent {
           type={segment.id}
           variantString={variant}
           onPointerOver={this.props.handlePointerOver}
+          randSeed={this.state.randSeed}
         />
       )
     })

--- a/assets/scripts/segments/SegmentForPalette.jsx
+++ b/assets/scripts/segments/SegmentForPalette.jsx
@@ -8,7 +8,6 @@ import { TILE_SIZE } from './constants'
 import { Types, paletteSegmentSource, collectDragSource } from './drag_and_drop'
 import { getSegmentVariantInfo, getSegmentInfo } from './info'
 import { getVariantInfoDimensions } from './view'
-import { generateRandSeed } from '../util/random'
 import './SegmentForPalette.scss'
 
 const PALETTE_SEGMENT_EXTRA_PADDING = 6
@@ -27,7 +26,8 @@ export class SegmentForPalette extends React.Component {
     // Provided by parent
     type: PropTypes.string.isRequired,
     variantString: PropTypes.string.isRequired,
-    onPointerOver: PropTypes.func
+    onPointerOver: PropTypes.func,
+    randSeed: PropTypes.number
   }
 
   componentDidMount = () => {
@@ -80,7 +80,7 @@ export class SegmentForPalette extends React.Component {
           actualWidth={actualWidth}
           type={this.props.type}
           variantString={this.props.variantString}
-          randSeed={generateRandSeed()}
+          randSeed={this.props.randSeed}
           multiplier={PALETTE_SEGMENT_MULTIPLIER}
           groundBaseline={PALETTE_GROUND_BASELINE}
         />

--- a/assets/scripts/segments/__tests__/SegmentForPalette.test.js
+++ b/assets/scripts/segments/__tests__/SegmentForPalette.test.js
@@ -5,12 +5,10 @@ import { createIntl, createIntlCache } from 'react-intl'
 import { SegmentForPalette } from '../SegmentForPalette'
 import { getSegmentInfo, getSegmentVariantInfo } from '../info'
 import { getVariantInfoDimensions } from '../view'
-import { generateRandSeed } from '../../util/random'
 
 jest.mock('../../streets/data_model', () => {})
 jest.mock('../info')
 jest.mock('../view')
-jest.mock('../../util/random')
 
 function connectDropTarget (el) { return el }
 function connectDragSource (el) { return el }
@@ -26,17 +24,16 @@ describe('SegmentForPalette', () => {
 
   beforeEach(() => {
     const dimensions = { left: 100, right: 200 }
-    generateRandSeed.mockImplementation(() => 42)
     getVariantInfoDimensions.mockImplementation(() => dimensions)
   })
   describe('on mount', () => {
     it('connects to drag', () => {
-      shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} />)
+      shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} randSeed={42} />)
       expect(connectDragPreview).toHaveBeenCalledTimes(1)
     })
   })
   it('renders width correctly depending on the dimension', () => {
-    const wrapper = shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} />)
+    const wrapper = shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} randSeed={42} />)
     expect(wrapper).toMatchSnapshot()
   })
   describe('mouseover', () => {
@@ -47,7 +44,7 @@ describe('SegmentForPalette', () => {
       const segment = { nameKey: 'key' }
       getSegmentInfo.mockImplementation(() => segment)
       getSegmentVariantInfo.mockImplementation(() => variant)
-      const wrapper = shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} onPointerOver={onPointerOver} />)
+      const wrapper = shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} onPointerOver={onPointerOver} randSeed={42} />)
       wrapper.simulate('pointerover', event)
       expect(onPointerOver).toHaveBeenCalledTimes(1)
       expect(onPointerOver).toHaveBeenCalledWith(event, 'Variant', 1)
@@ -59,7 +56,7 @@ describe('SegmentForPalette', () => {
       const segment = { name: 'Segment', nameKey: 'key' }
       getSegmentInfo.mockImplementation(() => segment)
       getSegmentVariantInfo.mockImplementation(() => variant)
-      const wrapper = shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} onPointerOver={onPointerOver} />)
+      const wrapper = shallow(<SegmentForPalette connectDropTarget={connectDropTarget} connectDragSource={connectDragSource} connectDragPreview={connectDragPreview} type={''} variantString={''} intl={intl} onPointerOver={onPointerOver} randSeed={42} />)
       wrapper.simulate('pointerover', event)
       expect(onPointerOver).toHaveBeenCalledTimes(1)
       expect(onPointerOver).toHaveBeenCalledWith(event, 'Segment', 1)

--- a/assets/scripts/segments/buildings.js
+++ b/assets/scripts/segments/buildings.js
@@ -1,4 +1,5 @@
-import { RandomGenerator } from '../util/random'
+import seedrandom from 'seedrandom'
+import { generateRandSeed } from '../util/random'
 import { prettifyWidth } from '../util/width_units'
 import { images } from '../app/load_resources'
 import { TILE_SIZE, TILESET_POINT_PER_PIXEL } from '../segments/constants'
@@ -253,11 +254,10 @@ export function drawBuilding (ctx, variant, floors, position, totalWidth, totalH
       multiplier, dpi)
 
     // middle floors
-    const randomGenerator = new RandomGenerator()
-    randomGenerator.seed = 0
+    const randomGenerator = seedrandom(generateRandSeed())
 
     for (let i = 1; i < floors; i++) {
-      const variant = (building.variantsCount === 0) ? 0 : Math.floor(randomGenerator.rand() * building.variantsCount) + 1
+      const variant = (building.variantsCount === 0) ? 0 : Math.floor(randomGenerator() * building.variantsCount) + 1
 
       drawSegmentImage(spriteId, ctx,
         0,

--- a/assets/scripts/segments/people.js
+++ b/assets/scripts/segments/people.js
@@ -1,14 +1,13 @@
 // TODO: Refactor this to have less magic numbers & stuff
+import seedrandom from 'seedrandom'
 import { images } from '../app/load_resources'
-import { RandomGenerator } from '../util/random'
 import { drawSegmentImage } from './view'
 import { getSpriteDef } from './info'
 import { TILE_SIZE, TILE_SIZE_ACTUAL } from './constants'
 import { getVariantArray } from './variant_utils'
 import PEOPLE from './people.json'
 
-// TODO magic number - randSeed defaults to 35: why?
-export function drawProgrammaticPeople (ctx, width, offsetLeft, groundLevel, randSeed = 35, multiplier, variantString, dpi) {
+export function drawProgrammaticPeople (ctx, width, offsetLeft, groundLevel, randSeed, multiplier, variantString, dpi) {
   const people = []
   let peopleWidth = 0
 
@@ -35,8 +34,7 @@ export function drawProgrammaticPeople (ctx, width, offsetLeft, groundLevel, ran
       break
   }
 
-  const randomGenerator = new RandomGenerator()
-  randomGenerator.seed = randSeed + 16 // TODO magic number - randSeed adds 16: why?
+  const randomGenerator = seedrandom(randSeed)
 
   let lastPersonId = 0
 
@@ -44,7 +42,7 @@ export function drawProgrammaticPeople (ctx, width, offsetLeft, groundLevel, ran
     let person
 
     do {
-      const index = Math.floor(randomGenerator.rand() * PEOPLE.length)
+      const index = Math.floor(randomGenerator() * PEOPLE.length)
 
       // Clone the person object
       person = Object.assign({}, PEOPLE[index])
@@ -53,7 +51,7 @@ export function drawProgrammaticPeople (ctx, width, offsetLeft, groundLevel, ran
     lastPersonId = person.id
     person.left = peopleWidth
 
-    var lastWidth = widthConst + (person.width * 12) - 24 + (randomGenerator.rand() * widthRand)
+    var lastWidth = widthConst + (person.width * 12) - 24 + (randomGenerator() * widthRand)
 
     peopleWidth += lastWidth
     people.push(person)

--- a/assets/scripts/util/random.js
+++ b/assets/scripts/util/random.js
@@ -1,27 +1,9 @@
 const MAX_RAND_SEED = 999999999
 
+/**
+ * Returns a random integer between 0 and MAX_RAND_SEED. This value should
+ * always be greater than 0.
+ */
 export function generateRandSeed () {
-  const randSeed = 1 + Math.floor(Math.random() * MAX_RAND_SEED) // So it’s not zero
-  return randSeed
-}
-
-export class RandomGenerator {
-  constructor () {
-    this.randSeed = 0
-  }
-
-  rand () {
-    const t32 = 0x100000000
-    const constant = 134775813
-    const x = (constant * this.randSeed) + 1
-    return (this.randSeed = x % t32) / t32
-  }
-
-  get seed () {
-    return this.randSeed
-  }
-
-  set seed (seed) {
-    this.randSeed = seed
-  }
+  return Math.ceil(Math.random() * MAX_RAND_SEED)
 }

--- a/docs/technical/helpers.rst
+++ b/docs/technical/helpers.rst
@@ -1,0 +1,52 @@
+Helpers and utilities
+=====================
+
+.. warning::
+
+   This page is a work in progress.
+
+
+We use the following utilities to solve common programming problems.
+
+
+Pseudo-random number generator
+------------------------------
+
+If you need a one-time use random number (which will never be stored), there's nothing wrong with JavaScript's built-in ``Math.random()``. However, there are times where we need a **seed** for a pseudo-random number generator (PRNG). Seeds generate a random-*looking* sequence of numbers, but they have the benefit of remaining consistent across renders. For example, this is useful on our sidewalk segment, where we want to generate a random set of pedestrians but we want those pedestrians to remain the same between page refreshes or React component updates.
+
+We can generate seeds by calling ``generateRandSeed()``, then by feeding those seeds into the ``seedrandom`` library:
+
+.. code-block:: javascript
+   :linenos:
+
+    import seedrandom from 'seedrandom'
+    import { generateRandSeed } from './util/random'
+
+    function doThingsWithThePRNG () {
+      const seed = generateRandSeed()
+      const prng1 = seedrandom(seed)
+
+      // Generate pseudo-random numbers. Each time rng() is called, it returns
+      // the next pseudo-random number in the sequence.
+      console.log(prng1()) // -> first pseudo-random number
+      console.log(prng1()) // -> second pseudo-random number
+      // .. etc
+
+      // Create another generator with the same seed
+      const prng2 = seedrandom(seed)
+      console.log(prng2()) // -> same value as the first call to prng1()
+    }
+
+When ``seedrandom()`` is called, it returns a function that will return a consistent sequence of numbers each time it is called, for the given ``seed``. The sequence returned is local to that function. 
+
+.. note::
+
+   Although the ``seed`` can be any type of value, like a string, ``generateRandSeed()`` returns only integer values so that when we store seeds in a data model we can check for type consistency.
+
+In the above example, we call ``seedrandom()`` twice, with the same ``seed``, so that we can create the same sequence of pseudo-random numbers in two different scenarios. This example is contrived because the pseudo-random number generators are used in the same function, and in reality the ``seedrandom()`` call may happen in separate parts of the application.
+
+
+**References**
+
+  - `Random Seeds, Coded Hints, and Quintillions <http://davidbau.com/archives/2010/01/30/random_seeds_coded_hints_and_quintillions.html>`_, *David Bau, 30 January 2010*
+  - `seedrandom.js <https://github.com/davidbau/seedrandom>`_ *[GitHub]*

--- a/docs/technical/index.rst
+++ b/docs/technical/index.rst
@@ -17,3 +17,4 @@ This section describes the architecture of Streetmix.
    project
    tests/index
    segment-definitions
+   helpers

--- a/package-lock.json
+++ b/package-lock.json
@@ -3117,7 +3117,7 @@
     },
     "bluebird": {
       "version": "2.11.0",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
       "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "bn.js": {
@@ -4089,7 +4089,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
     },
     "constant-case": {
       "version": "1.1.2",
@@ -6389,15 +6390,6 @@
         "estraverse": "^4.1.1"
       }
     },
-    "eslint-stats": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-stats/-/eslint-stats-1.0.1.tgz",
-      "integrity": "sha512-5/5v8UvciDsXFNb+e+DMjOX8YZY2l1zpZ8ga3s5pV2CJ/dR0MOFFVXGLItn/jiey+FGBEmCKkFfZlJQra4uQMw==",
-      "requires": {
-        "chalk": "^2.4.1",
-        "lodash": "^4.17.4"
-      }
-    },
     "eslint-utils": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
@@ -7122,7 +7114,7 @@
       "dependencies": {
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -7286,7 +7278,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -7312,6 +7305,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10915,6 +10909,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -10923,12 +10918,14 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },
@@ -14638,6 +14635,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
       "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio="
+    },
+    "seedrandom": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.1.tgz",
+      "integrity": "sha512-1/02Y/rUeU1CJBAGLebiC5Lbo5FnB22gQbIFFYTLkwvp1xdABZJH1sn4ZT1MzXmPpzv+Rf/Lu2NcsLJiK4rcDg=="
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "regenerator-runtime": "0.13.2",
     "requireindex": "1.2.0",
     "sass": "1.22.9",
+    "seedrandom": "3.0.1",
     "sequelize": "5.10.1",
     "sequelize-cli": "5.5.0",
     "shifty": "2.8.0",


### PR DESCRIPTION
I've been doing a lot of learning on how seeding pseudo-random number generation works, and looked into how we implement it here, which has been largely untouched (besides some language refactors) since 2013. In particular, I wanted to know why the random seeds are occasionally modified with magic numbers (and the short answer is: no good reason, at least not anymore, so we can remove those parts of the code).

Furthermore I found the `seedrandom` package which seems to be really well made as a PRNG utility, so in this PR I propose we start using it. There is one more dependency as a result, but the alternative is to vendor it into the code directly, and in any case I don't think we need our own implementation of it (however simple). The other tradeoff from migrating to this package is that it does change the result of existing random seeds. It only affects the layout of people on sidewalks right now, and if there is anyone out there that was relying on specific seeds for a specific mix of people they're in for a bad time. But I think that'll be a really rare case and in people can always re-roll pedestrians.