### PR TITLE
Adopt Prettier for staged JS files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+scripts/vendor

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,19 @@
+{
+  "overrides": [
+    {
+      "files": ["*.js", "*.jsx"],
+      "options": {
+        "semi": false,
+        "singleQuote": true,
+        "arrowParens": "always",
+        "htmlWhitespaceSensitivity": "strict"
+      }
+    },
+    {
+      "files": ["*.md"],
+      "options": {
+        "proseWrap": "never"
+      }
+    }
+  ]
+}

--- a/assets/scripts/app/BlockingError.jsx
+++ b/assets/scripts/app/BlockingError.jsx
@@ -9,286 +9,486 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { FormattedMessage, FormattedHTMLMessage } from 'react-intl'
 import Avatar from '../users/Avatar'
-import {
-  goReload,
-  goHome,
-  goNewStreet,
-  goExampleStreet
-} from './routing'
+import { goReload, goHome, goNewStreet, goExampleStreet } from './routing'
 import { goReloadClearSignIn } from '../users/authentication'
 import { ERRORS } from './errors'
 import PropTypes from 'prop-types'
 
-export class BlockingError extends React.Component {
-  static propTypes = {
-    errorType: PropTypes.number,
-    street: PropTypes.object
-  }
+BlockingError.propTypes = {
+  errorType: PropTypes.number,
+  street: PropTypes.object
+}
 
-  render () {
-    let title = ''
-    let description = ''
+function BlockingError (props) {
+  let title = ''
+  let description = ''
 
-    const homeButton =
-      <button onClick={goHome}>
-        <FormattedMessage id="error.button.home" defaultMessage="Go to the homepage" />
-      </button>
-    const linkToUser = (street) => {
-      return street && street.creatorId ? <a href={'/' + street.creatorId}><Avatar userId={street.creatorId} />{street.creatorId}</a> : null
-    }
-    const reloadButton =
-      <button onClick={goReload}>
-        <FormattedMessage id="error.button.reload" defaultMessage="Reload the page" />
-      </button>
-    const tryAgainButton =
-      <button onClick={goNewStreet}>
-        <FormattedMessage id="error.button.try-again" defaultMessage="Try again" />
-      </button>
-    const pleaseLetUsKnow =
-      <FormattedHTMLMessage
-        id="error.please-try-again"
-        defaultMessage="Please try again later or let us know via <a target='_blank' rel='noopener noreferrer' href='{email}'>email</a> or <a target='_blank' rel='noopener noreferrer' href='{tweet}'>Twitter</a>."
-        values={{
-          email: 'mailto:hello@streetmix.net',
-          tweet: 'https://twitter.com/intent/tweet?text=@streetmix'
-        }}
+  const homeButton = (
+    <button onClick={goHome}>
+      <FormattedMessage
+        id="error.button.home"
+        defaultMessage="Go to the homepage"
       />
-
-    switch (this.props.errorType) {
-      case ERRORS.NOT_FOUND:
-        title = <FormattedMessage id="error.page-not-found-title" defaultMessage="Page not found." />
-        description =
-          <>
-            <FormattedMessage id="error.page-not-found-description" defaultMessage="Oh, boy. There is no page with this address!" />
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.STREET_404:
-        title = <FormattedMessage id="error.street-not-found-title" defaultMessage="Street not found." />
-        description =
-          <>
-            <FormattedMessage id="error.street-not-found-description" defaultMessage="Oh, boy. There is no street with this link!" />
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.STREET_404_BUT_LINK_TO_USER:
-        title = <FormattedMessage id="error.street-not-found-title" defaultMessage="Street not found." />
-        description =
-          <>
-            <FormattedMessage
-              id="error.street-not-found-but-user-description"
-              defaultMessage="There is no street with this link! But you can look at other streets by {user}"
-              values={{
-                user: linkToUser(this.props.street)
-              }}
-            />
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.STREET_410_BUT_LINK_TO_USER:
-        title = <FormattedMessage id="error.street-deleted-title" defaultMessage="This street has been deleted." />
-        description =
-          <>
-            <FormattedMessage
-              id="error.street-deleted-description"
-              defaultMessage="There is no longer a street with this link, but you can look at other streets by {user}"
-              values={{
-                user: linkToUser(this.props.street)
-              }}
-            />
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.SIGN_OUT:
-        title = <FormattedMessage id="error.sign-out-title" defaultMessage="You are now signed out." />
-        description = homeButton
-        break
-      case ERRORS.NO_STREET:
-        title = <FormattedMessage id="msg.no-street" defaultMessage="No street selected." />
-        break
-      case ERRORS.GALLERY_STREET_FAILURE:
-        title = <FormattedMessage id="msg.having-trouble" defaultMessage="Having trouble…" />
-        description = <FormattedMessage id="error.gallery-street-failure-description" defaultMessage="We’re having trouble loading this street." />
-        break
-      case ERRORS.FORCE_RELOAD_SIGN_OUT:
-        title = <FormattedMessage id="error.reload-sign-out-title" defaultMessage="You signed out in another window." />
-        description =
-          <>
-            <FormattedMessage id="error.please-reload" defaultMessage="Please reload this page before continuing." />
-            <br />
-            {reloadButton}
-          </>
-        break
-      case ERRORS.FORCE_RELOAD_SIGN_OUT_401:
-        title = <FormattedMessage id="error.reload-sign-out-title" defaultMessage="You signed out in another window." />
-        description =
-          <>
-            <FormattedMessage id="error.please-reload" defaultMessage="Please reload this page before continuing." />
-            <br />
-            <FormattedMessage id="error.error-code" defaultMessage="(Error {code}.)" values={{ code: 'RM2' }} />
-            <br />
-            <button onClick={goReloadClearSignIn}>
-              <FormattedMessage id="error.button.reload" defaultMessage="Reload the page" />
-            </button>
-          </>
-        break
-      case ERRORS.FORCE_RELOAD_SIGN_IN:
-        title = <FormattedMessage id="error.reload-sign-in-title" defaultMessage="You signed in in another window." />
-        description =
-          <>
-            <FormattedMessage id="error.please-reload" defaultMessage="Please reload this page before continuing." />
-            <br />
-            {reloadButton}
-          </>
-        break
-      case ERRORS.STREET_DELETED_ELSEWHERE:
-        title = <FormattedMessage id="error.street-deleted-elsewhere-title" defaultMessage="This street has been deleted elsewhere." />
-        description =
-          <>
-            <FormattedMessage id="error.street-deleted-elsewhere-description" defaultMessage="This street has been deleted in another browser." />
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.NEW_STREET_SERVER_FAILURE:
-        title = <FormattedMessage id="msg.having-trouble" defaultMessage="Having trouble…" />
-        description =
-          <>
-            <FormattedMessage id="msg.trouble-loading" defaultMessage="We’re having trouble loading Streetmix." />
-            <br />
-            {tryAgainButton}
-          </>
-        break
-      case ERRORS.SIGN_IN_SERVER_FAILURE:
-        title = <FormattedMessage id="msg.having-trouble" defaultMessage="Having trouble…" />
-        description =
-          <>
-            <FormattedMessage id="msg.trouble-loading" defaultMessage="We’re having trouble loading Streetmix." />
-            <br />
-            <FormattedMessage id="error.error-code" defaultMessage="(Error {code}.)" values={{ code: '15A' }} />
-            <br />
-            {tryAgainButton}
-          </>
-        break
-      case ERRORS.SIGN_IN_401:
-        title = <FormattedMessage id="msg.having-trouble" defaultMessage="Having trouble…" />
-        description =
-          <>
-            <FormattedMessage id="msg.trouble-loading" defaultMessage="We’re having trouble loading Streetmix." />
-            <br />
-            <FormattedMessage id="error.error-code" defaultMessage="(Error {code}.)" values={{ code: 'RM1' }} />
-            <br />
-            {tryAgainButton}
-          </>
-        break
-      case ERRORS.STREET_DATA_FAILURE:
-        title = <FormattedMessage id="msg.having-trouble" defaultMessage="Having trouble…" />
-        description =
-          <>
-            <FormattedMessage id="msg.trouble-loading" defaultMessage="We’re having trouble loading Streetmix." />
-            <br />
-            <FormattedMessage id="error.error-code" defaultMessage="(Error {code}.)" values={{ code: '9B' }} />
-            <br />
-            {tryAgainButton}
-          </>
-        break
-      case ERRORS.ACCESS_DENIED:
-        title = <FormattedMessage id="error.access-denied-title" defaultMessage="You are not signed in." />
-        description =
-          <>
-            <FormattedMessage id="error.access-denied-description" defaultMessage="You cancelled the sign in process." />
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.AUTH_PROBLEM_NO_TWITTER_REQUEST_TOKEN:
-      case ERRORS.AUTH_PROBLEM_NO_TWITTER_ACCESS_TOKEN:
-      case ERRORS.AUTH_PROBLEM_NO_ACCESS_TOKEN:
-      case ERRORS.AUTH_PROBLEM_API_PROBLEM:
-        title = <FormattedMessage id="error.auth-api-problem-title" defaultMessage="There was a problem with signing you in." />
-        description =
-          <>
-            <FormattedMessage id="error.auth-api-problem-description" defaultMessage="There was a problem with authentication." />
-            &nbsp;{pleaseLetUsKnow}
-            <br />
-            {homeButton}
-          </>
-        break
-      case ERRORS.UNSUPPORTED_BROWSER:
-        title = <FormattedMessage id="error.unsupported-browser-title" defaultMessage="Streetmix doesn’t work on your browser." />
-        description =
-          <>
-            <p>
-              <FormattedHTMLMessage
-                id="error.unsupported-browser-description"
-                defaultMessage="Sorry about that. You might want to try <a target='_blank' rel='noopener noreferrer' href='{chromeUrl}'>Chrome</a>, <a target='_blank' rel='noopener noreferrer' href='{firefoxUrl}'>Firefox</a>, <a target='_blank' rel='noopener noreferrer' href='{edgeUrl}'>Microsoft Edge</a>, or Safari."
-                values={{
-                  chromeUrl: 'https://www.google.com/chrome',
-                  firefoxUrl: 'https://www.mozilla.org/firefox',
-                  edgeUrl: 'https://www.microsoft.com/en-us/windows/microsoft-edge'
-                }}
-              />
-            </p>
-            <p>
-              <FormattedHTMLMessage
-                id="error.unsupported-browser-internet-explorer"
-                defaultMessage="Are you on Internet Explorer? <a target='_blank' rel='noopener noreferrer' href='{readmeIEUrl}'>Find out more.</a>"
-                values={{
-                  readmeIEUrl: 'https://streetmix.readthedocs.io/en/latest/support/faq/#does-streetmix-support-internet-explorer'
-                }}
-              />
-            </p>
-            <p>
-              <FormattedHTMLMessage
-                id="error.unsupported-browser-contact-us"
-                defaultMessage="If you think your browser should be supported, please contact us via <a target='_blank' rel='noopener noreferrer' href='{email}'>email</a>."
-                values={{
-                  email: 'mailto:hello@streetmix.net'
-                }}
-              />
-            </p>
-          </>
-        break
-      case ERRORS.CANNOT_CREATE_NEW_STREET_ON_PHONE:
-        title = <FormattedMessage id="error.cannot-create-new-street-on-phone-title" defaultMessage="Streetmix works on tablets and desktops only." />
-        description =
-          <>
-            <FormattedMessage id="error.cannot-create-new-street-on-phone-description" defaultMessage="If you follow another link to a specific street, you can view it on your phone – but you cannot yet create new streets." />
-            <br />
-            <button onClick={goExampleStreet}>
-              <FormattedMessage id="error.button.view-example" defaultMessage="View an example street" />
-            </button>
-          </>
-        break
-      default: // also ERRORS.GENERIC_ERROR
-        title = <FormattedMessage id="error.generic-error-title" defaultMessage="Something went wrong." />
-        description =
-          <>
-            <FormattedMessage id="error.generic-error-description" defaultMessage="We’re sorry – something went wrong." />
-            &nbsp;{pleaseLetUsKnow}
-            <br />
-            {homeButton}
-          </>
-        break
-    }
-
-    return this.props.errorType ? (
-      <div id="error">
-        <div className="clouds-background">
-          <div className="rear-clouds" />
-          <div className="front-clouds" />
-        </div>
-        <div className="error-content">
-          <h1>{title}</h1>
-          <div>{description}</div>
-        </div>
-      </div>
+    </button>
+  )
+  const linkToUser = (street) => {
+    return street && street.creatorId ? (
+      <a href={'/' + street.creatorId}>
+        <Avatar userId={street.creatorId} />
+        {street.creatorId}
+      </a>
     ) : null
   }
+  const reloadButton = (
+    <button onClick={goReload}>
+      <FormattedMessage
+        id="error.button.reload"
+        defaultMessage="Reload the page"
+      />
+    </button>
+  )
+  const tryAgainButton = (
+    <button onClick={goNewStreet}>
+      <FormattedMessage
+        id="error.button.try-again"
+        defaultMessage="Try again"
+      />
+    </button>
+  )
+  const pleaseLetUsKnow = (
+    <FormattedHTMLMessage
+      id="error.please-try-again"
+      defaultMessage="Please try again later or let us know via <a target='_blank' rel='noopener noreferrer' href='{email}'>email</a> or <a target='_blank' rel='noopener noreferrer' href='{tweet}'>Twitter</a>."
+      values={{
+        email: 'mailto:hello@streetmix.net',
+        tweet: 'https://twitter.com/intent/tweet?text=@streetmix'
+      }}
+    />
+  )
+
+  switch (props.errorType) {
+    case ERRORS.NOT_FOUND:
+      title = (
+        <FormattedMessage
+          id="error.page-not-found-title"
+          defaultMessage="Page not found."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.page-not-found-description"
+            defaultMessage="Oh, boy. There is no page with this address!"
+          />
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.STREET_404:
+      title = (
+        <FormattedMessage
+          id="error.street-not-found-title"
+          defaultMessage="Street not found."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.street-not-found-description"
+            defaultMessage="Oh, boy. There is no street with this link!"
+          />
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.STREET_404_BUT_LINK_TO_USER:
+      title = (
+        <FormattedMessage
+          id="error.street-not-found-title"
+          defaultMessage="Street not found."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.street-not-found-but-user-description"
+            defaultMessage="There is no street with this link! But you can look at other streets by {user}"
+            values={{
+              user: linkToUser(props.street)
+            }}
+          />
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.STREET_410_BUT_LINK_TO_USER:
+      title = (
+        <FormattedMessage
+          id="error.street-deleted-title"
+          defaultMessage="This street has been deleted."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.street-deleted-description"
+            defaultMessage="There is no longer a street with this link, but you can look at other streets by {user}"
+            values={{
+              user: linkToUser(props.street)
+            }}
+          />
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.SIGN_OUT:
+      title = (
+        <FormattedMessage
+          id="error.sign-out-title"
+          defaultMessage="You are now signed out."
+        />
+      )
+      description = homeButton
+      break
+    case ERRORS.NO_STREET:
+      title = (
+        <FormattedMessage
+          id="msg.no-street"
+          defaultMessage="No street selected."
+        />
+      )
+      break
+    case ERRORS.GALLERY_STREET_FAILURE:
+      title = (
+        <FormattedMessage
+          id="msg.having-trouble"
+          defaultMessage="Having trouble…"
+        />
+      )
+      description = (
+        <FormattedMessage
+          id="error.gallery-street-failure-description"
+          defaultMessage="We’re having trouble loading this street."
+        />
+      )
+      break
+    case ERRORS.FORCE_RELOAD_SIGN_OUT:
+      title = (
+        <FormattedMessage
+          id="error.reload-sign-out-title"
+          defaultMessage="You signed out in another window."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.please-reload"
+            defaultMessage="Please reload this page before continuing."
+          />
+          <br />
+          {reloadButton}
+        </>
+      )
+      break
+    case ERRORS.FORCE_RELOAD_SIGN_OUT_401:
+      title = (
+        <FormattedMessage
+          id="error.reload-sign-out-title"
+          defaultMessage="You signed out in another window."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.please-reload"
+            defaultMessage="Please reload this page before continuing."
+          />
+          <br />
+          <FormattedMessage
+            id="error.error-code"
+            defaultMessage="(Error {code}.)"
+            values={{ code: 'RM2' }}
+          />
+          <br />
+          <button onClick={goReloadClearSignIn}>
+            <FormattedMessage
+              id="error.button.reload"
+              defaultMessage="Reload the page"
+            />
+          </button>
+        </>
+      )
+      break
+    case ERRORS.FORCE_RELOAD_SIGN_IN:
+      title = (
+        <FormattedMessage
+          id="error.reload-sign-in-title"
+          defaultMessage="You signed in in another window."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.please-reload"
+            defaultMessage="Please reload this page before continuing."
+          />
+          <br />
+          {reloadButton}
+        </>
+      )
+      break
+    case ERRORS.STREET_DELETED_ELSEWHERE:
+      title = (
+        <FormattedMessage
+          id="error.street-deleted-elsewhere-title"
+          defaultMessage="This street has been deleted elsewhere."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.street-deleted-elsewhere-description"
+            defaultMessage="This street has been deleted in another browser."
+          />
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.NEW_STREET_SERVER_FAILURE:
+      title = (
+        <FormattedMessage
+          id="msg.having-trouble"
+          defaultMessage="Having trouble…"
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="msg.trouble-loading"
+            defaultMessage="We’re having trouble loading Streetmix."
+          />
+          <br />
+          {tryAgainButton}
+        </>
+      )
+      break
+    case ERRORS.SIGN_IN_SERVER_FAILURE:
+      title = (
+        <FormattedMessage
+          id="msg.having-trouble"
+          defaultMessage="Having trouble…"
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="msg.trouble-loading"
+            defaultMessage="We’re having trouble loading Streetmix."
+          />
+          <br />
+          <FormattedMessage
+            id="error.error-code"
+            defaultMessage="(Error {code}.)"
+            values={{ code: '15A' }}
+          />
+          <br />
+          {tryAgainButton}
+        </>
+      )
+      break
+    case ERRORS.SIGN_IN_401:
+      title = (
+        <FormattedMessage
+          id="msg.having-trouble"
+          defaultMessage="Having trouble…"
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="msg.trouble-loading"
+            defaultMessage="We’re having trouble loading Streetmix."
+          />
+          <br />
+          <FormattedMessage
+            id="error.error-code"
+            defaultMessage="(Error {code}.)"
+            values={{ code: 'RM1' }}
+          />
+          <br />
+          {tryAgainButton}
+        </>
+      )
+      break
+    case ERRORS.STREET_DATA_FAILURE:
+      title = (
+        <FormattedMessage
+          id="msg.having-trouble"
+          defaultMessage="Having trouble…"
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="msg.trouble-loading"
+            defaultMessage="We’re having trouble loading Streetmix."
+          />
+          <br />
+          <FormattedMessage
+            id="error.error-code"
+            defaultMessage="(Error {code}.)"
+            values={{ code: '9B' }}
+          />
+          <br />
+          {tryAgainButton}
+        </>
+      )
+      break
+    case ERRORS.ACCESS_DENIED:
+      title = (
+        <FormattedMessage
+          id="error.access-denied-title"
+          defaultMessage="You are not signed in."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.access-denied-description"
+            defaultMessage="You cancelled the sign in process."
+          />
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.AUTH_PROBLEM_NO_TWITTER_REQUEST_TOKEN:
+    case ERRORS.AUTH_PROBLEM_NO_TWITTER_ACCESS_TOKEN:
+    case ERRORS.AUTH_PROBLEM_NO_ACCESS_TOKEN:
+    case ERRORS.AUTH_PROBLEM_API_PROBLEM:
+      title = (
+        <FormattedMessage
+          id="error.auth-api-problem-title"
+          defaultMessage="There was a problem with signing you in."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.auth-api-problem-description"
+            defaultMessage="There was a problem with authentication."
+          />
+          &nbsp;{pleaseLetUsKnow}
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+    case ERRORS.UNSUPPORTED_BROWSER:
+      title = (
+        <FormattedMessage
+          id="error.unsupported-browser-title"
+          defaultMessage="Streetmix doesn’t work on your browser."
+        />
+      )
+      description = (
+        <>
+          <p>
+            <FormattedHTMLMessage
+              id="error.unsupported-browser-description"
+              defaultMessage="Sorry about that. You might want to try <a target='_blank' rel='noopener noreferrer' href='{chromeUrl}'>Chrome</a>, <a target='_blank' rel='noopener noreferrer' href='{firefoxUrl}'>Firefox</a>, <a target='_blank' rel='noopener noreferrer' href='{edgeUrl}'>Microsoft Edge</a>, or Safari."
+              values={{
+                chromeUrl: 'https://www.google.com/chrome',
+                firefoxUrl: 'https://www.mozilla.org/firefox',
+                edgeUrl:
+                  'https://www.microsoft.com/en-us/windows/microsoft-edge'
+              }}
+            />
+          </p>
+          <p>
+            <FormattedHTMLMessage
+              id="error.unsupported-browser-internet-explorer"
+              defaultMessage="Are you on Internet Explorer? <a target='_blank' rel='noopener noreferrer' href='{readmeIEUrl}'>Find out more.</a>"
+              values={{
+                readmeIEUrl:
+                  'https://streetmix.readthedocs.io/en/latest/support/faq/#does-streetmix-support-internet-explorer'
+              }}
+            />
+          </p>
+          <p>
+            <FormattedHTMLMessage
+              id="error.unsupported-browser-contact-us"
+              defaultMessage="If you think your browser should be supported, please contact us via <a target='_blank' rel='noopener noreferrer' href='{email}'>email</a>."
+              values={{
+                email: 'mailto:hello@streetmix.net'
+              }}
+            />
+          </p>
+        </>
+      )
+      break
+    case ERRORS.CANNOT_CREATE_NEW_STREET_ON_PHONE:
+      title = (
+        <FormattedMessage
+          id="error.cannot-create-new-street-on-phone-title"
+          defaultMessage="Streetmix works on tablets and desktops only."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.cannot-create-new-street-on-phone-description"
+            defaultMessage="If you follow another link to a specific street, you can view it on your phone – but you cannot yet create new streets."
+          />
+          <br />
+          <button onClick={goExampleStreet}>
+            <FormattedMessage
+              id="error.button.view-example"
+              defaultMessage="View an example street"
+            />
+          </button>
+        </>
+      )
+      break
+    default:
+      // also ERRORS.GENERIC_ERROR
+      title = (
+        <FormattedMessage
+          id="error.generic-error-title"
+          defaultMessage="Something went wrong."
+        />
+      )
+      description = (
+        <>
+          <FormattedMessage
+            id="error.generic-error-description"
+            defaultMessage="We’re sorry – something went wrong."
+          />
+          &nbsp;{pleaseLetUsKnow}
+          <br />
+          {homeButton}
+        </>
+      )
+      break
+  }
+
+  return props.errorType ? (
+    <div id="error">
+      <div className="clouds-background">
+        <div className="rear-clouds" />
+        <div className="front-clouds" />
+      </div>
+      <div className="error-content">
+        <h1>{title}</h1>
+        <div>{description}</div>
+      </div>
+    </div>
+  ) : null
 }
 
 function mapStateToProps (state) {

--- a/assets/scripts/app/__tests__/BlockingError.test.js
+++ b/assets/scripts/app/__tests__/BlockingError.test.js
@@ -1,15 +1,22 @@
 /* eslint-env jest */
 import React from 'react'
-import { shallow } from 'enzyme'
-import { BlockingError } from '../BlockingError'
+import { renderWithReduxAndIntl } from '../../../../test/helpers/render'
+import BlockingError from '../BlockingError'
 import { ERRORS } from '../errors'
 
 jest.mock('../load_resources', () => {})
 jest.mock('../../users/authentication', () => {})
 
 describe('BlockingError', () => {
+  const initialState = {
+    errors: {
+      errorType: ERRORS.NOT_FOUND
+    },
+    street: {}
+  }
+
   it('renders', () => {
-    const wrapper = shallow(<BlockingError errorType={ERRORS.NOT_FOUND} street={{}} />)
-    expect(wrapper.exists()).toEqual(true)
+    const wrapper = renderWithReduxAndIntl(<BlockingError />, { initialState })
+    expect(wrapper.asFragment()).toMatchSnapshot()
   })
 })

--- a/assets/scripts/app/__tests__/Flash.test.js
+++ b/assets/scripts/app/__tests__/Flash.test.js
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import React from 'react'
-import { shallow } from 'enzyme'
+import { renderWithRedux } from '../../../../test/helpers/render'
 import Flash from '../Flash'
 
 describe('Flash', () => {
   it('renders', () => {
-    const wrapper = shallow(<Flash />)
-    expect(wrapper).toMatchSnapshot()
+    const wrapper = renderWithRedux(<Flash />)
+    expect(wrapper.asFragment()).toMatchSnapshot()
   })
 })

--- a/assets/scripts/app/__tests__/__snapshots__/BlockingError.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/BlockingError.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BlockingError renders 1`] = `
+<DocumentFragment>
+  <div
+    id="error"
+  >
+    <div
+      class="clouds-background"
+    >
+      <div
+        class="rear-clouds"
+      />
+      <div
+        class="front-clouds"
+      />
+    </div>
+    <div
+      class="error-content"
+    >
+      <h1>
+        Page not found.
+      </h1>
+      <div>
+        Oh, boy. There is no page with this address!
+        <br />
+        <button>
+          Go to the homepage
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/assets/scripts/app/__tests__/__snapshots__/Flash.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/Flash.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Flash renders 1`] = `
-<div
-  className="flash"
-/>
+<DocumentFragment>
+  <div
+    class="flash"
+  />
+</DocumentFragment>
 `;

--- a/package.json
+++ b/package.json
@@ -84,11 +84,8 @@
     }
   },
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ],
-    "*.jsx": [
+    "*.{js,jsx}": [
+      "prettier --write",
       "eslint --fix",
       "git add"
     ],


### PR DESCRIPTION
See #1528 .

I had a lot of issues getting just sections of files to be formatted, so the tradeoff is to format entire files if they've been staged for a commit.

This does not include text editor save-as-you-go formatting, in part because Prettier will do its own thing, and then eslint -fix will do its own thing on top of it. Both will occur during the lint-staged process during a commit.