### PR TITLE
Refactor sequelize configuration

### DIFF
--- a/app/db/config/config.js
+++ b/app/db/config/config.js
@@ -1,25 +1,13 @@
-require('dotenv').config()
+const config = require('config')
 
+// Export environment-specific Sequelize configuration
+// imported from app-level configuration
+// required by sequelize-cli utility
 module.exports = {
-  development: {
-    database: 'streetmix_dev',
-    host: process.env.PGHOST || '127.0.0.1',
-    port: process.env.PGPORT || 5432,
-    dialect: 'postgres'
-  },
-  test: {
-    database: 'streetmix_test',
-    host: process.env.PGHOST || '127.0.0.1',
-    port: process.env.PGPORT || 5432,
-    dialect: 'postgres'
-  },
-  staging: {
-    use_env_variable: 'DATABASE_URL',
-    dialect: 'postgres'
-  },
-  production: {
-    use_env_variable: 'DATABASE_URL',
-    logging: false,
-    dialect: 'postgres'
+  // Property needs to match the environment sequelize is used in
+  [config.env]: {
+    // Dialect needs to be explicitly supplied as of sequelize v4.0.0
+    dialect: 'postgres',
+    ...config.db.sequelize
   }
 }

--- a/app/db/migrations/20180729103650-create-sequence.js
+++ b/app/db/migrations/20180729103650-create-sequence.js
@@ -1,4 +1,5 @@
 'use strict'
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('Sequences', {

--- a/app/db/migrations/20191125021742-create-street.js
+++ b/app/db/migrations/20191125021742-create-street.js
@@ -1,4 +1,5 @@
 'use strict'
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('Streets', {

--- a/app/db/migrations/20191125021742-create-user.js
+++ b/app/db/migrations/20191125021742-create-user.js
@@ -1,4 +1,5 @@
 'use strict'
+
 module.exports = {
   up: (queryInterface, Sequelize) => {
     return queryInterface.createTable('Users', {

--- a/app/db/models/index.js
+++ b/app/db/models/index.js
@@ -4,20 +4,28 @@ const fs = require('fs')
 const path = require('path')
 const Sequelize = require('sequelize')
 const basename = path.basename(__filename)
-const env = process.env.NODE_ENV || 'development'
-const config = require(path.join(__dirname, '/../config/config'))[env]
+const config = require('config')
 const db = {}
 
+const configDb = config.get('db.sequelize')
+
 let sequelize
-if (config.use_env_variable) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config)
+
+// When we have a database connection URL string, it must
+// be passed in as the first argument to the Sequelize constructor.
+// Although sequelize-cli documents the `url` property as a valid
+// option, Sequelize core does not use it.
+if (config.has('db.sequelize.url')) {
+  const url = config.get('db.sequelize.url')
+  sequelize = new Sequelize(url, {
+    dialect: 'postgres',
+    ...configDb
+  })
 } else {
-  sequelize = new Sequelize(
-    config.database,
-    config.username,
-    config.password,
-    config
-  )
+  sequelize = new Sequelize({
+    dialect: 'postgres',
+    ...configDb
+  })
 }
 
 fs.readdirSync(__dirname)

--- a/app/db/models/index.js
+++ b/app/db/models/index.js
@@ -1,15 +1,16 @@
 'use strict'
 
-var fs = require('fs')
-var path = require('path')
-var Sequelize = require('sequelize')
-var basename = path.basename(__filename)
-var env = process.env.NODE_ENV || 'development'
-var config = require(path.join(__dirname, '/../config/config'))[env]
-var db = {}
+const fs = require('fs')
+const path = require('path')
+const Sequelize = require('sequelize')
+const basename = path.basename(__filename)
+const env = process.env.NODE_ENV || 'development'
+const config = require(path.join(__dirname, '/../config/config'))[env]
+const db = {}
 
+let sequelize
 if (config.use_env_variable) {
-  var sequelize = new Sequelize(process.env[config.use_env_variable], config)
+  sequelize = new Sequelize(process.env[config.use_env_variable], config)
 } else {
   sequelize = new Sequelize(
     config.database,
@@ -26,7 +27,7 @@ fs.readdirSync(__dirname)
     )
   })
   .forEach((file) => {
-    var model = sequelize.import(path.join(__dirname, file))
+    const model = sequelize.import(path.join(__dirname, file))
     if (!model) {
       throw new Error(`missing model for file: ${file}`)
     }

--- a/app/db/models/sequence.js
+++ b/app/db/models/sequence.js
@@ -1,18 +1,26 @@
+'use strict'
+
 module.exports = (sequelize, DataTypes) => {
-  var Sequence = sequelize.define('Sequence', {
-    id: {
-      type: DataTypes.STRING,
-      primaryKey: true
+  const Sequence = sequelize.define(
+    'Sequence',
+    {
+      id: {
+        type: DataTypes.STRING,
+        primaryKey: true
+      },
+      seq: {
+        type: DataTypes.INTEGER,
+        defaultValue: 1
+      }
     },
-    seq: {
-      type: DataTypes.INTEGER,
-      defaultValue: 1
+    {
+      timestamps: false
     }
-  }, {
-    timestamps: false
-  })
+  )
+
   Sequence.associate = function (models) {
     // associations can be defined here
   }
+
   return Sequence
 }

--- a/app/db/models/street.js
+++ b/app/db/models/street.js
@@ -1,6 +1,7 @@
 'use strict'
+
 module.exports = (sequelize, DataTypes) => {
-  var Street = sequelize.define(
+  const Street = sequelize.define(
     'Street',
     {
       id: {
@@ -47,6 +48,7 @@ module.exports = (sequelize, DataTypes) => {
       ]
     }
   )
+
   Street.associate = function (models) {
     models.Street.belongsTo(models.User, {
       foreignKey: 'creatorId',
@@ -58,5 +60,6 @@ module.exports = (sequelize, DataTypes) => {
       targetKey: 'id'
     })
   }
+
   return Street
 }

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -1,6 +1,7 @@
 'use strict'
+
 module.exports = (sequelize, DataTypes) => {
-  var User = sequelize.define(
+  const User = sequelize.define(
     'User',
     {
       id: {
@@ -55,8 +56,10 @@ module.exports = (sequelize, DataTypes) => {
       ]
     }
   )
+
   User.associate = function (models) {
     // associations can be defined here
   }
+
   return User
 }

--- a/config/default.js
+++ b/config/default.js
@@ -37,11 +37,10 @@ module.exports = {
     baseuri: '/api'
   },
   db: {
-    postgres: {
-      username: process.env.PG_USERNAME,
-      password: process.env.PG_PASSWORD,
-      name: 'streetmix',
-      host: '127.0.0.1'
+    sequelize: {
+      database: 'streetmix_dev',
+      host: process.env.PGHOST || '127.0.0.1',
+      port: process.env.PGPORT || 5432
     }
   },
   log_level: 'debug',

--- a/config/production.js
+++ b/config/production.js
@@ -11,6 +11,13 @@ module.exports = {
   // mixpanel_token: '61e4b1fdd39e00551df8911fe62b8c56',
   luckyorange_enabled: true,
   pinterest: '0175a0c658a16a45e7c1f6b7cefaa34f',
+  db: {
+    sequelize: {
+      // The `url` property is documented in sequelize-cli readme but not in Sequelize core
+      url: process.env.DATABASE_URL,
+      logging: false
+    }
+  },
   l10n: {
     use_local: true
   },

--- a/config/staging.js
+++ b/config/staging.js
@@ -6,6 +6,12 @@ module.exports = {
     protocol: 'https://'
   },
   facebook_app_id: '175861739245183',
+  db: {
+    sequelize: {
+      // The `url` property is documented in sequelize-cli readme but not in Sequelize core
+      url: process.env.DATABASE_URL
+    }
+  },
   l10n: {
     use_local: false
   }

--- a/config/test.js
+++ b/config/test.js
@@ -8,6 +8,13 @@ module.exports = {
     port: port,
     baseuri: '/api'
   },
+  db: {
+    sequelize: {
+      database: 'streetmix_test',
+      host: process.env.PGHOST || '127.0.0.1',
+      port: process.env.PGPORT || 5432
+    }
+  },
   l10n: {
     use_local: true
   }


### PR DESCRIPTION
Currently, environment-specific Sequelize configuration lives in its own separate file (at `./app/db/config/config.js`). For all other configuration relating to Streetmix, it lives in `./config/[env].js`). This PR consolidates Sequelize configuration into the same common location.

I also propose an alternate method for reading database URLs from environment variables, which reads it in directly, since our configuration script has access to environment variables, instead of using the `use_env_variable` configuration value. This is only a feature of the Sequelize CLI, which also already supports the `url` configuration property as a string.