### PR TITLE
fix(api/users): settings data should be updated

### DIFF
--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -466,8 +466,13 @@ exports.put = async function (req, res) {
     res.status(401).end()
     return
   }
-  user.data = body.data || user.data || {}
-  User.update(user, { where: { id: user.id }, returning: true })
+
+  User.update(
+    {
+      data: body.data || {}
+    },
+    { where: { id: user.id }, returning: true }
+  )
     .then((result) => {
       res.status(204).end()
     })


### PR DESCRIPTION
Bug: the user settings data (e.g. last street ID, save as image settings, etc) were not being updated when a PUT request with new settings is made to `/api/v1/username`.

Cause: The `User.update()` method updates zero rows, despite properly finding a row to update.

It appears that Sequelize does a shallow equality check on the incoming data object to see if anything has changed. Currently, we retrieve the user data, update the result object, then pass it back in to `User.update()`. Because it is the same object, it passes a shallow equality check and Sequelize believes nothing needs to be updated.

Solution: Create a new object with the settings data. Because it's a new object, Sequelize properly updates the user data.

----

This may be related to a user bug report in Discord where "new street"->"make a copy of the last street" did not make a copy, as expected. Upon investigation, the "last street id" was never updated, and so when the UI attempts to make a copy of a street, it uses the wrong street ID (one which was saved much longer ago, but never updated since).

I'm not entirely sure why it worked prior to #1894. Perhaps something about the way data was manipulated previously caused the settings to appear "new" to Sequelize.