### PR TITLE
Bug fixes for segment capacity

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -5,7 +5,7 @@ import { DragSource, DropTarget } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
 import flow from 'lodash/flow'
 import { CSSTransition } from 'react-transition-group'
-import { getSegmentCapacity, formatCapacity } from '../util/street_analytics'
+import { getSegmentCapacity } from '../util/street_analytics'
 
 import SegmentCanvas from './SegmentCanvas'
 import SegmentDragHandles from './SegmentDragHandles'
@@ -239,9 +239,8 @@ export class Segment extends React.Component {
     // Get localized names from store, fall back to segment default names if translated
     // text is not found. TODO: port to react-intl/formatMessage later.
     const displayName = segment.label || getLocaleSegmentName(segment.type, segment.variantString)
-    const avgCap = getSegmentCapacity(segment).capacity.average
-    let formattedCapacity = formatCapacity(avgCap, this.props.locale)
-    const showCapacity = enableAnalytics && Number.parseInt(avgCap, 10) > 0
+    let capacity = getSegmentCapacity(segment).capacity.average
+    const showCapacity = enableAnalytics && Number.parseInt(capacity, 10) > 0
     const actualWidth = this.calculateSegmentWidths()
     const elementWidth = actualWidth * TILE_SIZE
     const translate = 'translateX(' + this.props.segmentPos + 'px)'
@@ -267,10 +266,14 @@ export class Segment extends React.Component {
     if (segment && segment.warnings) {
       if (segment.warnings[SEGMENT_WARNING_OUTSIDE] || segment.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL] || segment.warnings[SEGMENT_WARNING_WIDTH_TOO_LARGE]) {
         classNames.push('warning')
-        formattedCapacity = 0
       }
       if (segment.warnings[SEGMENT_WARNING_OUTSIDE]) {
         classNames.push('outside')
+      }
+
+      // Set capacity to zero when certain warnings are present
+      if (segment.warnings[SEGMENT_WARNING_OUTSIDE] || segment.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL]) {
+        capacity = 0
       }
     }
 
@@ -288,7 +291,7 @@ export class Segment extends React.Component {
           width={actualWidth}
           units={this.props.units}
           locale={this.props.locale}
-          capacity={formattedCapacity}
+          capacity={capacity}
           showCapacity={showCapacity}
         />
         <SegmentDragHandles width={elementWidth} />

--- a/assets/scripts/segments/SegmentLabelContainer.jsx
+++ b/assets/scripts/segments/SegmentLabelContainer.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 import MeasurementText from '../ui/MeasurementText'
 import { SETTINGS_UNITS_METRIC } from '../users/constants'
+import { formatCapacity } from '../util/street_analytics'
 import './SegmentLabelContainer.scss'
 
 const SegmentLabelContainer = (props) => {
@@ -31,7 +32,9 @@ const SegmentLabelContainer = (props) => {
         <FormattedMessage
           id="capacity.ppl-per-hr"
           defaultMessage="{capacity} people/hr"
-          values={{ capacity: props.capacity }} />
+          values={{
+            capacity: formatCapacity(props.capacity, props.locale)
+          }} />
       </span>}
       <span className={gridClassNames.join(' ')} />
     </div>
@@ -44,15 +47,16 @@ SegmentLabelContainer.propTypes = {
     PropTypes.string,
     PropTypes.element
   ]).isRequired,
-  showCapacity: PropTypes.bool.isRequired,
-  capacity: PropTypes.number.isRequired,
+  showCapacity: PropTypes.bool,
+  capacity: PropTypes.number,
   width: PropTypes.number.isRequired,
   units: PropTypes.number,
   locale: PropTypes.string.isRequired
 }
 
 SegmentLabelContainer.defaultProps = {
-  units: SETTINGS_UNITS_METRIC
+  units: SETTINGS_UNITS_METRIC,
+  showCapacity: false
 }
 
 export default SegmentLabelContainer


### PR DESCRIPTION
- Prop `capacity` sent to `<SegmentLabelContainer />` should always be a number, as specified in PropTypes
- Prop `showCapacity` in `<SegmentLabelContainer />` is no longer required and defaults to `false` if undefined
- Capacity formatting now occurs in `<SegmentLabelContainer />`, which is the "view" component and should handle view logic
- Segment no longer displays zero capacity when the width of the segment is wider than recommended value