### PR TITLE
[fix] Only show one amount in capacity when appropriate

### DIFF
--- a/assets/locales/en/main.json
+++ b/assets/locales/en/main.json
@@ -185,7 +185,8 @@
       "export-csv": "Export to CSV",
       "heading": "Analytics",
       "street-summary": "Your street has an estimated average traffic of {averageTotal} passengers per hour, and potential for up to {potentialTotal} passengers per hour.",
-      "segment-summary": "{average} — {potential} people/hour"
+      "segment-summary": "{average} — {potential} people/hour",
+      "segment-summary-single": "{amount} people/hour"
     },
     "save": {
       "heading": "Save as image",

--- a/assets/scripts/dialogs/Analytics/CapacityMessage.js
+++ b/assets/scripts/dialogs/Analytics/CapacityMessage.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FormatNumber } from '../../util/formatting'
+import { FormattedMessage } from 'react-intl'
+
+CapacityMessage.propTypes = {
+  locale: PropTypes.string.isRequired,
+  average: PropTypes.number.isRequired,
+  potential: PropTypes.number.isRequired
+}
+
+export default function CapacityMessage ({ locale, average, potential }) {
+  if (average === potential) {
+    return (<FormattedMessage
+      id="dialogs.analytics.segment-summary-single"
+      defaultMessage="{amount} people/hour"
+      values={{
+        amount: FormatNumber(locale, average)
+      }}
+    />)
+  }
+
+  return (<FormattedMessage
+    id="dialogs.analytics.segment-summary"
+    defaultMessage="{average} — {potential} people/hour"
+    values={{
+      average: FormatNumber(locale, average),
+      potential: FormatNumber(locale, potential)
+    }}
+  />)
+}

--- a/assets/scripts/dialogs/Analytics/CapacityMessage.js
+++ b/assets/scripts/dialogs/Analytics/CapacityMessage.js
@@ -10,20 +10,14 @@ CapacityMessage.propTypes = {
 }
 
 export default function CapacityMessage ({ locale, average, potential }) {
-  if (average === potential) {
-    return (<FormattedMessage
-      id="dialogs.analytics.segment-summary-single"
-      defaultMessage="{amount} people/hour"
-      values={{
-        amount: FormatNumber(locale, average)
-      }}
-    />)
-  }
-
+  const isSingleAmount = average === potential
+  const defaultMessage = isSingleAmount ? '{amount} people/hour' : '{average} — {potential} people/hour'
+  const id = isSingleAmount ? 'dialogs.analytics.segment-summary-single' : 'dialogs.analytics.segment-summary'
   return (<FormattedMessage
-    id="dialogs.analytics.segment-summary"
-    defaultMessage="{average} — {potential} people/hour"
+    id={id}
+    defaultMessage={defaultMessage}
     values={{
+      amount: FormatNumber(locale, average),
       average: FormatNumber(locale, average),
       potential: FormatNumber(locale, potential)
     }}

--- a/assets/scripts/dialogs/Analytics/SegmentAnalytics.jsx
+++ b/assets/scripts/dialogs/Analytics/SegmentAnalytics.jsx
@@ -2,9 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import SegmentForPalette from '../../segments/SegmentForPalette'
-import { FormatNumber } from '../../util/formatting'
-import { FormattedMessage } from 'react-intl'
 import { getLocaleSegmentName } from '../../segments/view'
+import CapacityMessage from './CapacityMessage'
 
 const BAR_HEIGHT = '70px'
 const BAR_MODIFIER = 0.85
@@ -53,14 +52,7 @@ const SegmentAnalytics = ({ type, capacity, segment, locale, index, chartMax }) 
       <div className="capacity-text" style={{ width: `${widthPercentInv}%`, marginLeft: '2%' }}>
         <div className="capacity-label">{label}</div>
         <div className="capacity-summary">
-          <FormattedMessage
-            id="dialogs.analytics.segment-summary"
-            defaultMessage="{average} — {potential} people/hour"
-            values={{
-              average: FormatNumber(locale, average),
-              potential: FormatNumber(locale, potential)
-            }}
-          />
+          <CapacityMessage average={average} potential={potential} locale={locale} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
🐛 🔨 adds a component to handle cases where we should display 1 number instead of 2 in the analytics chart. 

See https://github.com/streetmix/streetmix/issues/1545