### PR TITLE
Remove use of defaultProps for functional components

### DIFF
--- a/assets/scripts/app/NotificationBar.jsx
+++ b/assets/scripts/app/NotificationBar.jsx
@@ -13,8 +13,16 @@ const TRANSITION_BASE_STYLE = {
 // const LSKEY_NOTIFICATION_TOS = 'notification-tos-dismissed'
 const LSKEY_NOTIFICATION_STORE = 'notification-store-dismissed'
 
-const NotificationBar = (props) => {
-  let shouldDisplay = props.notification.display
+const NotificationBar = ({ notification = {} }) => {
+  const {
+    display = false,
+    lede,
+    text,
+    link,
+    linkText
+  } = notification
+
+  let shouldDisplay = display
 
   // If dismissed, don't display again.
   if (window.localStorage[LSKEY_NOTIFICATION_STORE]) {
@@ -39,8 +47,6 @@ const NotificationBar = (props) => {
       // Cannot modify localstorage.
     }
   }
-
-  const { display, lede, text, link, linkText } = props.notification
 
   // If no one turns this on explicitly, don't display anything
   if (!display || (!lede && !text && !link)) return null
@@ -81,12 +87,6 @@ NotificationBar.propTypes = {
     link: PropTypes.string,
     linkText: PropTypes.string
   })
-}
-
-NotificationBar.defaultProps = {
-  notification: {
-    display: false
-  }
 }
 
 export default NotificationBar

--- a/assets/scripts/app/ScrollIndicators.jsx
+++ b/assets/scripts/app/ScrollIndicators.jsx
@@ -5,7 +5,7 @@ import { registerKeypress, deregisterKeypress } from './keypress'
 import './ScrollIndicators.scss'
 
 const ScrollIndicators = (props) => {
-  const { scrollTop, scrollStreet, scrollIndicatorsLeft, scrollIndicatorsRight } = props
+  const { scrollTop, scrollStreet, scrollIndicatorsLeft = 0, scrollIndicatorsRight = 0 } = props
 
   const doLeftScroll = (event) => {
     scrollStreet(true, event.shiftKey)
@@ -71,11 +71,6 @@ ScrollIndicators.propTypes = {
   scrollIndicatorsRight: PropTypes.number,
   scrollStreet: PropTypes.func.isRequired,
   scrollTop: PropTypes.number.isRequired
-}
-
-ScrollIndicators.defaultProps = {
-  scrollIndicatorsLeft: 0,
-  scrollIndicatorsRight: 0
 }
 
 export default React.memo(ScrollIndicators)

--- a/assets/scripts/app/SkyBackgroundObjects.jsx
+++ b/assets/scripts/app/SkyBackgroundObjects.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import { TransitionGroup, CSSTransition } from 'react-transition-group'
 import './SkyBackgroundObjects.scss'
 
-export function SkyBackgroundObjects (props) {
+export function SkyBackgroundObjects ({ objects = [] }) {
   return (
     <TransitionGroup className="sky-background-objects">
-      {props.objects.map((object) => (
+      {objects.map((object) => (
         <CSSTransition
           key={object.image}
           timeout={{
@@ -40,10 +40,6 @@ SkyBackgroundObjects.propTypes = {
     top: PropTypes.number,
     left: PropTypes.number
   }))
-}
-
-SkyBackgroundObjects.defaultProps = {
-  objects: []
 }
 
 export default SkyBackgroundObjects

--- a/assets/scripts/app/WelcomePanel/FirstTimeNewStreet.jsx
+++ b/assets/scripts/app/WelcomePanel/FirstTimeNewStreet.jsx
@@ -7,11 +7,7 @@ FirstTimeNewStreet.propTypes = {
   touch: PropTypes.bool
 }
 
-FirstTimeNewStreet.defaultProps = {
-  touch: false
-}
-
-function FirstTimeNewStreet (props) {
+function FirstTimeNewStreet ({ touch = false }) {
   return (
     <div className="welcome-panel-content first-time-new-street">
       <h1>
@@ -33,7 +29,7 @@ function FirstTimeNewStreet (props) {
           id="dialogs.welcome.new.instruct"
           defaultMessage="Start by moving some segments around with {pointer}."
           values={{
-            pointer: (props.touch)
+            pointer: (touch)
               ? (
                 <FormattedMessage
                   id="dialogs.welcome.new.instruct-pointer-finger"

--- a/assets/scripts/app/WelcomePanel/NewStreet.jsx
+++ b/assets/scripts/app/WelcomePanel/NewStreet.jsx
@@ -17,15 +17,11 @@ NewStreet.propTypes = {
   getLastStreet: PropTypes.func
 }
 
-NewStreet.defaultProps = {
-  priorLastStreetId: null
-}
-
-function NewStreet (props) {
+function NewStreet ({ newStreetPreference, priorLastStreetId = null, street, getLastStreet }) {
   // If welcomeType is WELCOME_NEW_STREET, there is an additional state
   // property that determines which of the new street modes is selected
   let selectedNewStreetType
-  switch (props.newStreetPreference) {
+  switch (newStreetPreference) {
     case NEW_STREET_EMPTY:
       selectedNewStreetType = 'new-street-empty'
       break
@@ -87,7 +83,7 @@ function NewStreet (props) {
         </li>
         {/* Display this button only if there is a previous street to copy
             from that is not the same as the current street */}
-        {(props.priorLastStreetId && props.priorLastStreetId !== props.street.id) && (
+        {(priorLastStreetId && priorLastStreetId !== street.id) && (
           <li>
             <input
               type="radio"
@@ -95,7 +91,7 @@ function NewStreet (props) {
               id="new-street-last"
               checked={state.selectedNewStreetType === 'new-street-last'}
               onChange={onChangeNewStreetType}
-              onClick={props.getLastStreet}
+              onClick={getLastStreet}
             />
             <label htmlFor="new-street-last">
               <FormattedMessage

--- a/assets/scripts/app/__tests__/__snapshots__/SkyBackground.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/SkyBackground.test.js.snap
@@ -31,9 +31,7 @@ exports[`SkyBackground renders 1`] = `
       }
     />
   </div>
-  <SkyBackgroundObjects
-    objects={Array []}
-  />
+  <SkyBackgroundObjects />
   <div
     className="rear-clouds"
     style={

--- a/assets/scripts/app/__tests__/__snapshots__/SkyBackgroundObjects.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/SkyBackgroundObjects.test.js.snap
@@ -3,7 +3,6 @@
 exports[`SkyBackgroundObjects renders 1`] = `
 <SkyBackgroundObjects
   environment="foo"
-  objects={Array []}
 >
   <mockConstructor
     className="sky-background-objects"

--- a/assets/scripts/dialogs/Geotag/LocationPopup.jsx
+++ b/assets/scripts/dialogs/Geotag/LocationPopup.jsx
@@ -7,7 +7,14 @@ const POPUP_MAX_WIDTH = 300
 const POPUP_OFFSET = [0, -30]
 
 const LocationPopup = (props) => {
-  const { label, position, isEditable, isClearable, handleClear, handleConfirm } = props
+  const {
+    label,
+    position,
+    isEditable = false,
+    isClearable = false,
+    handleClear,
+    handleConfirm
+  } = props
 
   if (!position) return null
 
@@ -57,11 +64,6 @@ LocationPopup.propTypes = {
   isClearable: PropTypes.bool,
   handleConfirm: PropTypes.func,
   handleClear: PropTypes.func
-}
-
-LocationPopup.defaultProps = {
-  isEditable: false,
-  isClearable: false
 }
 
 export default LocationPopup

--- a/assets/scripts/info_bubble/DebugHoverPolygon.jsx
+++ b/assets/scripts/info_bubble/DebugHoverPolygon.jsx
@@ -31,7 +31,7 @@ const drawPolygon = (canvas, polygon) => {
   ctx.stroke()
 }
 
-export const DebugHoverPolygon = (props) => {
+export const DebugHoverPolygon = ({ enabled = false, hoverPolygon = [] }) => {
   // When the window / viewport resizes, set the width and
   // height of the canvas element.
   const el = useRef(null)
@@ -50,13 +50,13 @@ export const DebugHoverPolygon = (props) => {
 
   // Draw the polygon area.
   useEffect(() => {
-    if (props.enabled) {
-      drawPolygon(el.current, props.hoverPolygon)
+    if (enabled) {
+      drawPolygon(el.current, hoverPolygon)
     }
-  }, [props.hoverPolygon, props.enabled])
+  }, [hoverPolygon, enabled])
 
   // Render component if enabled.
-  if (props.enabled) {
+  if (enabled) {
     return (
       <div className="debug-hover-polygon">
         <canvas
@@ -75,11 +75,6 @@ export const DebugHoverPolygon = (props) => {
 DebugHoverPolygon.propTypes = {
   enabled: PropTypes.bool,
   hoverPolygon: PropTypes.array
-}
-
-DebugHoverPolygon.defaultProps = {
-  enabled: false,
-  hoverPolygon: []
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/info_bubble/EditableLabel.jsx
+++ b/assets/scripts/info_bubble/EditableLabel.jsx
@@ -8,7 +8,7 @@ import { ICON_PENCIL, ICON_LOCK } from '../ui/icons'
 import './EditableLabel.scss'
 
 const EditableLabel = (props) => {
-  const { label, segment, position, customLabelEnabled } = props
+  const { label, segment, position, customLabelEnabled = false } = props
 
   const handleMouseEnterLabel = (event) => {
     trackEvent('Interaction', 'InoBubble: Hover over editable label', null, null, true)
@@ -56,10 +56,6 @@ EditableLabel.propTypes = {
 
   // Provided by Redux mapStateToProps
   customLabelEnabled: PropTypes.bool
-}
-
-EditableLabel.defaultProps = {
-  customLabelEnabled: false
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/info_bubble/Triangle.jsx
+++ b/assets/scripts/info_bubble/Triangle.jsx
@@ -2,10 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import './Triangle.scss'
 
-export default function Triangle (props) {
+export default function Triangle ({ highlight = false }) {
   const triangleClassNames = ['info-bubble-triangle']
 
-  if (props.highlight === true) {
+  if (highlight === true) {
     triangleClassNames.push('info-bubble-triangle-highlight')
   }
 
@@ -16,8 +16,4 @@ export default function Triangle (props) {
 
 Triangle.prototype.propTypes = {
   highlight: PropTypes.bool
-}
-
-Triangle.prototype.defaultProps = {
-  highlight: false
 }

--- a/assets/scripts/menus/MenuBarItem.jsx
+++ b/assets/scripts/menus/MenuBarItem.jsx
@@ -3,7 +3,15 @@ import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 
 export default function MenuBarItem (props) {
-  const { translation, label, url, onClick, dispatch, ...restProps } = props
+  const {
+    translation = '',
+    label = '',
+    url,
+    onClick = () => {},
+    dispatch,
+    ...restProps
+  } = props
+
   const children = props.children || <FormattedMessage id={translation} defaultMessage={label} />
 
   if (url) {
@@ -42,10 +50,4 @@ MenuBarItem.propTypes = {
 
   // Event handlers
   onClick: PropTypes.func
-}
-
-MenuBarItem.defaultProps = {
-  onClick: () => {},
-  translation: '',
-  label: ''
 }

--- a/assets/scripts/menus/SignInButton.jsx
+++ b/assets/scripts/menus/SignInButton.jsx
@@ -2,11 +2,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
 
-function SignInButton (props) {
+function SignInButton ({ onClick = () => {} }) {
   return (
     <button
       className="menu-sign-in"
-      onClick={props.onClick}
+      onClick={onClick}
     >
       <FormattedMessage id="menu.item.sign-in" defaultMessage="Sign in" />
     </button>
@@ -15,10 +15,6 @@ function SignInButton (props) {
 
 SignInButton.propTypes = {
   onClick: PropTypes.func
-}
-
-SignInButton.defaultProps = {
-  onClick: () => {}
 }
 
 export default SignInButton

--- a/assets/scripts/palette/PaletteTrashcan.jsx
+++ b/assets/scripts/palette/PaletteTrashcan.jsx
@@ -4,8 +4,7 @@ import { connect } from 'react-redux'
 import { FormattedMessage } from 'react-intl'
 import './PaletteTrashcan.scss'
 
-export const PaletteTrashcan = (props) => {
-  const { visible } = props
+export const PaletteTrashcan = ({ visible = false }) => {
   const classNames = ['palette-trashcan']
 
   if (visible) {
@@ -21,10 +20,6 @@ export const PaletteTrashcan = (props) => {
 
 PaletteTrashcan.propTypes = {
   visible: PropTypes.bool
-}
-
-PaletteTrashcan.defaultProps = {
-  visible: false
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/segments/EmptySegment.jsx
+++ b/assets/scripts/segments/EmptySegment.jsx
@@ -11,9 +11,7 @@ import './EmptySegment.scss'
  * component pattern. Its "container" (parent) component, <EmptySegmentContainer />,
  * determines and passes the `width` and `left` props to this component.
  */
-export function EmptySegment (props) {
-  const { width, left, units, locale } = props
-
+export function EmptySegment ({ width = 0, left = 0, units, locale }) {
   // Do not render if width is a negative number
   if (width <= 0) return null
 
@@ -42,11 +40,6 @@ EmptySegment.propTypes = {
   left: PropTypes.number,
   units: PropTypes.number,
   locale: PropTypes.string
-}
-
-EmptySegment.defaultProps = {
-  width: 0,
-  left: 0
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/segments/SegmentLabelContainer.jsx
+++ b/assets/scripts/segments/SegmentLabelContainer.jsx
@@ -7,10 +7,19 @@ import { formatCapacity } from '../util/street_analytics'
 import './SegmentLabelContainer.scss'
 
 const SegmentLabelContainer = (props) => {
+  const {
+    label,
+    showCapacity = false,
+    capacity,
+    width,
+    units = SETTINGS_UNITS_METRIC,
+    locale
+  } = props
+
   const gridClassNames = ['segment-grid']
 
   // Add class names for measurement grid marks
-  if (props.units === SETTINGS_UNITS_METRIC) {
+  if (units === SETTINGS_UNITS_METRIC) {
     gridClassNames.push('units-metric')
   } else {
     gridClassNames.push('units-imperial')
@@ -19,21 +28,21 @@ const SegmentLabelContainer = (props) => {
   return (
     <div className="segment-label-container">
       <span className="segment-label">
-        {props.label}
+        {label}
       </span>
       <span className="segment-width">
         <MeasurementText
-          value={props.width}
-          units={props.units}
-          locale={props.locale}
+          value={width}
+          units={units}
+          locale={locale}
         />
       </span>
-      {props.showCapacity && <span className="segment-capacity">
+      {showCapacity && <span className="segment-capacity">
         <FormattedMessage
           id="capacity.ppl-per-hr"
           defaultMessage="{capacity} people/hr"
           values={{
-            capacity: formatCapacity(props.capacity, props.locale)
+            capacity: formatCapacity(capacity, locale)
           }} />
       </span>}
       <span className={gridClassNames.join(' ')} />
@@ -52,11 +61,6 @@ SegmentLabelContainer.propTypes = {
   width: PropTypes.number.isRequired,
   units: PropTypes.number,
   locale: PropTypes.string.isRequired
-}
-
-SegmentLabelContainer.defaultProps = {
-  units: SETTINGS_UNITS_METRIC,
-  showCapacity: false
 }
 
 export default SegmentLabelContainer

--- a/assets/scripts/streets/StreetMetaWidthContainer.jsx
+++ b/assets/scripts/streets/StreetMetaWidthContainer.jsx
@@ -19,7 +19,7 @@ import { normalizeStreetWidth } from './width'
 import { processWidthInput, prettifyWidth } from '../util/width_units'
 import { updateStreetWidthAction as updateStreetWidth } from '../store/actions/street'
 
-const StreetMetaWidthContainer = (props) => {
+const StreetMetaWidthContainer = ({ editable = true, street, updateStreetWidth }) => {
   const [isEditing, setEditing] = useState(false)
   const intl = useIntl()
 
@@ -28,7 +28,7 @@ const StreetMetaWidthContainer = (props) => {
    * width is not read-only
    */
   const handleClickLabel = (event) => {
-    if (props.editable) {
+    if (editable) {
       setEditing(true)
     }
   }
@@ -41,7 +41,7 @@ const StreetMetaWidthContainer = (props) => {
   const handleChangeMenuSelection = (value) => {
     setEditing(false)
 
-    const { units, width, occupiedWidth } = props.street
+    const { units, width, occupiedWidth } = street
     const selection = Number.parseInt(value, 10)
 
     switch (selection) {
@@ -65,7 +65,7 @@ const StreetMetaWidthContainer = (props) => {
 
         if (inputWidth) {
           const newWidth = normalizeStreetWidth(processWidthInput(inputWidth, units), units)
-          props.updateStreetWidth(newWidth)
+          updateStreetWidth(newWidth)
         }
 
         break
@@ -76,7 +76,7 @@ const StreetMetaWidthContainer = (props) => {
       // Change width to the desired selection
       default:
         if (selection) {
-          props.updateStreetWidth(selection)
+          updateStreetWidth(selection)
         }
         break
     }
@@ -88,14 +88,14 @@ const StreetMetaWidthContainer = (props) => {
         (isEditing)
           ? (
             <StreetMetaWidthMenu
-              street={props.street}
+              street={street}
               onChange={handleChangeMenuSelection}
             />
           )
           : (
             <StreetMetaWidthLabel
-              street={props.street}
-              editable={props.editable}
+              street={street}
+              editable={editable}
               onClick={handleClickLabel}
             />
           )
@@ -111,10 +111,6 @@ StreetMetaWidthContainer.propTypes = {
 
   // from Redux mapDispatchToProps
   updateStreetWidth: PropTypes.func.isRequired
-}
-
-StreetMetaWidthContainer.defaultProps = {
-  editable: true
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/ui/Checkbox.jsx
+++ b/assets/scripts/ui/Checkbox.jsx
@@ -35,28 +35,30 @@ Checkbox.propTypes = {
   id: PropTypes.string
 }
 
-Checkbox.defaultProps = {
-  checked: false,
-  disabled: false,
-  onChange: () => {}
-}
-
 function Checkbox (props) {
-  // An `id` is required to associate a `label` with an `input` element.
-  // You can provide one manually in props, otherwise, this component
-  // will generate a unique ID on each render.
-  const id = props.id || `checkbox-id-${idCounter++}`
+  const {
+    children,
+    checked = false,
+    disabled = false,
+    value,
+    onChange = () => {},
+
+    // An `id` is required to associate a `label` with an `input` element.
+    // You can provide one manually in props, otherwise, this component
+    // will generate a unique ID on each render.
+    id = `checkbox-id-${idCounter++}`
+  } = props
 
   // This is a controlled component. The `useState` hook maintains
   // this component's internal state, and sets the initial state
   // based on the `checked` prop (which is `false` by default).
-  const [isChecked, setChecked] = useState(props.checked)
+  const [isChecked, setChecked] = useState(checked)
 
   // When the value is changed, we update the state, and we also call
   // any `onChange` handler that is provided by the parent via props.
   const handleChange = (event) => {
     setChecked(!isChecked)
-    props.onChange(event)
+    onChange(event)
   }
 
   return (
@@ -65,12 +67,12 @@ function Checkbox (props) {
         type="checkbox"
         id={id}
         checked={isChecked}
-        value={props.value}
-        disabled={props.disabled}
+        value={value}
+        disabled={disabled}
         onChange={handleChange}
       />
       <label htmlFor={id}>
-        {props.children}
+        {children}
       </label>
       {/* The visual state of this checkbox is affected by the value of the input, via CSS. */}
       <FontAwesomeIcon icon={ICON_CHECK} />

--- a/assets/scripts/ui/CloseButton.jsx
+++ b/assets/scripts/ui/CloseButton.jsx
@@ -6,7 +6,7 @@ import { ICON_TIMES } from '../ui/icons'
 import './CloseButton.scss'
 
 const CloseButton = (props) => {
-  const { title, className, onClick, ...restProps } = props
+  const { title, className = 'close', onClick, ...restProps } = props
   const defaultTitle = useIntl().formatMessage({
     id: 'btn.dismiss',
     defaultMessage: 'Dismiss'
@@ -28,10 +28,6 @@ CloseButton.propTypes = {
   onClick: PropTypes.func.isRequired,
   title: PropTypes.string,
   className: PropTypes.string
-}
-
-CloseButton.defaultProps = {
-  className: 'close'
 }
 
 export default React.memo(CloseButton)

--- a/assets/scripts/ui/MeasurementText.jsx
+++ b/assets/scripts/ui/MeasurementText.jsx
@@ -4,7 +4,7 @@ import { SETTINGS_UNITS_IMPERIAL, SETTINGS_UNITS_METRIC } from '../users/constan
 import { prettifyWidth } from '../util/width_units'
 
 const MeasurementText = React.memo((props) => {
-  const { value, units, locale } = props
+  const { value, units = SETTINGS_UNITS_METRIC, locale } = props
 
   return (
     <span>
@@ -17,10 +17,6 @@ MeasurementText.propTypes = {
   value: PropTypes.number,
   units: PropTypes.oneOf([SETTINGS_UNITS_METRIC, SETTINGS_UNITS_IMPERIAL]),
   locale: PropTypes.string
-}
-
-MeasurementText.defaultProps = {
-  units: SETTINGS_UNITS_METRIC
 }
 
 export default MeasurementText

--- a/assets/scripts/users/Avatar.jsx
+++ b/assets/scripts/users/Avatar.jsx
@@ -7,7 +7,11 @@ import { rememberUserProfile } from '../store/actions/user'
 import './Avatar.scss'
 
 function Avatar (props) {
-  const { userId, image, rememberUserProfile } = props
+  const {
+    userId,
+    image,
+    rememberUserProfile = () => {}
+  } = props
 
   useEffect(() => {
     async function fetchData () {
@@ -36,10 +40,6 @@ Avatar.propTypes = {
   userId: PropTypes.string.isRequired,
   image: PropTypes.string,
   rememberUserProfile: PropTypes.func
-}
-
-Avatar.defaultProps = {
-  rememberUserProfile: () => {}
 }
 
 // Retrieves cached profile image data, if available


### PR DESCRIPTION
This is for issue #1536. This removes the use of defaultProps for functional components, since the React team plans to deprecate this feature.

I'm contribution to your project as part of Hacktoberfest. Unfortunately, I could not install your app because you had no instructions for Linux, but I was able to run and pass your tests.

I did see some `UnhandledPromiseRejectionWarning`s when running the tests, but then I ran the tests on `master` and saw the same issues, so this seems like an ongoing problem unrelated to my changes. Also, I had to make some small Jest snapshot tweaks; seems like defaultProps show up in the snapshots, unlike JS default parameter values.