### PR TITLE
Refactors some street view components

### DIFF
--- a/app/data/flags.json
+++ b/app/data/flags.json
@@ -27,6 +27,10 @@
     "label": "Environment editor",
     "defaultValue": false
   },
+  "ENVIRONMENT_ANIMATIONS": {
+    "label": "Environment animations",
+    "defaultValue": false
+  },
   "SAVE_UNDO": {
     "label": "Save undo data to server",
     "defaultValue": false,

--- a/assets/scripts/app/ScrollIndicators.jsx
+++ b/assets/scripts/app/ScrollIndicators.jsx
@@ -4,16 +4,15 @@ import { useIntl } from 'react-intl'
 import { registerKeypress, deregisterKeypress } from './keypress'
 import './ScrollIndicators.scss'
 
-const ScrollIndicators = (props) => {
-  const { scrollTop, scrollStreet, scrollIndicatorsLeft = 0, scrollIndicatorsRight = 0 } = props
+ScrollIndicators.propTypes = {
+  left: PropTypes.number,
+  right: PropTypes.number,
+  scrollStreet: PropTypes.func.isRequired,
+  scrollTop: PropTypes.number.isRequired
+}
 
-  const doLeftScroll = (event) => {
-    scrollStreet(true, event.shiftKey)
-  }
-
-  const doRightScroll = (event) => {
-    scrollStreet(false, event.shiftKey)
-  }
+function ScrollIndicators ({ scrollTop, scrollStreet, left = 0, right = 0 }) {
+  const intl = useIntl()
 
   /**
    * Sets up and takes down event listeners for keys.
@@ -22,15 +21,23 @@ const ScrollIndicators = (props) => {
    *  - If shift is pressed, screen scrolls to extents.
    */
   useEffect(() => {
-    registerKeypress(['left', 'shift left'], doLeftScroll)
-    registerKeypress(['right', 'shift right'], doRightScroll)
+    registerKeypress(['left', 'shift left'], handleScrollLeft)
+    registerKeypress(['right', 'shift right'], handleScrollRight)
+
     return () => {
-      deregisterKeypress(['left', 'shift left'], doLeftScroll)
-      deregisterKeypress(['right', 'shift right'], doRightScroll)
+      deregisterKeypress(['left', 'shift left'], handleScrollLeft)
+      deregisterKeypress(['right', 'shift right'], handleScrollRight)
     }
   })
 
-  const intl = useIntl()
+  function handleScrollLeft (event) {
+    scrollStreet(true, event.shiftKey)
+  }
+
+  function handleScrollRight (event) {
+    scrollStreet(false, event.shiftKey)
+  }
+
   const scrollLeftLabel = intl.formatMessage({
     id: 'tooltip.scroll-street-left',
     defaultMessage: 'Scroll street left'
@@ -42,35 +49,28 @@ const ScrollIndicators = (props) => {
 
   return (
     <div className="street-scroll-indicators" style={{ top: `${scrollTop}px` }}>
-      {scrollIndicatorsLeft ? (
+      {left > 0 && (
         <button
           className="street-scroll-indicator-left"
-          onClick={doLeftScroll}
+          onClick={handleScrollLeft}
           title={scrollLeftLabel}
           aria-label={scrollLeftLabel}
         >
-          {Array(scrollIndicatorsLeft + 1).join('‹')}
+          {Array(left + 1).join('‹')}
         </button>
-      ) : null}
-      {scrollIndicatorsRight ? (
+      )}
+      {right > 0 && (
         <button
           className="street-scroll-indicator-right"
-          onClick={doRightScroll}
+          onClick={handleScrollRight}
           title={scrollRightLabel}
           aria-label={scrollRightLabel}
         >
-          {Array(scrollIndicatorsRight + 1).join('›')}
+          {Array(right + 1).join('›')}
         </button>
-      ) : null}
+      )}
     </div>
   )
-}
-
-ScrollIndicators.propTypes = {
-  scrollIndicatorsLeft: PropTypes.number,
-  scrollIndicatorsRight: PropTypes.number,
-  scrollStreet: PropTypes.func.isRequired,
-  scrollTop: PropTypes.number.isRequired
 }
 
 export default React.memo(ScrollIndicators)

--- a/assets/scripts/app/ScrollIndicators.jsx
+++ b/assets/scripts/app/ScrollIndicators.jsx
@@ -7,11 +7,10 @@ import './ScrollIndicators.scss'
 ScrollIndicators.propTypes = {
   left: PropTypes.number,
   right: PropTypes.number,
-  scrollStreet: PropTypes.func.isRequired,
-  scrollTop: PropTypes.number.isRequired
+  scrollStreet: PropTypes.func.isRequired
 }
 
-function ScrollIndicators ({ scrollTop, scrollStreet, left = 0, right = 0 }) {
+function ScrollIndicators ({ scrollStreet, left = 0, right = 0 }) {
   const intl = useIntl()
 
   /**
@@ -48,7 +47,7 @@ function ScrollIndicators ({ scrollTop, scrollStreet, left = 0, right = 0 }) {
   })
 
   return (
-    <div className="street-scroll-indicators" style={{ top: `${scrollTop}px` }}>
+    <div className="street-scroll-indicators">
       {left > 0 && (
         <button
           className="street-scroll-indicator-left"

--- a/assets/scripts/app/ScrollIndicators.scss
+++ b/assets/scripts/app/ScrollIndicators.scss
@@ -3,13 +3,14 @@
 
 .street-scroll-indicators {
   position: absolute;
+  bottom: 0;
 
   button {
     @include tap-highlight-color(transparent);
 
     position: fixed;
     height: 80px;
-    margin-top: -260px;
+    margin-top: -80px;
     padding: 0 0.2em;
     opacity: 0.25;
     font-size: 80px;

--- a/assets/scripts/app/SkyContainer.jsx
+++ b/assets/scripts/app/SkyContainer.jsx
@@ -20,10 +20,9 @@ function SkyContainer (props) {
   const environment = useSelector(
     (state) => state.street.environment || DEFAULT_ENVIRONS
   )
-
-  const skyStyle = {
-    height: `${height}px`
-  }
+  const animations = useSelector(
+    (state) => state.flags.ENVIRONMENT_ANIMATIONS?.value || false
+  )
 
   const environs = getEnvirons(environment)
   const frontCloudStyle = {
@@ -45,8 +44,13 @@ function SkyContainer (props) {
     foregroundStyle.opacity = 0
   }
 
+  const classes = ['street-section-sky']
+  if (animations) {
+    classes.push('environment-animations')
+  }
+
   return (
-    <section className="street-section-sky" style={skyStyle}>
+    <section className={classes.join(' ')} style={{ height: `${height}px` }}>
       <SkyBackground environment={environment} />
       <SkyObjects objects={environs.backgroundObjects} />
       <div className="rear-clouds" style={rearCloudStyle} />

--- a/assets/scripts/app/SkyContainer.scss
+++ b/assets/scripts/app/SkyContainer.scss
@@ -54,7 +54,7 @@
 
 // A setting activates this class and turns on environmental animations
 // This is so it can be disabled based on preference or performance reasons
-body.environment-animations {
+.environment-animations {
   .rear-clouds {
     animation-name: rear-clouds-move;
     animation-duration: 60s;

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -50,7 +50,6 @@ class StreetView extends React.Component {
         right: 0
       },
 
-      scrollTop: 0,
       skyHeight: 0,
 
       resizeType: null,
@@ -160,8 +159,6 @@ class StreetView extends React.Component {
       streetSectionTop += 80
     }
 
-    const scrollTop = streetSectionTop + streetSectionHeight
-
     // Not sure what 255 does, but it keeps it from getting too tall
     // `skyHeight` is needed so that when gallery opens and the
     // street slides down, there is some more sky to show
@@ -185,7 +182,6 @@ class StreetView extends React.Component {
     this.streetSectionInner.style.top = streetSectionTop + 'px'
 
     return {
-      scrollTop,
       skyHeight,
       resizeType: STREETVIEW_RESIZED
     }
@@ -367,17 +363,16 @@ class StreetView extends React.Component {
               <EmptySegmentContainer />
               <StreetViewDirt buildingWidth={this.state.buildingWidth} />
             </section>
+            <ScrollIndicators
+              left={this.state.scrollIndicators.left}
+              right={this.state.scrollIndicators.right}
+              scrollStreet={this.scrollStreet}
+            />
           </section>
         </section>
         <SkyContainer
           scrollPos={this.state.scrollPos}
           height={this.state.skyHeight}
-        />
-        <ScrollIndicators
-          left={this.state.scrollIndicators.left}
-          right={this.state.scrollIndicators.right}
-          scrollStreet={this.scrollStreet}
-          scrollTop={this.state.scrollTop}
         />
       </>
     )

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -56,7 +56,9 @@ class StreetView extends React.Component {
       buildingWidth: 0
     }
 
-    this.streetSectionEl = React.createRef()
+    this.sectionEl = React.createRef()
+    this.sectionInnerEl = React.createRef()
+    this.sectionCanvasEl = React.createRef()
   }
 
   componentDidMount () {
@@ -116,8 +118,8 @@ class StreetView extends React.Component {
 
   resizeStreetExtent = (resizeType, dontDelay) => {
     const marginUpdated = updateStreetMargin(
-      this.streetSectionCanvas,
-      this.streetSectionEl.current,
+      this.sectionCanvasEl.current,
+      this.sectionEl.current,
       dontDelay
     )
 
@@ -127,7 +129,7 @@ class StreetView extends React.Component {
   }
 
   updateScrollLeft = (deltaX) => {
-    let scrollLeft = this.streetSectionEl.current.scrollLeft
+    let scrollLeft = this.sectionEl.current.scrollLeft
 
     if (deltaX) {
       scrollLeft += deltaX
@@ -139,14 +141,14 @@ class StreetView extends React.Component {
       scrollLeft = (streetWidth + currBuildingSpace * 2 - window.innerWidth) / 2
     }
 
-    this.streetSectionEl.current.scrollLeft = scrollLeft
+    this.sectionEl.current.scrollLeft = scrollLeft
   }
 
   onResize = () => {
     const viewportHeight = window.innerHeight
     const viewportWidth = window.innerWidth
     let streetSectionTop
-    const streetSectionHeight = this.streetSectionInner.offsetHeight
+    const streetSectionHeight = this.sectionInnerEl.current.offsetHeight
 
     if (viewportHeight - streetSectionHeight > 450) {
       streetSectionTop =
@@ -177,9 +179,9 @@ class StreetView extends React.Component {
       streetSectionCanvasLeft = 0
     }
 
-    this.streetSectionCanvas.style.width = streetWidth + 'px'
-    this.streetSectionCanvas.style.left = streetSectionCanvasLeft + 'px'
-    this.streetSectionInner.style.top = streetSectionTop + 'px'
+    this.sectionCanvasEl.current.style.width = streetWidth + 'px'
+    this.sectionCanvasEl.current.style.left = streetSectionCanvasLeft + 'px'
+    this.sectionInnerEl.current.style.top = streetSectionTop + 'px'
 
     return {
       skyHeight,
@@ -225,7 +227,7 @@ class StreetView extends React.Component {
    * is calculated as the street scrolls and stored in state.
    */
   calculateScrollIndicators = () => {
-    const el = this.streetSectionEl.current
+    const el = this.sectionEl.current
     let scrollIndicatorsLeft
     let scrollIndicatorsRight
 
@@ -260,7 +262,7 @@ class StreetView extends React.Component {
   }
 
   scrollStreet = (left, far = false) => {
-    const el = this.streetSectionEl.current
+    const el = this.sectionEl.current
     let newScrollLeft
 
     if (left) {
@@ -295,11 +297,7 @@ class StreetView extends React.Component {
   }
 
   getStreetScrollPosition = () => {
-    return (
-      (this.streetSectionEl.current &&
-        this.streetSectionEl.current.scrollLeft) ||
-      0
-    )
+    return this.sectionEl.current?.scrollLeft ?? 0
   }
 
   /**
@@ -329,20 +327,10 @@ class StreetView extends React.Component {
         <section
           id="street-section-outer"
           onScroll={this.handleStreetScroll}
-          ref={this.streetSectionEl}
+          ref={this.sectionEl}
         >
-          <section
-            id="street-section-inner"
-            ref={(ref) => {
-              this.streetSectionInner = ref
-            }}
-          >
-            <section
-              id="street-section-canvas"
-              ref={(ref) => {
-                this.streetSectionCanvas = ref
-              }}
-            >
+          <section id="street-section-inner" ref={this.sectionInnerEl}>
+            <section id="street-section-canvas" ref={this.sectionCanvasEl}>
               <Building
                 position="left"
                 buildingWidth={this.state.buildingWidth}

--- a/assets/scripts/app/StreetView.jsx
+++ b/assets/scripts/app/StreetView.jsx
@@ -45,8 +45,10 @@ class StreetView extends React.Component {
 
     this.state = {
       isStreetScrolling: false,
-      scrollIndicatorsLeft: 0,
-      scrollIndicatorsRight: 0,
+      scrollIndicators: {
+        left: 0,
+        right: 0
+      },
 
       scrollTop: 0,
       skyHeight: 0,
@@ -198,7 +200,7 @@ class StreetView extends React.Component {
 
       this.setState({
         ...resizeState,
-        ...scrollIndicators
+        scrollIndicators
       })
     })
   }
@@ -215,7 +217,7 @@ class StreetView extends React.Component {
       const scrollIndicators = this.calculateScrollIndicators()
 
       this.setState({
-        ...scrollIndicators,
+        scrollIndicators,
         scrollPos: this.getStreetScrollPosition()
       })
     })
@@ -256,8 +258,8 @@ class StreetView extends React.Component {
     }
 
     return {
-      scrollIndicatorsLeft: scrollIndicatorsLeft,
-      scrollIndicatorsRight: scrollIndicatorsRight
+      left: scrollIndicatorsLeft,
+      right: scrollIndicatorsRight
     }
   }
 
@@ -372,8 +374,8 @@ class StreetView extends React.Component {
           height={this.state.skyHeight}
         />
         <ScrollIndicators
-          scrollIndicatorsLeft={this.state.scrollIndicatorsLeft}
-          scrollIndicatorsRight={this.state.scrollIndicatorsRight}
+          left={this.state.scrollIndicators.left}
+          right={this.state.scrollIndicators.right}
           scrollStreet={this.scrollStreet}
           scrollTop={this.state.scrollTop}
         />

--- a/assets/scripts/app/__tests__/ScrollIndicators.test.js
+++ b/assets/scripts/app/__tests__/ScrollIndicators.test.js
@@ -5,8 +5,8 @@ import { renderWithIntl as render } from '../../../../test/helpers/render'
 import ScrollIndicators from '../ScrollIndicators'
 
 const baseProps = {
-  scrollIndicatorsLeft: 1,
-  scrollIndicatorsRight: 3,
+  left: 1,
+  right: 3,
   scrollStreet: jest.fn(),
   scrollTop: 0
 }
@@ -19,11 +19,7 @@ describe('ScrollIndicators', () => {
 
   it('renders snapshot for zero indicators', () => {
     const wrapper = render(
-      <ScrollIndicators
-        {...baseProps}
-        scrollIndicatorsLeft={0}
-        scrollIndicatorsRight={0}
-      />
+      <ScrollIndicators {...baseProps} left={0} right={0} />
     )
     expect(wrapper.asFragment()).toMatchSnapshot()
   })

--- a/assets/scripts/app/__tests__/ScrollIndicators.test.js
+++ b/assets/scripts/app/__tests__/ScrollIndicators.test.js
@@ -7,8 +7,7 @@ import ScrollIndicators from '../ScrollIndicators'
 const baseProps = {
   left: 1,
   right: 3,
-  scrollStreet: jest.fn(),
-  scrollTop: 0
+  scrollStreet: jest.fn()
 }
 
 describe('ScrollIndicators', () => {

--- a/assets/scripts/app/__tests__/SkyContainer.test.js
+++ b/assets/scripts/app/__tests__/SkyContainer.test.js
@@ -27,4 +27,23 @@ describe('SkyContainer', () => {
     )
     expect(wrapper.asFragment()).toMatchSnapshot()
   })
+
+  it('renders background animations', () => {
+    const wrapper = renderWithRedux(
+      <SkyContainer scrollPos={0} height={100} />,
+      {
+        initialState: {
+          street: { environment: 'bar' },
+          flags: {
+            ENVIRONMENT_ANIMATIONS: { value: true }
+          }
+        }
+      }
+    )
+    expect(
+      wrapper.container
+        .querySelector('.street-section-sky')
+        .className.includes('environment-animations')
+    ).toEqual(true)
+  })
 })

--- a/assets/scripts/app/__tests__/__snapshots__/ScrollIndicators.test.js.snap
+++ b/assets/scripts/app/__tests__/__snapshots__/ScrollIndicators.test.js.snap
@@ -4,7 +4,6 @@ exports[`ScrollIndicators renders snapshot 1`] = `
 <DocumentFragment>
   <div
     class="street-scroll-indicators"
-    style="top: 0px;"
   >
     <button
       aria-label="Scroll street left"
@@ -28,7 +27,6 @@ exports[`ScrollIndicators renders snapshot for zero indicators 1`] = `
 <DocumentFragment>
   <div
     class="street-scroll-indicators"
-    style="top: 0px;"
   />
 </DocumentFragment>
 `;


### PR DESCRIPTION
Changelog:

- Some street view elements were positioned with code. This was a strategy left over from the first release, when development speed was a priority over code organization, and introduced magic numbers we are still working to entangle. When the street scroll indicators (arrows) were ported to React, the component continued to adopt the legacy strategy of receiving a position to render at. With some refactoring we can allow the DOM+CSS to handle positioning so that it no longer needs to be calculated with JavaScript and passed to the component via props.
- An old experiment to animate the background clouds was never released because the animations were CPU and resource intensive. While this is still possibly the case, we've always left the feature in, "because it was cool" and "just in case." Now, activate the animations via a flag so that we can test the experiment without needing to hand-code it back in; the animations were dead code otherwise. 
- Various parts of the React code are updated to bring it in line with how other components are now written.