### PR TITLE
test: deprecate enzyme shallow rendering (phase 1)

### DIFF
--- a/assets/scripts/app/__tests__/DateTimeRelative.test.js
+++ b/assets/scripts/app/__tests__/DateTimeRelative.test.js
@@ -1,58 +1,60 @@
 /* eslint-env jest */
 import React from 'react'
-import { shallow } from 'enzyme'
+import { cleanup } from '@testing-library/react'
 import { advanceTo, clear } from 'jest-date-mock'
-import { mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
+import { renderWithIntl } from '../../../../test/helpers/render'
 import DateTimeRelative from '../DateTimeRelative'
 
 // This will only test `en-US` (default) values. Assume that localized values will
 // be handled accurately by the react-intl implementation.
 
 describe('DateTimeRelative', () => {
-  // Mock global Date object so that Date.now() returns the value we specify
   beforeAll(() => {
+    // Mock global Date object so that Date.now() returns the value we specify
     advanceTo(new Date(1524506400000)) // '2018-04-23T18:00:00.000Z'
   })
 
-  it('renders without crashing', () => {
-    const wrapper = shallow(<DateTimeRelative value={new Date().toISOString()} />)
-    expect(wrapper.exists()).toEqual(true)
-  })
-
-  it('renders "seconds ago" string', () => {
-    const wrapper = mountWithIntl(<DateTimeRelative value={'2018-04-23T17:59:01.000Z'} />)
-    expect(wrapper.text()).toEqual('A few seconds ago')
-  })
-
-  it('renders "minutes ago" string', () => {
-    const wrapper = mountWithIntl(<DateTimeRelative value={'2018-04-23T17:50:01.000Z'} />)
-    expect(wrapper.text()).toEqual('A few minutes ago')
-  })
-
-  it('renders "today at {time}" string', () => {
-    // Pass in timezone as UTC to force it not to use server's time zone
-    const wrapper = mountWithIntl(<DateTimeRelative value={'2018-04-23T12:00:00.000Z'} timezone="UTC" />)
-    expect(wrapper.text()).toEqual('Today at 12:00 PM')
-  })
-
-  it('renders "yesterday at {time}" string', () => {
-    // Pass in timezone as UTC to force it not to use server's time zone
-    const wrapper = mountWithIntl(<DateTimeRelative value={'2018-04-22T06:00:00.000Z'} timezone="UTC" />)
-    expect(wrapper.text()).toEqual('Yesterday at 6:00 AM')
-  })
-
-  it('renders a date that happened this year', () => {
-    const wrapper = mountWithIntl(<DateTimeRelative value={'2018-02-03T18:00:00.000Z'} />)
-    expect(wrapper.text()).toEqual('February 3')
-  })
-
-  it('renders a date in another year', () => {
-    const wrapper = mountWithIntl(<DateTimeRelative value={'2017-10-17T18:00:00.000Z'} />)
-    expect(wrapper.text()).toEqual('October 17, 2017')
-  })
+  afterEach(cleanup)
 
   afterAll(() => {
     // Restore the implementation of global Date object
     clear()
+  })
+
+  it('renders snapshot', () => {
+    const wrapper = renderWithIntl(<DateTimeRelative value={new Date().toISOString()} />)
+    expect(wrapper.asFragment()).toMatchSnapshot()
+  })
+
+  it('renders "seconds ago" string', () => {
+    const wrapper = renderWithIntl(<DateTimeRelative value={'2018-04-23T17:59:01.000Z'} />)
+    expect(wrapper.container).toHaveTextContent('A few seconds ago')
+  })
+
+  it('renders "minutes ago" string', () => {
+    const wrapper = renderWithIntl(<DateTimeRelative value={'2018-04-23T17:50:01.000Z'} />)
+    expect(wrapper.container).toHaveTextContent('A few minutes ago')
+  })
+
+  it('renders "today at {time}" string', () => {
+    // Pass in timezone as UTC to force it not to use server's time zone
+    const wrapper = renderWithIntl(<DateTimeRelative value={'2018-04-23T12:00:00.000Z'} timezone="UTC" />)
+    expect(wrapper.container).toHaveTextContent('Today at 12:00 PM')
+  })
+
+  it('renders "yesterday at {time}" string', () => {
+    // Pass in timezone as UTC to force it not to use server's time zone
+    const wrapper = renderWithIntl(<DateTimeRelative value={'2018-04-22T06:00:00.000Z'} timezone="UTC" />)
+    expect(wrapper.container).toHaveTextContent('Yesterday at 6:00 AM')
+  })
+
+  it('renders a date that happened this year', () => {
+    const wrapper = renderWithIntl(<DateTimeRelative value={'2018-02-03T18:00:00.000Z'} />)
+    expect(wrapper.container).toHaveTextContent('February 3')
+  })
+
+  it('renders a date in another year', () => {
+    const wrapper = renderWithIntl(<DateTimeRelative value={'2017-10-17T18:00:00.000Z'} />)
+    expect(wrapper.container).toHaveTextContent('October 17, 2017')
   })
 })

--- a/assets/scripts/app/__tests__/NotificationBar.test.js
+++ b/assets/scripts/app/__tests__/NotificationBar.test.js
@@ -1,70 +1,63 @@
 /* eslint-env jest */
 import React from 'react'
+import { cleanup, fireEvent } from '@testing-library/react'
+import { renderWithIntl } from '../../../../test/helpers/render'
 import NotificationBar from '../NotificationBar'
-import { shallowWithIntl, mountWithIntl } from '../../../../test/helpers/intl-enzyme-test-helper.js'
 
 const TEST_NOTIFICATION = {
   display: true,
   lede: 'Heads up!',
-  text: 'Streetmix will be offline for maintainance on January 1, 2018 at 19:00 GMT.',
+  text: 'Streetmix will be offline for maintainance on January 1, 2025 at 19:00 GMT.',
   link: 'https://twitter.com/streetmix/',
   linkText: 'Follow us on Twitter for updates.'
 }
 
 describe('NotificationBar', () => {
-  it('renders without crashing', () => {
-    const wrapper = shallowWithIntl(<NotificationBar locale="en" notification={TEST_NOTIFICATION} />)
-    expect(wrapper.exists()).toEqual(true)
+  afterEach(cleanup)
+
+  it('renders snapshot', () => {
+    const wrapper = renderWithIntl(<NotificationBar locale="en" notification={TEST_NOTIFICATION} />)
+    expect(wrapper.asFragment()).toMatchSnapshot()
   })
 
   describe('conditions that render nothing', () => {
     it('renders nothing if notification is not provided', () => {
-      const wrapper = mountWithIntl(<NotificationBar locale="en" />)
-      expect(wrapper.html()).toEqual(null)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" />)
+      expect(wrapper.container.firstChild).toBeNull()
     })
 
     it('renders nothing if notification is the empty object', () => {
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={{}} />)
-      expect(wrapper.html()).toEqual(null)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={{}} />)
+      expect(wrapper.container.firstChild).toBeNull()
     })
 
     it('renders nothing if notification’s display property is false', () => {
       const notification = { ...TEST_NOTIFICATION, display: false }
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={notification} />)
-      expect(wrapper.html()).toEqual(null)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={notification} />)
+      expect(wrapper.container.firstChild).toBeNull()
     })
 
     it('renders nothing if notification’s display property is true but has no other properties', () => {
       const notification = { display: true }
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={notification} />)
-      expect(wrapper.html()).toEqual(null)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={notification} />)
+      expect(wrapper.container.firstChild).toBeNull()
     })
 
     it('renders nothing if the locale is not English', () => {
       const notification = { display: true }
-      const wrapper = mountWithIntl(<NotificationBar locale="de" notification={notification} />)
-      expect(wrapper.html()).toEqual(null)
+      const wrapper = renderWithIntl(<NotificationBar locale="de" notification={notification} />)
+      expect(wrapper.container.firstChild).toBeNull()
     })
   })
 
   describe('conditions that render something', () => {
-    it('renders an entire notification', () => {
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={TEST_NOTIFICATION} />)
-      expect(wrapper.find('.notification-bar-intro').text()).toEqual(TEST_NOTIFICATION.lede)
-      expect(wrapper.find('.notification-bar-text').text()).toEqual(TEST_NOTIFICATION.text)
-      expect(wrapper.find('a').prop('href')).toEqual(TEST_NOTIFICATION.link)
-      expect(wrapper.find('a').text()).toEqual(TEST_NOTIFICATION.linkText)
-    })
-
     it('renders only the lede', () => {
       const notification = {
         display: true,
         lede: TEST_NOTIFICATION.lede
       }
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={notification} />)
-      expect(wrapper.find('.notification-bar-intro').text()).toEqual(notification.lede)
-      expect(wrapper.find('.notification-bar-text').exists()).toEqual(false)
-      expect(wrapper.find('a').exists()).toEqual(false)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={notification} />)
+      expect(wrapper.asFragment()).toMatchSnapshot()
     })
 
     it('renders only the notification text', () => {
@@ -72,10 +65,8 @@ describe('NotificationBar', () => {
         display: true,
         text: TEST_NOTIFICATION.text
       }
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={notification} />)
-      expect(wrapper.find('.notification-bar-intro').exists()).toEqual(false)
-      expect(wrapper.find('.notification-bar-text').text()).toEqual(notification.text)
-      expect(wrapper.find('a').exists()).toEqual(false)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={notification} />)
+      expect(wrapper.asFragment()).toMatchSnapshot()
     })
 
     it('renders only the link', () => {
@@ -84,40 +75,25 @@ describe('NotificationBar', () => {
         link: TEST_NOTIFICATION.link,
         linkText: TEST_NOTIFICATION.linkText
       }
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={notification} />)
-      expect(wrapper.find('.notification-bar-intro').exists()).toEqual(false)
-      expect(wrapper.find('.notification-bar-text').exists()).toEqual(false)
-      expect(wrapper.find('a').prop('href')).toEqual(TEST_NOTIFICATION.link)
-      expect(wrapper.find('a').text()).toEqual(TEST_NOTIFICATION.linkText)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={notification} />)
+      expect(wrapper.asFragment()).toMatchSnapshot()
     })
 
-    it('renders placeholder link text', () => {
+    it('renders default link text if no link text is provided', () => {
       const notification = {
         display: true,
         link: TEST_NOTIFICATION.link
       }
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={notification} />)
-      expect(wrapper.find('.notification-bar-intro').exists()).toEqual(false)
-      expect(wrapper.find('.notification-bar-text').exists()).toEqual(false)
-      expect(wrapper.find('a').prop('href')).toEqual(TEST_NOTIFICATION.link)
-      expect(wrapper.find('a').text()).toEqual('More info')
-    })
-
-    it('renders the close button', () => {
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={TEST_NOTIFICATION} />)
-      expect(wrapper.find('.close').exists()).toEqual(true)
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={notification} />)
+      expect(wrapper.getByRole('link')).toHaveTextContent('More info')
     })
   })
 
   describe('dismiss', () => {
-    it.skip('handles clicking the close button', () => {
-      // Apparently, you can't spy on a method declared as a class field property.
-      // Ongoing discussion:
-      // https://github.com/airbnb/enzyme/issues/365
-      const spy = NotificationBar.prototype.onClickDismiss = jest.fn()
-      const wrapper = mountWithIntl(<NotificationBar locale="en" notification={TEST_NOTIFICATION} />)
-      wrapper.find('.close').simulate('click')
-      expect(spy).toHaveBeenCalled()
+    it('is no longer rendered after clicking the close button', () => {
+      const wrapper = renderWithIntl(<NotificationBar locale="en" notification={TEST_NOTIFICATION} />)
+      fireEvent.click(wrapper.getByTitle('Dismiss'))
+      expect(wrapper.queryByText(TEST_NOTIFICATION.lede)).toBeNull()
     })
   })
 })

--- a/assets/scripts/app/__tests__/__snapshots__/DateTimeRelative.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/DateTimeRelative.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateTimeRelative renders snapshot 1`] = `
+<DocumentFragment>
+  <time
+    datetime="2018-04-23T18:00:00.000Z"
+    title="2018-04-23T18:00:00.000Z"
+  >
+    A few seconds ago
+  </time>
+</DocumentFragment>
+`;

--- a/assets/scripts/app/__tests__/__snapshots__/NotificationBar.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/NotificationBar.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotificationBar conditions that render something renders only the lede 1`] = `
+<DocumentFragment>
+  <div
+    class="notification-bar"
+    style="margin-top: -0px;"
+  >
+    <strong
+      class="notification-bar-intro"
+    >
+      Heads up!
+    </strong>
+    <button
+      class="close"
+      title="Dismiss"
+    >
+      <svg
+        class="svg-inline--fa fa-times"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`NotificationBar conditions that render something renders only the link 1`] = `
+<DocumentFragment>
+  <div
+    class="notification-bar"
+    style="margin-top: -0px;"
+  >
+    <a
+      class="notification-bar-link"
+      href="https://twitter.com/streetmix/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Follow us on Twitter for updates.
+    </a>
+    <button
+      class="close"
+      title="Dismiss"
+    >
+      <svg
+        class="svg-inline--fa fa-times"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`NotificationBar conditions that render something renders only the notification text 1`] = `
+<DocumentFragment>
+  <div
+    class="notification-bar"
+    style="margin-top: -0px;"
+  >
+    <span
+      class="notification-bar-text"
+    >
+      Streetmix will be offline for maintainance on January 1, 2025 at 19:00 GMT.
+    </span>
+    <button
+      class="close"
+      title="Dismiss"
+    >
+      <svg
+        class="svg-inline--fa fa-times"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`NotificationBar renders snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="notification-bar"
+    style="margin-top: -0px;"
+  >
+    <strong
+      class="notification-bar-intro"
+    >
+      Heads up!
+    </strong>
+    <span
+      class="notification-bar-text"
+    >
+      Streetmix will be offline for maintainance on January 1, 2025 at 19:00 GMT.
+    </span>
+    <a
+      class="notification-bar-link"
+      href="https://twitter.com/streetmix/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Follow us on Twitter for updates.
+    </a>
+    <button
+      class="close"
+      title="Dismiss"
+    >
+      <svg
+        class="svg-inline--fa fa-times"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -356,10 +356,6 @@ class SaveAsImageDialog extends React.Component {
   }
 }
 
-// Inject Intl via a higher-order component provided by react-intl.
-// Exported so that this component can be tested.
-export const SaveAsImageDialogWithIntl = injectIntl(SaveAsImageDialog)
-
 function mapStateToProps (state) {
   return {
     locale: state.locale.locale,
@@ -377,4 +373,4 @@ function mapStateToProps (state) {
 
 const mapDispatchToProps = { setSettings }
 
-export default connect(mapStateToProps, mapDispatchToProps)(SaveAsImageDialogWithIntl)
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(SaveAsImageDialog))

--- a/assets/scripts/dialogs/__tests__/SaveAsImageDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/SaveAsImageDialog.test.js
@@ -1,7 +1,8 @@
 /* eslint-env jest */
 import React from 'react'
-import { SaveAsImageDialogWithIntl as SaveAsImageDialog } from '../SaveAsImageDialog'
-import { shallowWithIntl as shallow } from '../../../../test/helpers/intl-enzyme-test-helper.js'
+import { cleanup } from '@testing-library/react'
+import { renderWithReduxAndIntl } from '../../../../test/helpers/render'
+import SaveAsImageDialog from '../SaveAsImageDialog'
 
 // Mock dependencies that could break tests
 jest.mock('../../streets/image', () => {
@@ -9,19 +10,31 @@ jest.mock('../../streets/image', () => {
     getStreetImage: () => {}
   }
 })
-jest.mock('../../users/settings', () => {})
+
+const initialState = {
+  locale: {
+    locale: 'en'
+  },
+  settings: {
+    saveAsImageTransparentSky: false,
+    saveAsImageSegmentNamesAndWidths: false,
+    saveAsImageStreetName: false,
+    saveAsImageWatermark: true
+  },
+  street: {
+    name: 'foo'
+  },
+  flags: {
+    SAVE_AS_IMAGE_CUSTOM_DPI: { value: false },
+    EXPORT_WATERMARK: { value: false }
+  }
+}
 
 describe('SaveAsImageDialog', () => {
-  it('renders without crashing', () => {
-    const wrapper = shallow(
-      <SaveAsImageDialog
-        transparentSky={false}
-        segmentNames={false}
-        streetName={false}
-        watermark
-        street={{}}
-      />
-    )
-    expect(wrapper.exists()).toEqual(true)
+  afterEach(cleanup)
+
+  it('renders snapshot', () => {
+    const wrapper = renderWithReduxAndIntl(<SaveAsImageDialog />, { initialState })
+    expect(wrapper.asFragment()).toMatchSnapshot()
   })
 })

--- a/assets/scripts/dialogs/__tests__/__snapshots__/SaveAsImageDialog.test.js.snap
+++ b/assets/scripts/dialogs/__tests__/__snapshots__/SaveAsImageDialog.test.js.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SaveAsImageDialog renders snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="dialog-box-container"
+  >
+    <div
+      class="dialog-box-backdrop"
+    />
+    <div
+      class="dialog-box"
+      role="dialog"
+    >
+      <button
+        class="close"
+        title="Dismiss"
+      >
+        <svg
+          class="svg-inline--fa fa-times"
+        />
+      </button>
+      <div
+        class="save-as-image-dialog"
+      >
+        <header>
+          <h1>
+            Save as image
+          </h1>
+        </header>
+        <div
+          class="dialog-content"
+        >
+          <div
+            class="save-as-image-options"
+          >
+            <div
+              class="checkbox-item"
+            >
+              <input
+                id="checkbox-id-4"
+                type="checkbox"
+                value=""
+              />
+              <label
+                for="checkbox-id-4"
+              >
+                Segment names and widths
+              </label>
+              <svg
+                class="svg-inline--fa fa-check"
+              />
+            </div>
+            <div
+              class="checkbox-item"
+            >
+              <input
+                id="checkbox-id-5"
+                type="checkbox"
+                value=""
+              />
+              <label
+                for="checkbox-id-5"
+              >
+                Street name
+              </label>
+              <svg
+                class="svg-inline--fa fa-check"
+              />
+            </div>
+            <div
+              class="checkbox-item"
+            >
+              <input
+                id="checkbox-id-6"
+                type="checkbox"
+                value=""
+              />
+              <label
+                for="checkbox-id-6"
+              >
+                Transparent sky
+              </label>
+              <svg
+                class="svg-inline--fa fa-check"
+              />
+            </div>
+            <div
+              class="checkbox-item"
+            >
+              <input
+                checked=""
+                disabled=""
+                id="checkbox-id-7"
+                type="checkbox"
+                value=""
+              />
+              <label
+                for="checkbox-id-7"
+              >
+                Watermark
+              </label>
+              <svg
+                class="svg-inline--fa fa-check"
+              />
+            </div>
+          </div>
+          <div
+            class="save-as-image-preview"
+          >
+            <div
+              class="save-as-image-preview-error"
+            >
+              Saving to image is not available on this browser.
+            </div>
+          </div>
+          <div
+            class="save-as-image-download"
+          >
+            <button
+              disabled=""
+            >
+              Save to your computer…
+            </button>
+          </div>
+        </div>
+        <footer>
+          This Streetmix-created image may be reused anywhere, for any purpose, under the 
+          <a
+            href="https://creativecommons.org/licenses/by-sa/4.0/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)‎
+          </a>
+           license.
+        </footer>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/assets/scripts/palette/__tests__/UndoRedo.test.js
+++ b/assets/scripts/palette/__tests__/UndoRedo.test.js
@@ -38,8 +38,8 @@ describe('UndoRedo', () => {
     fireEvent.click(wrapper.getByTitle('Undo'))
 
     // Redo should now be available, but undo is not.
-    expect(wrapper.getByTitle('Undo').disabled).toEqual(true)
-    expect(wrapper.getByTitle('Redo').disabled).toEqual(false)
+    expect(wrapper.getByTitle('Undo')).toBeDisabled()
+    expect(wrapper.getByTitle('Redo')).toBeEnabled()
   })
 
   it('handles clicking redo button', () => {
@@ -60,7 +60,7 @@ describe('UndoRedo', () => {
     fireEvent.click(wrapper.getByTitle('Redo'))
 
     // Undo should now be available, but redo is not.
-    expect(wrapper.getByTitle('Undo').disabled).toEqual(false)
-    expect(wrapper.getByTitle('Redo').disabled).toEqual(true)
+    expect(wrapper.getByTitle('Undo')).toBeEnabled()
+    expect(wrapper.getByTitle('Redo')).toBeDisabled()
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -2899,6 +2899,59 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.1.0.tgz",
+      "integrity": "sha512-cKAONDmJKGJ2DSu6R/+lgA8i8uyZIx4CaOiiK0yMjp+2UecH6kfjunJiy5hfExKMtR74eyzFriqO1w9aTC8VyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.1",
+        "chalk": "^2.4.1",
+        "css": "^2.2.3",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "lodash": "^4.17.11",
+        "pretty-format": "^24.0.0",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "8.0.7",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.7.tgz",
@@ -5109,6 +5162,26 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
       "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -5290,6 +5363,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
       "integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ=="
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssesc": {
       "version": "0.1.0",
@@ -12876,6 +12955,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "assets/scripts",
       "test"
     ],
-    "setupFiles": [
+    "setupFilesAfterEnv": [
       "./test/setup-jest.js"
     ],
     "testPathIgnorePatterns": [
@@ -185,6 +185,7 @@
     "@babel/plugin-proposal-class-properties": "7.5.5",
     "@babel/preset-env": "7.5.4",
     "@babel/preset-react": "7.0.0",
+    "@testing-library/jest-dom": "4.1.0",
     "@testing-library/react": "8.0.7",
     "axios-mock-adapter": "1.17.0",
     "babel-eslint": "10.0.2",

--- a/test/__mocks__/react-transition-group.js
+++ b/test/__mocks__/react-transition-group.js
@@ -1,0 +1,5 @@
+/* eslint-env jest */
+
+export const Transition = jest.fn((props) => props.in ? props.children : null)
+export const CSSTransition = jest.fn((props) => props.in ? props.children : null)
+export const TransitionGroup = jest.fn(({ children }) => children)

--- a/test/setup-jest.js
+++ b/test/setup-jest.js
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom/extend-expect'
 import Enzyme from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import fetch from 'jest-fetch-mock'


### PR DESCRIPTION
As we are slowly adopting [react-testing-library](https://testing-library.com/docs/react-testing-library/intro), we want to replace our current tests in Enzyme and eventually remove Enzyme altogether. (We talk about this in [our docs](https://streetmix.readthedocs.io/en/latest/technical/tests/frontend/components/#component-tests)).

One goal of this transition is to stop shallow rendering. (["Why I Never Use Shallow Rendering"](https://kentcdodds.com/blog/why-i-never-use-shallow-rendering), by Kent Dodds.)

This PR is one step in that direction. It removes most instances of the `shallowWithIntl` helper function (all except one, more on this in the "future work" section below).

## What's changed?

- **New developer dependency.** I add the [`@testing-library/jest-dom`](https://github.com/testing-library/jest-dom) extension to the `expect` assertion library, which provides a number of useful test methods that make assertions more readable.
    - As an example of this usage, the `<UndoRedo />` test now uses `.toBeEnabled()` to test the button state rather than the `disabled=false` attribute directly, which is less readable.
- **Globally mock `react-transition-group`.** We do not need to test the effects of the animation itself, so this component only returns children if it should be displayed, otherwise `null`. This change does not affect any existing tests.
- **Migrate tests using the `shallowWithIntl` helper for Enzyme.** I update the tests for `<DateTimeRelative />`, `<NotificationBar />`, and `<SaveAsImageDialog />`.
    - In the case of `<SaveAsImageDialog />`, it no longer needs to export in two steps to make it testable.

## Future work

This doesn't cover everything, only some of the low-hanging fruit.

- **The `<GeotagDialog />` component still uses `shallowWithIntl`.** We shallow render this component because it's a very complex one, which interacts with a handful of other third-party components, such as Leaflet. This may be an ideal component to use integration tests with Cypress rather than unit-test on its own.
- **Eventually replace all of Enzyme's `shallow` rendering.** We use Enzyme's default `shallow` rendering in many more components. These should be pretty easy to address on their own in follow up commits after this PR is merged.