### PR TITLE
fix: include user flags in street JSON serializer

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -38,6 +38,7 @@ module.exports = {
   },
   db: {
     sequelize: {
+      logging: true,
       database: 'streetmix_dev',
       host: process.env.PGHOST || '127.0.0.1',
       port: process.env.PGPORT || 5432

--- a/lib/util.js
+++ b/lib/util.js
@@ -52,6 +52,7 @@ exports.asUserJson = function (user) {
   const userJson = {
     id: user.id,
     profileImageUrl: user.profileImageUrl,
+    flags: user.flags || {},
     roles: user.roles || [],
     data: user.data || {}
   }


### PR DESCRIPTION
🤕 fixes a case where our postgres utils didn't explicitly include `flags` as part of the user model. Going forward, we should find ways to eliminate this kind of pitfall, but for now let's just get a fix out. 