### PR TITLE
chore(deps): bump pg from 7.17.1 to 8.2.1, magically makes app Node 14 compatible 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18201,15 +18201,15 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pg": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-7.17.1.tgz",
-      "integrity": "sha512-SYWEip6eADsgDQIZk0bmB2JDOrC8Xu6z10KlhlXl03NSomwVmHB6ZTVyDCwOfT6bXHI8QndJdk5XxSSRXikaSA==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.2.1.tgz",
+      "integrity": "sha512-DKzffhpkWRr9jx7vKxA+ur79KG+SKw+PdjMb1IRhMiKI9zqYUGczwFprqy+5Veh/DCcFs1Y6V8lRLN5I1DlleQ==",
       "requires": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
-        "pg-connection-string": "0.1.3",
-        "pg-packet-stream": "^1.1.0",
-        "pg-pool": "^2.0.9",
+        "pg-connection-string": "^2.2.3",
+        "pg-pool": "^3.2.1",
+        "pg-protocol": "^1.2.4",
         "pg-types": "^2.1.0",
         "pgpass": "1.x",
         "semver": "4.3.2"
@@ -18223,24 +18223,24 @@
       }
     },
     "pg-connection-string": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
-      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.2.3.tgz",
+      "integrity": "sha512-I/KCSQGmOrZx6sMHXkOs2MjddrYcqpza3Dtsy0AjIgBr/bZiPJRK9WhABXN1Uy1UDazRbi9gZEzO2sAhL5EqiQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
-    "pg-packet-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
-      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
-    },
     "pg-pool": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.9.tgz",
-      "integrity": "sha512-gNiuIEKNCT3OnudQM2kvgSnXsLkSpd6mS/fRnqs6ANtrke6j8OY5l9mnAryf1kgwJMWLg0C1N1cYTZG1xmEYHQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.2.1.tgz",
+      "integrity": "sha512-BQDPWUeKenVrMMDN9opfns/kZo4lxmSWhIqo+cSAF7+lfi9ZclQbr9vfnlNaPr8wYF3UYjm5X0yPAhbcgqNOdA=="
+    },
+    "pg-protocol": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.4.tgz",
+      "integrity": "sha512-/8L/G+vW/VhWjTGXpGh8XVkXOFx1ZDY+Yuz//Ab8CfjInzFkreI+fDG3WjCeSra7fIZwAFxzbGptNbm8xSXenw=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -19222,9 +19222,9 @@
       "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
     },
     "postgres-date": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.4.tgz",
-      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.5.tgz",
+      "integrity": "sha512-pdau6GRPERdAYUQwkBnGKxEfPyhVZXG/JiS44iZWiNdSOWE09N2lUgN6yshuq6fVSon4Pm0VMXd1srUUkLe9iA=="
     },
     "postgres-interval": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "oauth": "0.9.15",
     "parcel-bundler": "1.12.4",
     "pelias-js": "0.0.8",
-    "pg": "7.17.1",
+    "pg": "8.2.1",
     "postcss": "7.0.27",
     "postcss-round-subpixels": "1.2.0",
     "prop-types": "15.7.2",


### PR DESCRIPTION
fixes #1914 

Ok, so this is fun! I'm interested to see if this passes CI. 

Going down the rabbit hole with #1915 I found: 
https://github.com/sequelize/sequelize/issues/12158#issuecomment-618644494

Just upgrading _this_ library seems to make things work on my end under Node 14, and should minimize other breaking changes. 