### PR TITLE
fix analytics totals when segments have certain warnings

### DIFF
--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -239,7 +239,7 @@ export class Segment extends React.Component {
     // Get localized names from store, fall back to segment default names if translated
     // text is not found. TODO: port to react-intl/formatMessage later.
     const displayName = segment.label || getLocaleSegmentName(segment.type, segment.variantString)
-    let capacity = getSegmentCapacity(segment).capacity.average
+    const capacity = getSegmentCapacity(segment).capacity.average
     const showCapacity = enableAnalytics && Number.parseInt(capacity, 10) > 0
     const actualWidth = this.calculateSegmentWidths()
     const elementWidth = actualWidth * TILE_SIZE
@@ -269,11 +269,6 @@ export class Segment extends React.Component {
       }
       if (segment.warnings[SEGMENT_WARNING_OUTSIDE]) {
         classNames.push('outside')
-      }
-
-      // Set capacity to zero when certain warnings are present
-      if (segment.warnings[SEGMENT_WARNING_OUTSIDE] || segment.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL]) {
-        capacity = 0
       }
     }
 

--- a/assets/scripts/util/street_analytics.js
+++ b/assets/scripts/util/street_analytics.js
@@ -1,6 +1,10 @@
 import { getSegmentVariantInfo, getSegmentInfo } from '../segments/info'
 // import store from '../store'
 import memoizeFormatConstructor from './memoized_formatting'
+import {
+  SEGMENT_WARNING_OUTSIDE,
+  SEGMENT_WARNING_WIDTH_TOO_SMALL
+} from '../segments/constants'
 
 // take in a street and returns a list of segments with analytics info
 const getAnalyticsFromStreet = (street, locale) => {
@@ -33,9 +37,11 @@ const sumFunc = (total, num) => {
 }
 
 const addSegmentData = item => {
+  const hasZeroCapacityError = item && item.warnings && (item.warnings[SEGMENT_WARNING_OUTSIDE] || item.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL])
+
   return {
     label: `${item.variantString} ${item.type}`,
-    capacity: getCapacity(item.type),
+    capacity: hasZeroCapacityError ? NO_CAPACITY : getCapacity(item.type),
     segment: item
   }
 }


### PR DESCRIPTION
🌷 moves fix for analytics totals of segments to the root util, thus ensuring it works in the totals, graphs, etc. 