### PR TITLE
Prefer methods on Number object over global alternatives

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,25 @@
       "error",
       "prefer-double"
     ],
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "isNaN",
+        "message": "Use Number.isNaN() instead of the global isNan()."
+      },
+      {
+        "name": "isFinite",
+        "message": "Use Number.isFinite() instead of the global isFinite()."
+      },
+      {
+        "name": "parseInt",
+        "message": "Use Number.parseInt() instead of the global parseInt()."
+      },
+      {
+        "name": "parseFloat",
+        "message": "Use Number.parseFloat() instead of the global parseFloat()."
+      }
+    ],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn"
   }

--- a/app/resources/v1/street_images.js
+++ b/app/resources/v1/street_images.js
@@ -71,7 +71,7 @@ exports.post = async function (req, res) {
   // 3a) If street is a DEFAULT_STREET or EMPTY_STREET and thumbnail exists, return existing street thumbnail.
   // 3b) If nothing changed since the last street thumbnail upload (based on editCount), return existing street thumbnail.
   const tag = resource && resource.tags && resource.tags[0]
-  const thumbnailSaved = (streetType && resource) || (tag && editCount && parseInt(tag, 10) === editCount)
+  const thumbnailSaved = (streetType && resource) || (tag && editCount && Number.parseInt(tag, 10) === editCount)
 
   // Currently only uploading street thumbnails for initial street render. If not initial street render, only log details.
   if (event !== SAVE_THUMBNAIL_EVENTS.INITIAL && event !== SAVE_THUMBNAIL_EVENTS.TEST) {

--- a/app/resources/v1/streets.js
+++ b/app/resources/v1/streets.js
@@ -251,8 +251,8 @@ exports.get = async function (req, res) {
 exports.find = function (req, res) {
   const creatorId = req.query.creatorId
   const namespacedId = req.query.namespacedId
-  const start = (req.query.start && parseInt(req.query.start, 10)) || 0
-  const count = (req.query.count && parseInt(req.query.count, 10)) || 20
+  const start = (req.query.start && Number.parseInt(req.query.start, 10)) || 0
+  const count = (req.query.count && Number.parseInt(req.query.count, 10)) || 20
 
   const findStreetWithCreatorId = async function (creatorId) {
     let user

--- a/app/resources/v1/streets_pg.js
+++ b/app/resources/v1/streets_pg.js
@@ -278,8 +278,8 @@ exports.get = async function (req, res) {
 exports.find = async function (req, res) {
   const creatorId = req.query.creatorId
   const namespacedId = req.query.namespacedId
-  const start = (req.query.start && parseInt(req.query.start, 10)) || 0
-  const count = (req.query.count && parseInt(req.query.count, 10)) || 20
+  const start = (req.query.start && Number.parseInt(req.query.start, 10)) || 0
+  const count = (req.query.count && Number.parseInt(req.query.count, 10)) || 20
 
   const findStreetWithCreatorId = async function (creatorId) {
     let user

--- a/assets/scripts/app/keypress.js
+++ b/assets/scripts/app/keypress.js
@@ -213,7 +213,7 @@ export function registerKeypress (commands, options, callback) {
       command.originalCommands = originalCommands
 
       // Special case for 'ESC' key; it defaults to global (window) focus
-      if (parseInt(keyCode, 10) === KEYS['esc']) {
+      if (Number.parseInt(keyCode, 10) === KEYS['esc']) {
         command.requireFocusOnBody = false
         command.stopPropagation = true
       }

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -223,7 +223,7 @@ export function fetchStreetForVerification () {
         throw response
       }
 
-      const requestId = parseInt(response.headers.get('X-Streetmix-Request-Id'), 10)
+      const requestId = Number.parseInt(response.headers.get('X-Streetmix-Request-Id'), 10)
 
       if (requestId !== latestRequestId) {
         throw new Error('1')


### PR DESCRIPTION
Question: are the messages I put into the ESLint rules too much, or is it valuable context?

---

Updated for context.

ECMAScript 2015 modularizes the following global number checking functions onto the global object `Number`:

- [`isNaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN)
- [`isFinite`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite)
- [`parseInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt)
- [`parseFloat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat)

In particular, `Number.isNaN` and `Number.isFinite` behave slightly differently from their global counterparts: they won't coerce inputs to values that will return `true` despite not actually being of the correct type. This improvement makes it important to use the updated functions whenever possible.

`Number.parseInt` and `Number.parseFloat` remain functionally identical to their global counterparts. However, we take their inclusion onto the `Number` object as a signal that we should begin referring to them there.

ESLint does not provide its own rule against prohibiting these globals, opting instead for projects to use the generic `no-restricted-globals` rule to write their own rules.