### PR TITLE
chore(lint): replace jsonlint with prettier

### DIFF
--- a/docs/contributing/code/styleguide.rst
+++ b/docs/contributing/code/styleguide.rst
@@ -36,7 +36,7 @@ Our JavaScript code style is `Standard JS`_.
 
 .. admonition:: In the future...
 
-   ...we may adopt `Prettier <https://github.com/prettier/prettier>`_ (or `prettier-standard <https://github.com/sheerun/prettier-standard>`_) to automatically format code. We have not introduced it yet because doing so across the entire codebase would be disruptive to existing work. If someone wants to champion adoption of Prettier, please get in touch.
+   ...we may adopt `Prettier <https://github.com/prettier/prettier>`_ (or `prettier-standard <https://github.com/sheerun/prettier-standard>`_) to automatically format code. We have not introduced it yet because doing so across the entire codebase would be disruptive to existing work. We currently use Prettier to lint and format JSON. If someone wants to champion adoption of Prettier, please get in touch.
 
 
 Import order

--- a/docs/technical/tests/index.rst
+++ b/docs/technical/tests/index.rst
@@ -47,7 +47,9 @@ Linting
 
 We use `ESLint <https://eslint.org/>`_ and `Stylelint <https://stylelint.io/>`_ to lint JavaScript and CSS, respectively. There is a commit hook that automatically runs the linter on each commit. If the lint fails, you will need to fix your code and try your commit again, or force it to ignore the lint errors. For more on code style, see :ref:`code-styleguide`.
 
-In addition, we use `JSONLint <https://github.com/zaach/jsonlint>`_ to automatically format JSON or report errors when JSON is improperly formatted.
+.. admonition:: In the future...
+
+   ...we may adopt `Prettier <https://github.com/prettier/prettier>`_ (or `prettier-standard <https://github.com/sheerun/prettier-standard>`_) to automatically format code. We have not introduced it yet because doing so across the entire codebase would be disruptive to existing work. We currently use Prettier to lint and format JSON. If someone wants to champion adoption of Prettier, please get in touch.
 
 
 Type safety

--- a/package-lock.json
+++ b/package-lock.json
@@ -3314,12 +3314,6 @@
       "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.9.tgz",
       "integrity": "sha512-bYuSNomfn4hu2tPiDN+JZtnzCpSpbJ/PNeulmocDy3xN2X5OkJL65zo6rPZp65cPPhLF9vfT/dgE+RtFRCSxOA=="
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=",
-      "dev": true
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -12177,16 +12171,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonlint": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.3.tgz",
-      "integrity": "sha512-jMVTMzP+7gU/IyC6hvKyWpUU8tmTkK5b3BPNuMI9U8Sit+YAWLlZwB6Y6YrdCxfg2kNz05p3XY3Bmm4m26Nv3A==",
-      "dev": true,
-      "requires": {
-        "JSV": "^4.0.x",
-        "nomnom": "^1.5.x"
-      }
-    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -13902,24 +13886,6 @@
       "integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
       "requires": {
         "semver": "^5.3.0"
-      }
-    },
-    "nomnom": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-      "dev": true,
-      "requires": {
-        "colors": "0.5.x",
-        "underscore": "~1.4.4"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        }
       }
     },
     "nopt": {
@@ -15809,6 +15775,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+    },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
     },
     "pretty-format": {
       "version": "24.8.0",
@@ -19325,12 +19297,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
-      "dev": true
     },
     "unfetch": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,9 @@
     "mongo:start": "mongod --fork --logpath /dev/null",
     "mongo:stop": "mongo admin --eval 'db.shutdownServer()'",
     "app:start": "supervisor --extensions js --ignore .cache,assets,build,test index.js",
-    "lint": "npm run lint:css && npm run lint:js && npm run lint:json",
+    "lint": "npm run lint:css && npm run lint:js",
     "lint:css": "stylelint \"./assets/**/*.scss\"",
     "lint:js": "eslint \"**/*.js\" \"**/*.jsx\"",
-    "lint:json": "find assets -name '*.json' -exec jsonlint {} --quiet \\;",
     "jest": "jest --collectCoverage",
     "jest:watch": "jest --watch",
     "translations:download": "node bin/download_translations.js",
@@ -94,7 +93,7 @@
       "git add"
     ],
     "*.json": [
-      "jsonlint --in-place",
+      "prettier --write",
       "git add"
     ],
     "*.scss": [
@@ -209,8 +208,8 @@
     "jest-canvas-mock": "2.1.0",
     "jest-date-mock": "1.0.7",
     "jest-fetch-mock": "2.1.2",
-    "jsonlint": "1.6.3",
     "lint-staged": "9.2.0",
+    "prettier": "1.18.2",
     "react-test-renderer": "16.8.6",
     "recompose": "0.30.0",
     "redux-mock-store": "1.5.3",


### PR DESCRIPTION
First step in issue #1528. Replacing `jsonlint` is low-hanging fruit, the eventual goal is to adopt `prettier` across CSS and JS as well.
