### PR TITLE
feat: allow user roles to specify a set of feature flags

### DIFF
--- a/app/data/user_roles.json
+++ b/app/data/user_roles.json
@@ -1,5 +1,66 @@
 {
-  "ADMIN": "ADMIN",
-  "TIER1": "TIER1",
-  "USER": "USER"
+  "USER": {
+    "key": "user",
+    "text": "User",
+    "value": "USER",
+    "flags": {
+      "SILLY_CLOWNS": true
+    }
+  },
+  "ADMIN": {
+    "key": "admin",
+    "text": "Administrator",
+    "value": "ADMIN",
+    "flags": {
+      "LOCALES_LEVEL_1": true
+    }
+  },
+  "BETA_TESTER": {
+    "key": "beta_tester",
+    "text": "Beta tester",
+    "value": "BETA_TESTER",
+    "flags": {
+      "ANALYTICS": true,
+      "BODY_FONT_UPDATE": true,
+      "ENVIRONMENT_EDITOR": true,
+      "LOCALES_LEVEL_1": true,
+      "SEGMENT_AV": true,
+      "SEGMENT_CAFE_SEATING": true,
+      "SEGMENT_CONSTRUCTION": true,
+      "SEGMENT_MAGIC_CARPET": true,
+      "SEGMENT_RAISED_BIKES": true,
+      "SEGMENT_UTILITIES": true,
+      "CUSTOM_SEGMENT_LABELS": true
+    }
+  },
+  "TRANSLATOR": {
+    "key": "translator",
+    "text": "Translator",
+    "value": "TRANSLATOR",
+    "flags": {
+      "LOCALES_LEVEL_1": true
+    }
+  },
+  "SUBSCRIBER_1": {
+    "key": "subscriber_1",
+    "text": "Subscriber tier 1",
+    "value": "SUBSCRIBER_1",
+    "flags": {
+      "CUSTOM_SEGMENT_LABELS": true,
+      "SAVE_AS_IMAGE_CUSTOM_DPI": true,
+      "EXPORT_WATERMARK": true
+    }
+  },
+  "SUBSCRIBER_2": {
+    "key": "subscriber_2",
+    "text": "Subscriber tier 2",
+    "value": "SUBSCRIBER_2",
+    "flags": {}
+  },
+  "SUBSCRIBER_3": {
+    "key": "subscriber_3",
+    "text": "Subscriber tier 3",
+    "value": "SUBSCRIBER_3",
+    "flags": {}
+  }
 }

--- a/app/resources/services/payments.js
+++ b/app/resources/services/payments.js
@@ -6,7 +6,7 @@ const logger = require('../../../lib/logger.js')()
 const tier1PlanId = config.stripe.tier1_plan_id
 
 const planMap = {
-  [tier1PlanId]: roles.TIER1
+  [tier1PlanId]: roles.SUBSCRIBER_1
 }
 
 exports.post = async (req, res) => {
@@ -53,7 +53,7 @@ exports.post = async (req, res) => {
 
   try {
     const { data, roles } = user
-    const newRole = planMap[tier1PlanId]
+    const newRole = planMap[tier1PlanId].value
 
     // if we already have the role, skip adding it
     if (!roles.includes(newRole)) {

--- a/app/resources/v1/user.js
+++ b/app/resources/v1/user.js
@@ -94,7 +94,15 @@ exports.get = async function (req, res) {
           userJson.profileImageUrl = user.profile_image_url
         }
 
-        res.status(200).send(userJson)
+        // All users automatically are the USER role
+        // First create the roles array if it's not present
+        userJson.roles = userJson.roles || []
+        if (!userJson.roles.includes('USER')) {
+          // Also, make USER appear first in the list consistently
+          userJson.roles.unshift('USER')
+        }
+
+        res.status(200).json(userJson)
       })
     } // END function - sendUserJson
 

--- a/assets/scripts/app/DebugInfo.jsx
+++ b/assets/scripts/app/DebugInfo.jsx
@@ -19,7 +19,8 @@ export class DebugInfo extends React.Component {
     settings: PropTypes.object.isRequired,
     street: PropTypes.object.isRequired,
     flags: PropTypes.object.isRequired,
-    undo: PropTypes.object.isRequired
+    undo: PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired
   }
 
   constructor (props) {
@@ -61,6 +62,7 @@ export class DebugInfo extends React.Component {
     // Create a JSON object, this parses better in editors
     const debugObj = {
       DATA: debugStreetData,
+      USER: this.props.user,
       SETTINGS: this.props.settings,
       FLAGS: this.props.flags,
       UNDO: debugUndo
@@ -120,7 +122,8 @@ function mapStateToProps (state) {
     settings: state.settings,
     street: state.street,
     flags: state.flags,
-    undo: state.undo
+    undo: state.undo,
+    user: state.user
   }
 }
 

--- a/assets/scripts/app/DebugInfo.scss
+++ b/assets/scripts/app/DebugInfo.scss
@@ -20,8 +20,8 @@
     height: 100%;
     border: 1px solid lightgray;
     background-color: whitesmoke;
-    font-family: "Courier New", monospace;
-    font-size: 11px;
+    font-family: monospace;
+    font-size: 13px;
     resize: none;
   }
 }

--- a/assets/scripts/app/__tests__/DebugInfo.test.js
+++ b/assets/scripts/app/__tests__/DebugInfo.test.js
@@ -9,7 +9,8 @@ describe('DebugInfo', () => {
     const street = { }
     const flags = { }
     const undo = { }
-    const wrapper = shallow(<DebugInfo settings={settings} street={street} flags={flags} undo={undo} />)
+    const user = { }
+    const wrapper = shallow(<DebugInfo settings={settings} street={street} flags={flags} undo={undo} user={user} />)
     expect(wrapper).toMatchSnapshot()
   })
   it('is visible when state visible is set', () => {
@@ -17,7 +18,8 @@ describe('DebugInfo', () => {
     const street = { }
     const flags = { }
     const undo = { }
-    const wrapper = shallow(<DebugInfo settings={settings} street={street} flags={flags} undo={undo} />)
+    const user = { }
+    const wrapper = shallow(<DebugInfo settings={settings} street={street} flags={flags} undo={undo} user={user} />)
     wrapper.setState({ visible: true })
     expect(wrapper).toMatchSnapshot()
   })

--- a/assets/scripts/app/__tests__/flag_utils.test.js
+++ b/assets/scripts/app/__tests__/flag_utils.test.js
@@ -20,7 +20,7 @@ const userOverrides = {
     { flag: 'FOO_BAR', value: false },
     { flag: 'BAZ_BAR', value: true }
   ],
-  priority: 1
+  priority: 2
 }
 
 const sessionOverrides = {
@@ -29,7 +29,7 @@ const sessionOverrides = {
     { flag: 'BAZ_QUX', value: true },
     { flag: 'FOO_BAR', value: true }
   ],
-  priority: 2
+  priority: 3
 }
 
 describe('generateFlagOverrides', () => {
@@ -44,7 +44,7 @@ describe('generateFlagOverrides', () => {
       flags: [
         { flag: 'FOO_BAR', value: false }
       ],
-      priority: 1
+      priority: 2
     })
   })
 })
@@ -69,7 +69,7 @@ describe('applyFlagOverrides', () => {
       flags: [
         { flag: 'FOO_BAZ', value: false }
       ],
-      priority: 1
+      priority: 2
     }
 
     const result = applyFlagOverrides(initialFlags, userOverrides)

--- a/assets/scripts/app/flag_utils.js
+++ b/assets/scripts/app/flag_utils.js
@@ -4,8 +4,9 @@ import { setFlagOverrides } from '../store/actions/flags'
 
 export const PRIORITY_LEVELS = {
   initial: 0,
-  user: 1,
-  session: 2
+  role: 1,
+  user: 2,
+  session: 3
 }
 
 export function initializeFlagSubscribers () {
@@ -76,7 +77,8 @@ export function generateFlagOverrides (flags, source) {
   const flagsOverrides = {
     source,
     flags: [],
-    priority: PRIORITY_LEVELS[source]
+    // Source can be a string that looks like 'role:USER', so just take the first part
+    priority: PRIORITY_LEVELS[source.split(':')[0]]
   }
 
   return Object.entries(flags).reduce((obj, item) => {

--- a/assets/scripts/app/keyboard_commands.js
+++ b/assets/scripts/app/keyboard_commands.js
@@ -58,7 +58,7 @@ export function registerKeypresses () {
   // Secret menu to toggle feature flags
   // Only active in development/staging
   registerKeypress('shift f', () => {
-    if (ENV !== 'production' || (isSignedIn() && getSignInData().details.roles.includes(USER_ROLES.ADMIN))) {
+    if (ENV !== 'production' || (isSignedIn() && getSignInData().details.roles.includes(USER_ROLES.ADMIN.value))) {
       store.dispatch(showDialog('FEATURE_FLAGS'))
     }
   })

--- a/assets/scripts/dialogs/UpgradeDialog.jsx
+++ b/assets/scripts/dialogs/UpgradeDialog.jsx
@@ -17,7 +17,7 @@ const UpgradeDialog = ({ userId, roles }) => {
   const [error, setError] = useState(null)
   const [data, setData] = useState(null)
 
-  const hasTier1 = roles.includes(userRoles.TIER1)
+  const hasTier1 = roles.includes(userRoles.SUBSCRIBER_1.value)
 
   async function onToken (token) {
     const requestBody = { userId, token }

--- a/assets/scripts/menus/AvatarMenu.jsx
+++ b/assets/scripts/menus/AvatarMenu.jsx
@@ -1,15 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import Avatar from '../users/Avatar'
 import USER_ROLES from '../../../app/data/user_roles'
+import Avatar from '../users/Avatar'
 import { ICON_CROWN } from '../ui/icons'
 import './AvatarMenu.scss'
 
+AvatarMenu.propTypes = {
+  user: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    roles: PropTypes.arrayOf(PropTypes.string)
+  }).isRequired,
+  onClick: PropTypes.func
+}
+
 function AvatarMenu (props) {
-  const { user, onClick } = props
-  const { id, roles } = user
-  const isAdmin = roles && roles.includes(USER_ROLES.ADMIN.value)
+  const { user, onClick = () => {} } = props
+  const { id, roles = [] } = user
+  const isAdmin = roles.includes(USER_ROLES.ADMIN.value)
 
   return (
     <button
@@ -21,18 +29,6 @@ function AvatarMenu (props) {
       <span className="user-id">{id}</span>
     </button>
   )
-}
-
-AvatarMenu.propTypes = {
-  user: PropTypes.shape({
-    id: PropTypes.string.isRequired,
-    roles: PropTypes.arrayOf(PropTypes.string)
-  }).isRequired,
-  onClick: PropTypes.func
-}
-
-AvatarMenu.defaultProps = {
-  onClick: () => {}
 }
 
 export default AvatarMenu

--- a/assets/scripts/menus/AvatarMenu.jsx
+++ b/assets/scripts/menus/AvatarMenu.jsx
@@ -9,7 +9,7 @@ import './AvatarMenu.scss'
 function AvatarMenu (props) {
   const { user, onClick } = props
   const { id, roles } = user
-  const isAdmin = roles && roles.includes(USER_ROLES.ADMIN)
+  const isAdmin = roles && roles.includes(USER_ROLES.ADMIN.value)
 
   return (
     <button

--- a/assets/scripts/menus/Menu.scss
+++ b/assets/scripts/menus/Menu.scss
@@ -54,7 +54,6 @@ $menu-box-shadow: $medium-box-shadow;
     }
   }
 
-  textarea,
   input {
     appearance: none;
     background: $form-element-background;

--- a/assets/styles/_typography.scss
+++ b/assets/styles/_typography.scss
@@ -10,7 +10,6 @@ button,
 a.button-like,
 input,
 select,
-textarea,
 option {
   font-family: $font-family;
 }
@@ -22,7 +21,6 @@ body.experimental-font-family {
   a.button-like,
   input,
   select,
-  textarea,
   option {
     font-family: $experimental-font-family;
   }


### PR DESCRIPTION
This PR allows user roles to define a set of active feature flags for all the roles that a user holds.

Role flags have a low default priority. They can be overridden on a user-by-user basis or session basis. Between role flags, there is no differentiation of priority, and will be applied in the order that the roles are assigned. This might be changed later, but we currently do not have roles that need to counter another role. (Another quality of life improvement we might consider later are roles that inherit flags from a parent role.)

Other improvements:
- The `TIER1` role was renamed `SUBSCRIBER_1` to match the flag set by the admin panel.
- The `DebugInfo` component now displays user information and some visuals were tweaked to make it display monospace text correctly.
- All logged-in users are now automatically assigned the USER role, even if they were not specifically assigned it before.