### PR TITLE
feat: add client_updated_at to street data model

### DIFF
--- a/app/api_routes.js
+++ b/app/api_routes.js
@@ -211,6 +211,11 @@ const resources = require('./resources')
  *       updatedAt:
  *         type: string
  *         format: date-time
+ *         description: Server-side updates will update this timestamp. This is the canonical timestamp for the street and should be used for display purposes.
+ *       clientUpdatedAt:
+ *         type: string
+ *         format: date-time
+ *         description: Client-side updates will update this timestamp. This should only be used to verify the age of client side data.
  *   Flags:
  *     type: object
  *     example:

--- a/app/db/models/street.js
+++ b/app/db/models/street.js
@@ -21,6 +21,7 @@ module.exports = (sequelize, DataTypes) => {
     timestamp: true,
     createdAt: 'created_at',
     updatedAt: 'updated_at',
+    clientUpdatedAt: 'client_updated_at',
     index: [{
       fields: ['namespaced_id', 'created_at', 'updated_at']
     }]

--- a/app/models/street.js
+++ b/app/models/street.js
@@ -15,6 +15,7 @@ const streetSchema = new mongoose.Schema({
   data: mongoose.Schema.Types.Mixed,
   created_at: { type: Date, index: true },
   updated_at: { type: Date, index: true },
+  client_updated_at: { type: Date },
   creator_ip: String
 })
 
@@ -39,7 +40,8 @@ streetSchema.methods.asJson = function (cb) {
     name: this.name,
     data: this.data,
     createdAt: this.created_at,
-    updatedAt: this.updated_at
+    updatedAt: this.updated_at,
+    clientUpdatedAt: this.client_updated_at
   }
 
   const creatorId = this.creator_id

--- a/app/resources/v1/streets.js
+++ b/app/resources/v1/streets.js
@@ -25,6 +25,7 @@ exports.post = async function (req, res) {
     street.name = body.name
     street.data = body.data
     street.creator_ip = requestIp(req)
+    street.client_updated_at = body.clientUpdatedAt
   }
 
   const makeNamespacedId = async function () {
@@ -407,6 +408,8 @@ exports.put = async function (req, res) {
   async function updateStreetData (street) {
     street.name = body.name || street.name
     street.data = body.data || street.data
+    street.client_updated_at = body.clientUpdatedAt || street.client_updated_at
+
     if (body.originalStreetId) {
       let origStreet
       try {
@@ -421,10 +424,9 @@ exports.put = async function (req, res) {
       }
 
       street.original_street_id = origStreet
-      return street.save()
-    } else {
-      return street.save()
     }
+
+    return street.save()
   } // END function - updateStreetData
 
   async function updateStreetWithCreatorId (street) {

--- a/assets/scripts/store/reducers/street.js
+++ b/assets/scripts/store/reducers/street.js
@@ -144,7 +144,8 @@ const street = (state = initialState, action) => {
     case SET_UPDATE_TIME:
       return {
         ...state,
-        updatedAt: action.time
+        updatedAt: action.time,
+        clientUpdatedAt: action.time
       }
     case SAVE_ORIGINAL_STREET_ID:
       return {

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -366,6 +366,7 @@ function fillDefaultSegments (units) {
 
 export function prepareDefaultStreet () {
   const units = getUnits()
+  const currentDate = new Date().toISOString()
   const defaultStreet = {
     units: units,
     location: null,
@@ -380,7 +381,8 @@ export function prepareDefaultStreet () {
     rightBuildingVariant: DEFAULT_BUILDING_VARIANT_RIGHT,
     schemaVersion: LATEST_SCHEMA_VERSION,
     segments: fillDefaultSegments(units),
-    updatedAt: new Date().toISOString(),
+    updatedAt: currentDate,
+    clientUpdatedAt: currentDate,
     creatorId: (isSignedIn() && getSignInData().userId) || null
   }
 
@@ -393,6 +395,7 @@ export function prepareDefaultStreet () {
 
 export function prepareEmptyStreet () {
   const units = getUnits()
+  const currentDate = new Date().toISOString()
   const emptyStreet = {
     units: units,
     location: null,
@@ -407,7 +410,8 @@ export function prepareEmptyStreet () {
     rightBuildingVariant: DEFAULT_BUILDING_VARIANT_EMPTY,
     schemaVersion: LATEST_SCHEMA_VERSION,
     segments: [],
-    updatedAt: new Date().toISOString(),
+    updatedAt: currentDate,
+    clientUpdatedAt: currentDate,
     creatorId: (isSignedIn() && getSignInData().userId) || null
   }
 

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -269,16 +269,18 @@ export function fetchStreetForVerification () {
 }
 
 /**
- * Compares the street data locally to the street data received from the server.
- * If the local copy is outdated, then we replace it with the updated data.
+ * Compare the `clientUpdatedAt` value of local data to server data.
+ * We don't use `updatedAt` which is only updated on the server. We use
+ * `clientUpdatedAt` which is only used to validate the age of local data.
+ * If local data is outdated, then we replace it with the updated data.
  *
  * @param {Object} transmission - server data
  */
 function receiveStreetForVerification (transmission) {
-  const localUpdatedAt = new Date(store.getState().street.updatedAt)
-  const serverUpdatedAt = new Date(transmission.updatedAt)
+  const localUpdatedAt = new Date(store.getState().street.clientUpdatedAt)
+  const serverUpdatedAt = new Date(transmission.clientUpdatedAt)
 
-  if (serverUpdatedAt > localUpdatedAt) {
+  if (serverUpdatedAt && localUpdatedAt && serverUpdatedAt > localUpdatedAt) {
     showStatusMessage(
       t(
         'toast.reloaded',
@@ -326,6 +328,7 @@ function unpackStreetDataFromServerTransmission (transmission) {
   street.creatorId = (transmission.creator && transmission.creator.id) || null
   street.originalStreetId = transmission.originalStreetId || null
   street.updatedAt = transmission.updatedAt || null
+  street.clientUpdatedAt = transmission.clientUpdatedAt || null
   street.name = transmission.name || null
   street.location = transmission.data.street.location || null
 
@@ -397,6 +400,7 @@ export function packServerStreetData () {
   delete data.street.name
   delete data.street.originalStreetId
   delete data.street.updatedAt
+  delete data.street.clientUpdatedAt
 
   // This will be implied through authorization header
   delete data.street.creatorId
@@ -410,7 +414,8 @@ export function packServerStreetData () {
   var transmission = {
     name: street.name,
     originalStreetId: street.originalStreetId,
-    data: data
+    data: data,
+    clientUpdatedAt: street.clientUpdatedAt
   }
 
   return JSON.stringify(transmission)


### PR DESCRIPTION
### The problem

If a user has the same street opened in multiple tabs (or even across multiple browsers or devices!), updating the street in one tab will cause other tabs to be obsolete. Compounding this issue is if a user then tries to make a new update in one of the obsolete tabs; it will then clobber (overwrite) the previous update. One way that Streetmix attempts to work around this (which works in most cases) is if a user returns to a tab, it does a check with the server to see if the street has updated, and if so, reloads the current tab, so that the user is presented with the freshest version of the street.

Checking for "freshness" is the difficult part. In the past, we attempted to compare entire data structures, but this proved to be too brittle. More recently, we attempted to compare the payload's `updatedAt` value, but the problem is that **the client side update time will always lag slightly behind the server side update time.**

This means even when the update is the latest one, this discrepancy in the timestamps will cause data to appear to be out of date.

### The solution

The proposed solution here is to store a new `client_updated_at` value on the server side. This value represents the most recent `updatedAt` value that is generated on the client side. As a result, when we compare the local (client side) timestamp with the stored timestamp from the server's most recent copy, we will expect to see the same timestamps when the data is current.

We still store `updated_at` on the server side using the server-side generated value, because we may still want to preserve the server-side canonical timestamp. This canonical timestamp will still be used in all other situations: for instance, displaying the age of a street, or sorting by update time. The `client_updated_at` value will *only* be used to compare the freshness of data.

### Notes:

- Swagger API has been updated and a description has been added to both `updated_at` and `client_updated_at` to distinguish between their purposes.
- This PR does not include changes necessary to update the schema in Postgres.
- Prettier's auto-formatting has been disabled during the commit phase to keep the changes in this PR easier to review.
