### PR TITLE
feat(colors): add scss variables for brand colors

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -41,6 +41,36 @@ $street-name-background:    white;
 $hr-colour:                 darken($ui-colour, 10%);
 $control-disabled-colour:   gray;
 
+// Brand colours
+$colour-emerald-700:        rgb(12, 62, 22);
+$colour-emerald-600:        rgb(35, 113, 55);
+$colour-emerald-500:        rgb(35, 144, 80);
+$colour-emerald-400:        rgb(95, 192, 127);
+$colour-emerald-300:        rgb(149, 218, 170);
+$colour-emerald-200:        rgb(201, 236, 210);
+$colour-emerald-100:        rgb(231, 247, 234);
+$colour-turquoise-700:      rgb(23, 68, 70);
+$colour-turquoise-600:      rgb(51, 108, 113);
+$colour-turquoise-500:      rgb(86, 162, 174);
+$colour-turquoise-400:      rgb(139, 193, 205);
+$colour-turquoise-300:      rgb(194, 235, 246);
+$colour-turquoise-200:      rgb(221, 243, 249);
+$colour-turquoise-100:      rgb(235, 249, 252);
+$colour-copper-700:         rgb(85, 34, 19);
+$colour-copper-600:         rgb(136, 69, 44);
+$colour-copper-500:         rgb(180, 109, 76);
+$colour-copper-400:         rgb(214, 141, 104);
+$colour-copper-300:         rgb(247, 184, 147);
+$colour-copper-200:         rgb(248, 213, 193);
+$colour-copper-100:         rgb(249, 238, 232);
+$colour-midnight-700:       rgb(24, 38, 72);
+$colour-midnight-600:       rgb(54, 68, 117);
+$colour-midnight-500:       rgb(84, 101, 143);
+$colour-midnight-400:       rgb(124, 140, 172);
+$colour-midnight-300:       rgb(166, 178, 200);
+$colour-midnight-200:       rgb(212, 219, 231);
+$colour-midnight-100:       rgb(230, 235, 244);
+
 // Layered UI box shadows
 $light-box-shadow:          0 0 14px 0 rgba(0, 0, 0, 0.075);
 $medium-box-shadow:         0 0 10px 0 rgba(0, 0, 0, 0.1);

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -444,37 +444,37 @@ h1, h2, h3, h4, h5, h6, .rst-content .toctree-wrapper p.caption, legend {
   color: #562211;
 }
 
-.stmx-brand-color-slate-700 {
+.stmx-brand-color-midnight-700 {
   background-color: #182549;
   color: #e6ebf4;
 }
 
-.stmx-brand-color-slate-600 {
+.stmx-brand-color-midnight-600 {
   background-color: #354377;
   color: #e6ebf4;
 }
 
-.stmx-brand-color-slate-500 {
+.stmx-brand-color-midnight-500 {
   background-color: #536491;
   color: #e6ebf4;
 }
 
-.stmx-brand-color-slate-400 {
+.stmx-brand-color-midnight-400 {
   background-color: #7b8bad;
   color: #e6ebf4;
 }
 
-.stmx-brand-color-slate-300 {
+.stmx-brand-color-midnight-300 {
   background-color: #a6b2c9;
   color: #182549;
 }
 
-.stmx-brand-color-slate-200 {
+.stmx-brand-color-midnight-200 {
   background-color: #d4dbe8;
   color: #182549;
 }
 
-.stmx-brand-color-slate-100 {
+.stmx-brand-color-midnight-100 {
   background-color: #e6ebf4;
   color: #182549;
 }

--- a/docs/contributing/ui/index.rst
+++ b/docs/contributing/ui/index.rst
@@ -213,10 +213,10 @@ Copper
    #f9eee8
 
 
-Slate
-~~~~~
+Midnight
+~~~~~~~~
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-700
+.. container:: stmx-color-swatch stmx-brand-color-midnight-700
 
    | **700**
    | **R** 24
@@ -225,7 +225,7 @@ Slate
 
    #182549
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-600
+.. container:: stmx-color-swatch stmx-brand-color-midnight-600
 
    | **600**
    | **R** 54
@@ -234,7 +234,7 @@ Slate
 
    #354377
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-500
+.. container:: stmx-color-swatch stmx-brand-color-midnight-500
 
    | **500**
    | **R** 84
@@ -243,7 +243,7 @@ Slate
 
    #536491
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-400
+.. container:: stmx-color-swatch stmx-brand-color-midnight-400
 
    | **400**
    | **R** 124
@@ -252,7 +252,7 @@ Slate
 
    #7b8bad
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-300
+.. container:: stmx-color-swatch stmx-brand-color-midnight-300
 
    | **300**
    | **R** 166
@@ -261,7 +261,7 @@ Slate
 
    #a6b2c9
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-200
+.. container:: stmx-color-swatch stmx-brand-color-midnight-200
 
    | **200**
    | **R** 212
@@ -270,7 +270,7 @@ Slate
 
    #d4dbe8
 
-.. container:: stmx-color-swatch stmx-brand-color-slate-100
+.. container:: stmx-color-swatch stmx-brand-color-midnight-100
 
    | **100**
    | **R** 230


### PR DESCRIPTION
Add the new colors from here: https://streetmix.readthedocs.io/en/latest/contributing/ui/

Naming SCSS variables with the British form of `colour` is a tradition from the beginning of the project 😎