### PR TITLE
fix: add flags column to user model

### DIFF
--- a/app/db/migrations/20200323115435-update-user-flags.js
+++ b/app/db/migrations/20200323115435-update-user-flags.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', 'flags', Sequelize.JSON)
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Users', 'flags')
+  }
+}

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -36,6 +36,7 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         field: 'profile_image_url'
       },
+      flags: DataTypes.JSON,
       data: DataTypes.JSON,
       lastStreetId: {
         type: DataTypes.INTEGER,


### PR DESCRIPTION
Adds back column we missed on the user model in our recent transition to postgres. 

### QA
These steps have been run on staging. 

Importing data: Assuming the import table includes a relevant mongoDB snapshot, you can add back flags with the following command:

First run the migration so that the new column is added:
```
npx sequelize-cli db:migrate
```

Then import existing flags from a mongoDB snapshot.
```
UPDATE public."Users" user1
  SET flags = user2.data->'flags'
FROM import.users user2
WHERE user1.id = user2.data->>'id';
```

Now all users should have their old feature flags present again.  🌷 