### PR TITLE
fix(Avatar): handle cancelled API calls

### DIFF
--- a/assets/scripts/menus/__tests__/AvatarMenu.test.js
+++ b/assets/scripts/menus/__tests__/AvatarMenu.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
 import React from 'react'
-import { shallow } from 'enzyme'
+import { fireEvent, cleanup } from '@testing-library/react'
+import { renderWithRedux } from '../../../../test/helpers/render'
 import AvatarMenu from '../AvatarMenu'
 
 const user = {
@@ -8,9 +9,11 @@ const user = {
 }
 
 describe('AvatarMenu', () => {
+  afterEach(cleanup)
+
   it('renders user avatar', () => {
-    const wrapper = shallow(<AvatarMenu user={user} />)
-    expect(wrapper).toMatchSnapshot()
+    const wrapper = renderWithRedux(<AvatarMenu user={user} />)
+    expect(wrapper.asFragment()).toMatchSnapshot()
   })
 
   it('renders user avatar for admin', () => {
@@ -18,14 +21,14 @@ describe('AvatarMenu', () => {
       id: 'foo',
       roles: ['ADMIN']
     }
-    const wrapper = shallow(<AvatarMenu user={user} />)
-    expect(wrapper.find('.menu-avatar-admin')).toHaveLength(1)
+    const wrapper = renderWithRedux(<AvatarMenu user={user} />)
+    expect(wrapper.asFragment()).toMatchSnapshot()
   })
 
   it('calls click handler', () => {
     const onClick = jest.fn()
-    const wrapper = shallow(<AvatarMenu user={user} onClick={onClick} />)
-    wrapper.find('button').simulate('click')
+    const wrapper = renderWithRedux(<AvatarMenu user={user} onClick={onClick} />)
+    fireEvent.click(wrapper.getByText(user.id))
     expect(onClick).toHaveBeenCalled()
   })
 })

--- a/assets/scripts/menus/__tests__/__snapshots__/AvatarMenu.test.js.snap
+++ b/assets/scripts/menus/__tests__/__snapshots__/AvatarMenu.test.js.snap
@@ -1,17 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AvatarMenu renders user avatar 1`] = `
-<button
-  className="menu-attached menu-avatar"
-  onClick={[Function]}
->
-  <Memo(Connect(Avatar))
-    userId="foo"
-  />
-  <span
-    className="user-id"
+<DocumentFragment>
+  <button
+    class="menu-attached menu-avatar"
   >
-    foo
-  </span>
-</button>
+    <div
+      class="avatar"
+    >
+      <img
+        alt="foo"
+      />
+    </div>
+    <span
+      class="user-id"
+    >
+      foo
+    </span>
+  </button>
+</DocumentFragment>
+`;
+
+exports[`AvatarMenu renders user avatar for admin 1`] = `
+<DocumentFragment>
+  <button
+    class="menu-attached menu-avatar"
+  >
+    <div
+      class="avatar"
+    >
+      <img
+        alt="foo"
+      />
+    </div>
+    <svg
+      class="svg-inline--fa menu-avatar-admin fa-crown"
+    />
+    <span
+      class="user-id"
+    >
+      foo
+    </span>
+  </button>
+</DocumentFragment>
 `;

--- a/assets/scripts/menus/__tests__/__snapshots__/AvatarMenu.test.js.snap
+++ b/assets/scripts/menus/__tests__/__snapshots__/AvatarMenu.test.js.snap
@@ -5,7 +5,7 @@ exports[`AvatarMenu renders user avatar 1`] = `
   className="menu-attached menu-avatar"
   onClick={[Function]}
 >
-  <Connect(Avatar)
+  <Memo(Connect(Avatar))
     userId="foo"
   />
   <span

--- a/assets/scripts/menus/__tests__/__snapshots__/ShareMenu.test.js.snap
+++ b/assets/scripts/menus/__tests__/__snapshots__/ShareMenu.test.js.snap
@@ -39,7 +39,7 @@ exports[`ShareMenu renders (user not signed in) 1`] = `
       target="_blank"
     >
       <svg
-        class="svg-inline--fa fa-twitter"
+        class="svg-inline--fa menu-item-icon fa-twitter"
       />
       Share using Twitter
     </a>
@@ -50,7 +50,7 @@ exports[`ShareMenu renders (user not signed in) 1`] = `
       target="_blank"
     >
       <svg
-        class="svg-inline--fa fa-facebook-square"
+        class="svg-inline--fa menu-item-icon fa-facebook-square"
       />
       Share using Facebook
     </a>
@@ -103,7 +103,7 @@ exports[`ShareMenu renders (user signed in) 1`] = `
       target="_blank"
     >
       <svg
-        class="svg-inline--fa fa-twitter"
+        class="svg-inline--fa menu-item-icon fa-twitter"
       />
       Share using Twitter
     </a>
@@ -114,7 +114,7 @@ exports[`ShareMenu renders (user signed in) 1`] = `
       target="_blank"
     >
       <svg
-        class="svg-inline--fa fa-facebook-square"
+        class="svg-inline--fa menu-item-icon fa-facebook-square"
       />
       Share using Facebook
     </a>

--- a/test/__mocks__/@fortawesome/react-fontawesome.js
+++ b/test/__mocks__/@fortawesome/react-fontawesome.js
@@ -6,18 +6,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-export function FontAwesomeIcon (props) {
-  const classNames = ['svg-inline--fa']
-
-  if (typeof props.icon === 'string') {
-    classNames.push(props.icon)
-  } else {
-    classNames.push(`fa-${props.icon.iconName}`)
-  }
-
-  return <svg className={classNames.join(' ')} />
-}
-
 FontAwesomeIcon.propTypes = {
   icon: PropTypes.oneOfType([
     PropTypes.string,
@@ -26,5 +14,23 @@ FontAwesomeIcon.propTypes = {
       iconName: PropTypes.string,
       icon: PropTypes.arrayOf(PropTypes.any)
     })
-  ]).isRequired
+  ]).isRequired,
+  className: PropTypes.string
+}
+
+export function FontAwesomeIcon (props) {
+  const { icon, className } = props
+  const classNames = ['svg-inline--fa']
+
+  if (className) {
+    classNames.push(className)
+  }
+
+  if (typeof icon === 'string') {
+    classNames.push(icon)
+  } else {
+    classNames.push(`fa-${icon.iconName}`)
+  }
+
+  return <svg className={classNames.join(' ')} />
 }


### PR DESCRIPTION
The axios (XHR) request in the `<Avatar />` component did not have an error handler, so when the component unmounted prematurely (e.g. the component re-renders; the component is rendered and then cleaned up rapidly during a test) the cancelled network request would be left unhandled. In particular this caused problems in our tests. This PR now prevents cancelled requests from logging errors, because we don't expect cancelled requests to be critical errors.

Other updates:
- The `<Avatar />` component is now rendered with `React.memo()` so that a single instance of the component doesn't re-render more often than is necessary.
- The `<AvatarMenu />` component test had to be updated, and as a result, has been ported to use `react-testing-library` over Enzyme.
- The mock `<FontAwesomeIcon />` component now correctly renders with custom class name props.