### PR TITLE
A pretty good refactor

### DIFF
--- a/assets/scripts/palette/UndoRedo.jsx
+++ b/assets/scripts/palette/UndoRedo.jsx
@@ -1,52 +1,38 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { FormattedMessage } from 'react-intl'
+import { useIntl } from 'react-intl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ICON_UNDO, ICON_REDO } from '../ui/icons'
 import { undo, redo } from '../store/actions/undo'
 import { isUndoAvailable, isRedoAvailable } from '../streets/undo_stack'
 
-export class UndoRedo extends React.Component {
-  static propTypes = {
-    undoPosition: PropTypes.number,
-    undoStack: PropTypes.array,
-    undo: PropTypes.func,
-    redo: PropTypes.func
-  }
+const UndoRedo = (props) => {
+  const intl = useIntl()
 
-  shouldComponentUpdate (nextProps) {
-    return nextProps.undoPosition !== this.props.undoPosition || nextProps.undoStack !== this.props.undoStack
-  }
+  return (
+    <>
+      <button
+        onClick={props.undo}
+        disabled={!isUndoAvailable()}
+        title={intl.formatHTMLMessage({ id: 'btn.undo', defaultMessage: 'Undo' })}
+      >
+        <FontAwesomeIcon icon={ICON_UNDO} />
+      </button>
+      <button
+        onClick={props.redo}
+        disabled={!isRedoAvailable()}
+        title={intl.formatHTMLMessage({ id: 'btn.redo', defaultMessage: 'Redo' })}
+      >
+        <FontAwesomeIcon icon={ICON_REDO} />
+      </button>
+    </>
+  )
+}
 
-  render () {
-    return (
-      <React.Fragment>
-        <FormattedMessage id="btn.undo" defaultMessage="Undo">
-          {(title) => (
-            <button
-              onClick={this.props.undo}
-              disabled={!isUndoAvailable()}
-              title={title}
-            >
-              <FontAwesomeIcon icon={ICON_UNDO} />
-            </button>
-          )}
-        </FormattedMessage>
-        <FormattedMessage id="btn.redo" defaultMessage="Redo">
-          {(title) => (
-            <button
-              onClick={this.props.redo}
-              disabled={!isRedoAvailable()}
-              title={title}
-            >
-              <FontAwesomeIcon icon={ICON_REDO} />
-            </button>
-          )}
-        </FormattedMessage>
-      </React.Fragment>
-    )
-  }
+UndoRedo.propTypes = {
+  undo: PropTypes.func,
+  redo: PropTypes.func
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/palette/UndoRedo.jsx
+++ b/assets/scripts/palette/UndoRedo.jsx
@@ -4,25 +4,35 @@ import { connect } from 'react-redux'
 import { useIntl } from 'react-intl'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ICON_UNDO, ICON_REDO } from '../ui/icons'
+import { getRemixOnFirstEdit } from '../streets/remix'
 import { undo, redo } from '../store/actions/undo'
-import { isUndoAvailable, isRedoAvailable } from '../streets/undo_stack'
 
 const UndoRedo = (props) => {
   const intl = useIntl()
+
+  // Don’t allow undo/redo unless you own the street
+  // TODO: We need a better function name than `getRemixOnFirstEdit`
+  function isUndoAvailable () {
+    return (props.undoPosition > 0) && !getRemixOnFirstEdit()
+  }
+
+  function isRedoAvailable () {
+    return (props.undoPosition >= 0 && props.undoPosition < props.undoStack.length - 1) && !getRemixOnFirstEdit()
+  }
 
   return (
     <>
       <button
         onClick={props.undo}
         disabled={!isUndoAvailable()}
-        title={intl.formatHTMLMessage({ id: 'btn.undo', defaultMessage: 'Undo' })}
+        title={intl.formatMessage({ id: 'btn.undo', defaultMessage: 'Undo' })}
       >
         <FontAwesomeIcon icon={ICON_UNDO} />
       </button>
       <button
         onClick={props.redo}
         disabled={!isRedoAvailable()}
-        title={intl.formatHTMLMessage({ id: 'btn.redo', defaultMessage: 'Redo' })}
+        title={intl.formatMessage({ id: 'btn.redo', defaultMessage: 'Redo' })}
       >
         <FontAwesomeIcon icon={ICON_REDO} />
       </button>
@@ -31,8 +41,10 @@ const UndoRedo = (props) => {
 }
 
 UndoRedo.propTypes = {
-  undo: PropTypes.func,
-  redo: PropTypes.func
+  undoPosition: PropTypes.number.isRequired,
+  undoStack: PropTypes.array.isRequired,
+  undo: PropTypes.func.isRequired,
+  redo: PropTypes.func.isRequired
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/palette/__tests__/UndoRedo.test.js
+++ b/assets/scripts/palette/__tests__/UndoRedo.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import React from 'react'
-import { cleanup } from '@testing-library/react'
+import { cleanup, fireEvent } from '@testing-library/react'
 import { renderWithReduxAndIntl } from '../../../../test/helpers/render'
 import UndoRedo from '../UndoRedo'
 import { replaceUndoStack } from '../../store/actions/undo'
@@ -37,8 +37,8 @@ describe('UndoRedo', () => {
     expect(undoButton.disabled).toEqual(true)
     expect(redoButton.disabled).toEqual(true)
 
-    // Update undo stack state, and `<UndoRedo>` should receive new props
-    // This is akin to a user editing the street once
+    // Update undo stack state from "elsewhere", and `<UndoRedo>` should
+    // receive new props. This is akin to a user editing the street once
     wrapper.store.dispatch(replaceUndoStack([{ foo: 'bar' }], 1))
 
     // Undo button state should become enabled
@@ -63,5 +63,41 @@ describe('UndoRedo', () => {
     // In this scenario, redo is available, but undo is not.
     expect(wrapper.getByTitle('Undo').disabled).toEqual(true)
     expect(wrapper.getByTitle('Redo').disabled).toEqual(false)
+  })
+
+  it('calls undo action when undo button is clicked', () => {
+    const wrapper = renderWithReduxAndIntl(<UndoRedo />, {
+      initialState: {
+        undo: {
+          stack: [
+            { foo: 'bar' },
+            { foo: 'baz' }
+          ],
+          position: 1
+        }
+      }
+    })
+
+    // Expect the undo position to decrement when undo button is clicked
+    fireEvent.click(wrapper.getByTitle('Undo'))
+    expect(wrapper.store.getState().undo.position).toEqual(0)
+  })
+
+  it('calls redo action when redo button is clicked', () => {
+    const wrapper = renderWithReduxAndIntl(<UndoRedo />, {
+      initialState: {
+        undo: {
+          stack: [
+            { foo: 'bar' },
+            { foo: 'baz' }
+          ],
+          position: 0
+        }
+      }
+    })
+
+    // Expect the undo position to increment when redo button is clicked
+    fireEvent.click(wrapper.getByTitle('Redo'))
+    expect(wrapper.store.getState().undo.position).toEqual(1)
   })
 })

--- a/assets/scripts/palette/__tests__/__snapshots__/UndoRedo.test.js.snap
+++ b/assets/scripts/palette/__tests__/__snapshots__/UndoRedo.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UndoRedo renders two buttons 1`] = `
+<DocumentFragment>
+  <button
+    disabled=""
+    title="Undo"
+  >
+    <svg
+      class="svg-inline--fa fa-undo"
+    />
+  </button>
+  <button
+    disabled=""
+    title="Redo"
+  >
+    <svg
+      class="svg-inline--fa fa-redo"
+    />
+  </button>
+</DocumentFragment>
+`;

--- a/assets/scripts/streets/__mocks__/undo_stack.js
+++ b/assets/scripts/streets/__mocks__/undo_stack.js
@@ -1,6 +1,0 @@
-/* eslint-env jest */
-
-export const undo = jest.fn()
-export const redo = jest.fn()
-export const isUndoAvailable = jest.fn().mockImplementation(() => true)
-export const isRedoAvailable = jest.fn().mockImplementation(() => false)

--- a/assets/scripts/streets/undo_stack.js
+++ b/assets/scripts/streets/undo_stack.js
@@ -4,7 +4,6 @@ import { trackEvent } from '../app/event_tracking'
 import { hideStatusMessage } from '../app/status_message'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { cancelSegmentResizeTransitions } from '../segments/resizing'
-import { getRemixOnFirstEdit } from './remix'
 import { setUpdateTimeToNow, updateEverything } from './data_model'
 import store from '../store'
 import { updateStreetData } from '../store/actions/street'
@@ -43,19 +42,6 @@ export function createNewUndoIfNecessary (lastStreet, currentStreet) {
   }
 
   store.dispatch(createNewUndo(cloneDeep(lastStreet)))
-}
-
-export function isUndoAvailable () {
-  const undoPosition = getUndoPosition()
-  // Don’t allow undo/redo unless you own the street
-  return (undoPosition > 0) && !getRemixOnFirstEdit()
-}
-
-export function isRedoAvailable () {
-  const undoStack = getUndoStack()
-  const undoPosition = getUndoPosition()
-  // Don’t allow undo/redo unless you own the street
-  return (undoPosition >= 0 && undoPosition < undoStack.length - 1) && !getRemixOnFirstEdit()
 }
 
 export function unifyUndoStack () {


### PR DESCRIPTION
With `react-intl` introducing the `useIntl` hook, I've been looking for opportunities we can use it to further refactor some of our simpler components to function components, because this also creates much simpler component structures where `injectIntl` is no longer needed as a higher-order component. (Relevant issue: https://github.com/streetmix/streetmix/issues/1173)

The `<UndoRedo />` component works great for this, and it dramatically simplifies the component code.

Other refactoring updates:

- `isUndoAvailable()` and `isRedoAvailable()` was previously exported from another module because the `ctrl-z` (etc) key bindings used to rely on them. This is no longer the case, and it only affects the disabled/enabled state of buttons. They've been moved into the component.
- Tests have been refactored to use `react-testing-library`. The previous tests would test implementation directly, which is ouch.
