### PR TITLE
tweak logic of no-capacity segments so we never need undefined values

### DIFF
--- a/assets/scripts/dialogs/AnalyticsDialog.jsx
+++ b/assets/scripts/dialogs/AnalyticsDialog.jsx
@@ -82,11 +82,12 @@ function AnalyticsDialog (props) {
     }}
   />)
 
-  const getRolledCapacity = item => Number.isInteger(item.capacity.potential) ? item.capacity.potential : 0
-  const hasRolledCapacity = item => Number.isInteger(item.capacity.potential)
+  const displayCapacity = item => {
+    return item.capacity && item.capacity.display && item.capacity.average > 0
+  }
 
   const rolledUp = rollUpCategories(segmentData)
-  const chartMax = Math.max(...rolledUp.map(getRolledCapacity)) + 1000
+  const chartMax = Math.max(...rolledUp.map(item => item.capacity.potential)) + 1000
 
   function exportCSV () {
     const name = props.street.name || intl.formatMessage({
@@ -110,7 +111,7 @@ function AnalyticsDialog (props) {
               <p>
                 {summary}
               </p>
-              {rolledUp.filter(hasRolledCapacity).map((item, index) => (item.capacity.average > 0) && <SegmentAnalytics index={index} {...item} chartMax={chartMax} />)}
+              {rolledUp.filter(displayCapacity).map((item, index) => (item.capacity.average > 0) && <SegmentAnalytics index={index} {...item} chartMax={chartMax} />)}
               <p>
                 <strong>Source:</strong> <em><a href="">Environmentally Sustainable Transport - Main Principles and Impacts</a></em>, Manfred Breithaupt, Deutsche Gesellschaft für Internationale Zusammenarbeit (GIZ)
               </p>

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -239,8 +239,9 @@ export class Segment extends React.Component {
     // Get localized names from store, fall back to segment default names if translated
     // text is not found. TODO: port to react-intl/formatMessage later.
     const displayName = segment.label || getLocaleSegmentName(segment.type, segment.variantString)
-    const capacity = getSegmentCapacity(segment).capacity.average
-    const showCapacity = enableAnalytics && capacity !== undefined
+
+    const { capacity: { average, display = true } } = getSegmentCapacity(segment)
+    const showCapacity = enableAnalytics && display
     const actualWidth = this.calculateSegmentWidths()
     const elementWidth = actualWidth * TILE_SIZE
     const translate = 'translateX(' + this.props.segmentPos + 'px)'
@@ -286,7 +287,7 @@ export class Segment extends React.Component {
           width={actualWidth}
           units={this.props.units}
           locale={this.props.locale}
-          capacity={capacity}
+          capacity={average}
           showCapacity={showCapacity}
         />
         <SegmentDragHandles width={elementWidth} />

--- a/assets/scripts/streets/StreetMetaAnalytics.jsx
+++ b/assets/scripts/streets/StreetMetaAnalytics.jsx
@@ -20,7 +20,7 @@ function StreetMetaAnalytics (props) {
   const averageTotal = getStreetCapacity(street, locale).averageTotal
 
   // For zero capacity, don't display anything
-  return (averageTotal > 0) && (
+  return (Number.parseInt(averageTotal, 10) > 0) && (
     <span className="street-metadata-author">
       <a href="#" onClick={showAnalyticsDialog}>
         <FormattedMessage

--- a/assets/scripts/util/street_analytics.js
+++ b/assets/scripts/util/street_analytics.js
@@ -48,7 +48,7 @@ const getAnalyticsFromStreet = (street, locale) => {
 }
 
 const NO_CAPACITY = { average: 0, potential: 0 }
-const UNDEFINED_CAPACITY = { average: undefined, potential: undefined }
+const UNDEFINED_CAPACITY = { average: 0, potential: 0, display: false }
 
 const CAPACITIES = {
   sidewalk: { average: 19000, potential: 19000 },
@@ -61,8 +61,12 @@ const CAPACITIES = {
   'magic-carpet': { average: 2, potential: 3 }
 }
 
+const hasCapacityType = (type) => {
+  return type in CAPACITIES
+}
+
 export const getCapacity = (type) => {
-  return CAPACITIES[type] || UNDEFINED_CAPACITY
+  return hasCapacityType(type) ? { ...CAPACITIES[type] } : UNDEFINED_CAPACITY
 }
 
 const sumFunc = (total, num) => {
@@ -71,7 +75,7 @@ const sumFunc = (total, num) => {
 }
 
 const addSegmentData = item => {
-  const hasZeroCapacityError = item && item.warnings && (item.warnings[SEGMENT_WARNING_OUTSIDE] || item.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL])
+  const hasZeroCapacityError = item && hasCapacityType(item.type) && item.warnings && (item.warnings[SEGMENT_WARNING_OUTSIDE] || item.warnings[SEGMENT_WARNING_WIDTH_TOO_SMALL])
 
   return {
     label: `${item.variantString} ${item.type}`,


### PR DESCRIPTION
See https://github.com/streetmix/streetmix/issues/1568 and https://github.com/streetmix/streetmix/issues/1565

Using 'undefined' as a capacity turns out to be a bad idea for a number of reasons. Instead, we will explicitly set a `display` attribute to determine whether the system should render it in the relevant locations, this way the data itself can still be handled uniformly. 

<img width="535" alt="Screen Shot 2019-09-25 at 8 13 45 PM" src="https://user-images.githubusercontent.com/15174372/65648649-20070280-dfd1-11e9-8f5d-e8404c54f294.png">

Content from CSV generated from a standard street:

```
"type","averageCapacity","potentialCapacity"
"sidewalk-tree",0,0
"transit-shelter",0,0
"sidewalk-lamp",0,0
"divider",0,0
"turn-lane",0,0
"parking-lane",0,0
"drive-lane",1500,2000
"bus-lane",5000,8000
"bike-lane",14000,14000
"sidewalk",38000,38000
```

(note there are no 'NaN' values)