### PR TITLE
(refactor) use redux dispatch shorthand (part 1)

### DIFF
--- a/assets/scripts/app/PrintContainer.jsx
+++ b/assets/scripts/app/PrintContainer.jsx
@@ -78,11 +78,9 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    startPrinting: () => { dispatch(startPrinting()) },
-    stopPrinting: () => { dispatch(stopPrinting()) }
-  }
+const mapDispatchToProps = {
+  startPrinting,
+  stopPrinting
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(PrintContainer)

--- a/assets/scripts/app/StatusMessage.jsx
+++ b/assets/scripts/app/StatusMessage.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
 import { FormattedMessage } from 'react-intl'
 
 import { doSignIn } from '../users/authentication'
@@ -124,8 +123,6 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return bindActionCreators({ hideStatusMessage, doUndo }, dispatch)
-}
+const mapDispatchToProps = { hideStatusMessage, doUndo }
 
 export default connect(mapStateToProps, mapDispatchToProps)(StatusMessage)

--- a/assets/scripts/dialogs/Geotag/GeoSearch.jsx
+++ b/assets/scripts/dialogs/Geotag/GeoSearch.jsx
@@ -132,10 +132,6 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    setMapState: (...args) => { dispatch(setMapState(...args)) }
-  }
-}
+const mapDispatchToProps = { setMapState }
 
 export default connect(mapStateToProps, mapDispatchToProps)(GeoSearchWithIntl)

--- a/assets/scripts/dialogs/GeotagDialog.jsx
+++ b/assets/scripts/dialogs/GeotagDialog.jsx
@@ -336,14 +336,12 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    setMapState: (...args) => { dispatch(setMapState(...args)) },
-    addLocation: (...args) => { dispatch(addLocation(...args)) },
-    clearLocation: () => { dispatch(clearLocation()) },
-    saveStreetName: (...args) => { dispatch(saveStreetName(...args)) },
-    closeDialog: () => { dispatch(clearDialogs()) }
-  }
+const mapDispatchToProps = {
+  setMapState,
+  addLocation,
+  clearLocation,
+  saveStreetName,
+  clearDialogs
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(GeotagDialogWithIntl)

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -375,10 +375,6 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    setSettings: (settings) => { dispatch(setSettings(settings)) }
-  }
-}
+const mapDispatchToProps = { setSettings }
 
 export default connect(mapStateToProps, mapDispatchToProps)(SaveAsImageDialogWithIntl)

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -544,11 +544,9 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    setInfoBubbleMouseInside: (value) => { dispatch(setInfoBubbleMouseInside(value)) },
-    updateHoverPolygon: (polygon) => { dispatch(updateHoverPolygon(polygon)) }
-  }
+const mapDispatchToProps = {
+  setInfoBubbleMouseInside,
+  updateHoverPolygon
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(InfoBubble)

--- a/assets/scripts/info_bubble/Variants.jsx
+++ b/assets/scripts/info_bubble/Variants.jsx
@@ -226,11 +226,9 @@ function mapStateToProps (state, ownProps) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    setBuildingVariant: (position, variant) => { dispatch(setBuildingVariant(position, variant)) },
-    changeSegmentVariant: (position, set, selection) => { dispatch(changeSegmentVariant(position, set, selection)) }
-  }
+const mapDispatchToProps = {
+  setBuildingVariant,
+  changeSegmentVariant
 }
 
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(Variants))

--- a/assets/scripts/menus/SettingsMenu.jsx
+++ b/assets/scripts/menus/SettingsMenu.jsx
@@ -103,11 +103,9 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    changeLocale: (locale) => dispatch(changeLocale(locale)),
-    clearMenus: () => dispatch(clearMenus())
-  }
+const mapDispatchToProps = {
+  changeLocale,
+  clearMenus
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(SettingsMenu)

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -241,11 +241,9 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    removeBuildingFloor: (...args) => { dispatch(removeBuildingFloor(...args)) },
-    addBuildingFloor: (...args) => { dispatch(addBuildingFloor(...args)) }
-  }
+const mapDispatchToProps = {
+  removeBuildingFloor,
+  addBuildingFloor
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Building)

--- a/assets/scripts/streets/StreetNameCanvas.jsx
+++ b/assets/scripts/streets/StreetNameCanvas.jsx
@@ -134,10 +134,6 @@ function mapStateToProps (state) {
   }
 }
 
-function mapDispatchToProps (dispatch) {
-  return {
-    saveStreetName: (...args) => { dispatch(saveStreetName(...args)) }
-  }
-}
+const mapDispatchToProps = { saveStreetName }
 
 export default injectIntl(connect(mapStateToProps, mapDispatchToProps)(StreetNameCanvas))


### PR DESCRIPTION
See https://github.com/streetmix/streetmix/issues/1175

This is part 1. Part 2 will include a standard treatment of the remaining instances of dispatches with arguments, as per this section of the original issue:

> If a prop is called without arguments, but the dispatch includes its own arguments, the arguments can be moved to the body of the component; or new action creators can be written

(This is coming soon! But we can merge the easy cases right away)