### PR TITLE
Disable excess sequelize logging on production

### DIFF
--- a/app/db/config/config.js
+++ b/app/db/config/config.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   production: {
     use_env_variable: 'DATABASE_URL',
+    logging: false,
     dialect: 'postgres'
   }
 }


### PR DESCRIPTION
📖 too much logging was happening in papertrail for successful queries. Let's keep these limited on production, so we don't crowd out helpful messages or go over our monthly limit.