### PR TITLE
refactor: add explicit true to boolean props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,20 +19,11 @@
       "version": "detect"
     }
   },
-  "plugins": [
-    "react",
-    "cypress",
-    "react-hooks"
-  ],
-  "extends": [
-    "standard",
-    "standard-react"
-  ],
+  "plugins": ["react", "cypress", "react-hooks"],
+  "extends": ["standard", "standard-react"],
   "rules": {
-    "jsx-quotes": [
-      "error",
-      "prefer-double"
-    ],
+    "jsx-quotes": ["error", "prefer-double"],
+    "react/jsx-boolean-value": ["error", "always"],
     "no-restricted-globals": [
       "error",
       {

--- a/assets/scripts/app/DebugInfo.jsx
+++ b/assets/scripts/app/DebugInfo.jsx
@@ -89,7 +89,7 @@ function DebugInfo (props) {
   if (isVisible === true) {
     return (
       <div className="debug-info">
-        <textarea readOnly wrap="off" ref={textareaEl} />
+        <textarea readOnly={true} wrap="off" ref={textareaEl} />
       </div>
     )
   }

--- a/assets/scripts/app/NotificationBar.jsx
+++ b/assets/scripts/app/NotificationBar.jsx
@@ -76,7 +76,7 @@ function NotificationBar ({ notification = {} }) {
       in={show}
       timeout={TRANSITION_DURATION}
       onExited={handleExited}
-      unmountOnExit
+      unmountOnExit={true}
     >
       <div
         className="notification-bar"

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -166,7 +166,7 @@ export class StreetEditable extends React.Component {
           classNames="switching-away"
           exit={!immediateRemoval}
           onExit={this.handleSwitchSegmentAway}
-          unmountOnExit
+          unmountOnExit={true}
         >
           <Segment
             key={segment.id}

--- a/assets/scripts/dialogs/Analytics/SegmentAnalytics.jsx
+++ b/assets/scripts/dialogs/Analytics/SegmentAnalytics.jsx
@@ -35,9 +35,10 @@ function SegmentAnalytics ({ type, capacity, segment, index, chartMax }) {
   const { average, potential } = capacity
   const label = getLocaleSegmentName(type, locale)
   const color = BAR_COLORS[index % BAR_COLORS.length]
-  const widthPercent = `${(Number.parseInt(potential, 10) /
-    Number.parseInt(chartMax, 10)) *
-    (100 * BAR_MODIFIER)}`
+  const widthPercent = `${
+    (Number.parseInt(potential, 10) / Number.parseInt(chartMax, 10)) *
+    (100 * BAR_MODIFIER)
+  }`
   // leave 2% margin
   const widthPercentInv = `${98 - Number.parseFloat(widthPercent)}`
 
@@ -45,7 +46,7 @@ function SegmentAnalytics ({ type, capacity, segment, index, chartMax }) {
     <div className="segment-analytics">
       <div className="segment-icon">
         <SegmentForPalette
-          isIcon
+          isIcon={true}
           key={segment.id}
           type={segment.type}
           variantString={segment.variantString}

--- a/assets/scripts/dialogs/Dialog.jsx
+++ b/assets/scripts/dialogs/Dialog.jsx
@@ -57,7 +57,7 @@ function Dialog ({ children }) {
 
   return (
     <CSSTransition
-      appear
+      appear={true}
       in={appear}
       timeout={80}
       classNames="dialog-transition"

--- a/assets/scripts/dialogs/Geotag/__tests__/LocationPopup.test.js
+++ b/assets/scripts/dialogs/Geotag/__tests__/LocationPopup.test.js
@@ -34,7 +34,7 @@ describe('LocationPopup', () => {
     const wrapper = renderWithIntl(
       <LocationPopup
         position={{ lat: 0, lng: 0 }}
-        isEditable
+        isEditable={true}
         handleConfirm={handleConfirm}
       />
     )
@@ -53,8 +53,8 @@ describe('LocationPopup', () => {
     const wrapper = renderWithIntl(
       <LocationPopup
         position={{ lat: 0, lng: 0 }}
-        isEditable
-        isClearable
+        isEditable={true}
+        isClearable={true}
         handleClear={handleClear}
       />
     )

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -295,7 +295,7 @@ class SaveAsImageDialog extends React.Component {
                     />
                   </a>
                 ) : (
-                  <button disabled>
+                  <button disabled={true}>
                     <FormattedMessage
                       id="dialogs.save.save-button"
                       defaultMessage="Save to your computer…"

--- a/assets/scripts/dialogs/SignInDialog.jsx
+++ b/assets/scripts/dialogs/SignInDialog.jsx
@@ -239,7 +239,7 @@ export default class SignInDialog extends React.Component {
                   name="email"
                   onChange={this.handleChange}
                   placeholder="test@test.com"
-                  required
+                  required={true}
                 />
 
                 {this.state.error && this.renderErrorMessage()}

--- a/assets/scripts/dialogs/UpgradeDialog.jsx
+++ b/assets/scripts/dialogs/UpgradeDialog.jsx
@@ -9,7 +9,8 @@ import userRoles from '../../../app/data/user_roles.json'
 import Dialog from './Dialog'
 import './UpgradeDialog.scss'
 
-const DEFAULT_BODY = 'Thank you for using Streetmix! For only $5/month, the Enthusiast Plan lets users support Streetmix while also gaining access to new experimental features. Plus your avatar gets a neat badge!'
+const DEFAULT_BODY =
+  'Thank you for using Streetmix! For only $5/month, the Enthusiast Plan lets users support Streetmix while also gaining access to new experimental features. Plus your avatar gets a neat badge!'
 
 const UpgradeDialog = ({ userId, roles }) => {
   const intl = useIntl()
@@ -49,24 +50,37 @@ const UpgradeDialog = ({ userId, roles }) => {
   if (hasTier1) {
     activePanel = (
       <p>
-        <FormattedMessage id="upgrade.hasTier1" defaultMessage="Thanks for supporting Streetmix!" />
-      </p>)
+        <FormattedMessage
+          id="upgrade.hasTier1"
+          defaultMessage="Thanks for supporting Streetmix!"
+        />
+      </p>
+    )
   } else if (loading) {
     activePanel = (
       <p>
         <FormattedMessage id="upgrade.loading" defaultMessage="Loading..." />
-      </p>)
+      </p>
+    )
   } else if (error) {
     activePanel = (
       <p>
-        <FormattedMessage id="upgrade.error" defaultMessage="We encountered an error:" />
+        <FormattedMessage
+          id="upgrade.error"
+          defaultMessage="We encountered an error:"
+        />
         {error}
-      </p>)
+      </p>
+    )
   } else if (data) {
     activePanel = (
       <p>
-        <FormattedMessage id="upgrade.success" defaultMessage="Thank you! Please refresh this page to see your upgrades." />
-      </p>)
+        <FormattedMessage
+          id="upgrade.success"
+          defaultMessage="Thank you! Please refresh this page to see your upgrades."
+        />
+      </p>
+    )
   } else {
     activePanel = (
       <>
@@ -81,9 +95,10 @@ const UpgradeDialog = ({ userId, roles }) => {
           locale="auto"
           stripeKey={STRIPE_API_KEY}
           token={onToken}
-          zipCode
+          zipCode={true}
         />
-      </>)
+      </>
+    )
   }
 
   return (
@@ -104,7 +119,9 @@ const UpgradeDialog = ({ userId, roles }) => {
 
 function mapStateToProps (state) {
   const { userId } = state.user.signInData || {}
-  const roles = state.user.profileCache ? state.user.profileCache[userId].roles : []
+  const roles = state.user.profileCache
+    ? state.user.profileCache[userId].roles
+    : []
   return {
     userId,
     roles

--- a/assets/scripts/gallery/GalleryContents.jsx
+++ b/assets/scripts/gallery/GalleryContents.jsx
@@ -105,14 +105,14 @@ function GalleryContents (props) {
                 <FormattedMessage id="btn.copy" defaultMessage="Make a copy" />
               </a>
             ) : (
-              <button className="gallery-copy-last-street" disabled>
+              <button className="gallery-copy-last-street" disabled={true}>
                 <FormattedMessage id="btn.copy" defaultMessage="Make a copy" />
               </button>
             )}
           </div>
         )}
 
-        <Scrollable className="streets" allowKeyboardScroll>
+        <Scrollable className="streets" allowKeyboardScroll={true}>
           {streets.map((item) => (
             <GalleryStreetItem
               key={item.id}

--- a/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
+++ b/assets/scripts/gallery/__tests__/GalleryStreetItem.test.js
@@ -71,7 +71,11 @@ describe('GalleryStreetItem', () => {
     window.confirm = jest.fn(() => true)
 
     const wrapper = renderWithReduxAndIntl(
-      <GalleryStreetItem street={MOCK_STREET} doDelete={doDelete} allowDelete />
+      <GalleryStreetItem
+        street={MOCK_STREET}
+        doDelete={doDelete}
+        allowDelete={true}
+      />
     )
 
     fireEvent.click(wrapper.getByTitle('Delete street'))
@@ -83,7 +87,11 @@ describe('GalleryStreetItem', () => {
     window.confirm = jest.fn(() => false)
 
     const wrapper = renderWithReduxAndIntl(
-      <GalleryStreetItem street={MOCK_STREET} doDelete={doDelete} allowDelete />
+      <GalleryStreetItem
+        street={MOCK_STREET}
+        doDelete={doDelete}
+        allowDelete={true}
+      />
     )
 
     fireEvent.click(wrapper.getByTitle('Delete street'))

--- a/assets/scripts/info_bubble/__tests__/Triangle.test.js
+++ b/assets/scripts/info_bubble/__tests__/Triangle.test.js
@@ -10,7 +10,7 @@ describe('Triangle', () => {
   })
 
   it('renders an highlighted triangle', () => {
-    const wrapper = render(<Triangle highlight />)
+    const wrapper = render(<Triangle highlight={true} />)
     expect(wrapper.asFragment()).toMatchSnapshot()
   })
 

--- a/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
+++ b/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
@@ -50,7 +50,7 @@ describe('UpDownInput', () => {
   })
 
   it('renders inputs as disabled', () => {
-    const wrapper = render(<UpDownInput {...defaultProps} disabled />)
+    const wrapper = render(<UpDownInput {...defaultProps} disabled={true} />)
 
     const inputEl = wrapper.getByTitle('input')
     const upButton = wrapper.getByTitle('up')

--- a/assets/scripts/menus/MenusContainer.jsx
+++ b/assets/scripts/menus/MenusContainer.jsx
@@ -156,7 +156,7 @@ class MenusContainer extends React.PureComponent {
           <IdentityMenu
             isActive={activeMenu === 'identity'}
             menuItemNode={activeMenuItemNode}
-            alignOpposite
+            alignOpposite={true}
           />
         </div>
       </>

--- a/assets/scripts/menus/ShareMenu.jsx
+++ b/assets/scripts/menus/ShareMenu.jsx
@@ -38,7 +38,8 @@ function ShareMenu (props) {
           message = intl.formatMessage(
             {
               id: 'menu.share.messages.my-street',
-              defaultMessage: 'Check out my street, {streetName}, on Streetmix!'
+              defaultMessage:
+                'Check out my street, {streetName}, on Streetmix!'
             },
             { streetName: street.name }
           )
@@ -188,7 +189,7 @@ function ShareMenu (props) {
             value={shareUrl}
             spellCheck="false"
             ref={shareViaLinkInputRef}
-            readOnly
+            readOnly={true}
           />
           <button
             title={intl.formatMessage({

--- a/assets/scripts/palette/__tests__/PaletteTooltips.test.js
+++ b/assets/scripts/palette/__tests__/PaletteTooltips.test.js
@@ -5,7 +5,9 @@ import { renderWithReduxAndIntl } from '../../../../test/helpers/render'
 
 describe('PaletteTooltips', () => {
   it('renders with the `show` class when `visible` prop is true', () => {
-    const { container } = renderWithReduxAndIntl(<PaletteTooltips visible />)
+    const { container } = renderWithReduxAndIntl(
+      <PaletteTooltips visible={true} />
+    )
     expect(container.querySelectorAll('.palette-tooltip-show').length).toEqual(
       1
     )
@@ -22,7 +24,7 @@ describe('PaletteTooltips', () => {
 
   it('renders the label', () => {
     const { getByText } = renderWithReduxAndIntl(
-      <PaletteTooltips visible label="foo" />
+      <PaletteTooltips visible={true} label="foo" />
     )
     expect(getByText('foo')).toBeDefined()
   })

--- a/assets/scripts/segments/Building.jsx
+++ b/assets/scripts/segments/Building.jsx
@@ -252,7 +252,7 @@ class Building extends React.Component {
           timeout={250}
           classNames="switching-in"
           onEntered={this.handleSwitchBuildings}
-          unmountOnExit
+          unmountOnExit={true}
         >
           {this.renderBuilding('new')}
         </CSSTransition>
@@ -261,7 +261,7 @@ class Building extends React.Component {
           in={oldBuildingEnter}
           timeout={250}
           classNames="switching-away"
-          unmountOnExit
+          unmountOnExit={true}
         >
           {this.renderBuilding('old')}
         </CSSTransition>

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -377,7 +377,7 @@ export class Segment extends React.Component {
           classNames="switching-away"
           timeout={250}
           onExited={this.handleSwitchSegments}
-          unmountOnExit
+          unmountOnExit={true}
         >
           {this.renderSegmentCanvas('old')}
         </CSSTransition>
@@ -386,7 +386,7 @@ export class Segment extends React.Component {
           in={this.state.switchSegments}
           classNames="switching-in"
           timeout={250}
-          unmountOnExit
+          unmountOnExit={true}
         >
           {this.renderSegmentCanvas('new')}
         </CSSTransition>
@@ -402,7 +402,9 @@ function mapStateToProps (state) {
     locale: state.locale.locale,
     descriptionVisible: state.infoBubble.descriptionVisible,
     activeSegment:
-      typeof state.ui.activeSegment === 'number' ? state.ui.activeSegment : null
+      typeof state.ui.activeSegment === 'number'
+        ? state.ui.activeSegment
+        : null
   }
 }
 

--- a/assets/scripts/segments/__tests__/SegmentLabelContainer.test.js
+++ b/assets/scripts/segments/__tests__/SegmentLabelContainer.test.js
@@ -48,7 +48,7 @@ describe('SegmentLabelContainer', () => {
     const { asFragment } = renderWithReduxAndIntl(
       <SegmentLabelContainer
         {...testProps}
-        editable
+        editable={true}
         editSegmentLabel={() => {}}
       />
     )

--- a/assets/scripts/streets/StreetMetaWidthMenu.jsx
+++ b/assets/scripts/streets/StreetMetaWidthMenu.jsx
@@ -66,7 +66,7 @@ function StreetMetaWidthMenu ({ street, onChange }) {
   const CustomWidthOption =
     defaultWidths.indexOf(Number.parseFloat(width)) === -1 ? (
       <>
-        <option disabled />
+        <option disabled={true} />
         {renderOption(width, units)}
       </>
     ) : null
@@ -83,15 +83,15 @@ function StreetMetaWidthMenu ({ street, onChange }) {
         defaultMessage: 'Change width of the street'
       })}
     >
-      <option disabled>
+      <option disabled={true}>
         {formatMessage({
           id: 'width.occupied',
           defaultMessage: 'Occupied width:'
         })}
       </option>
-      <option disabled>{prettifyWidth(occupiedWidth, units)}</option>
-      <option disabled />
-      <option disabled>
+      <option disabled={true}>{prettifyWidth(occupiedWidth, units)}</option>
+      <option disabled={true} />
+      <option disabled={true}>
         {formatMessage({
           id: 'width.building',
           defaultMessage: 'Building-to-building width:'
@@ -105,7 +105,7 @@ function StreetMetaWidthMenu ({ street, onChange }) {
           defaultMessage: 'Different width…'
         })}
       </option>
-      <option disabled />
+      <option disabled={true} />
       <option
         id="switch-to-imperial-units"
         value={STREET_WIDTH_SWITCH_TO_IMPERIAL}

--- a/assets/scripts/streets/__tests__/StreetMetaWidthLabel.test.js
+++ b/assets/scripts/streets/__tests__/StreetMetaWidthLabel.test.js
@@ -16,7 +16,7 @@ describe('StreetMetaWidthLabel', () => {
     const wrapper = renderWithIntl(
       <StreetMetaWidthLabel
         street={dummyStreetObject}
-        editable
+        editable={true}
         onClick={jest.fn()}
       />
     )
@@ -44,7 +44,7 @@ describe('StreetMetaWidthLabel', () => {
           occupiedWidth: 9,
           remainingWidth: 1
         }}
-        editable
+        editable={true}
         onClick={jest.fn()}
       />
     )
@@ -60,7 +60,7 @@ describe('StreetMetaWidthLabel', () => {
           occupiedWidth: 11,
           remainingWidth: -1
         }}
-        editable
+        editable={true}
         onClick={jest.fn()}
       />
     )
@@ -73,7 +73,7 @@ describe('StreetMetaWidthLabel', () => {
     const wrapper = renderWithIntl(
       <StreetMetaWidthLabel
         street={dummyStreetObject}
-        editable
+        editable={true}
         onClick={handleClick}
       />
     )

--- a/assets/scripts/streets/__tests__/StreetMetaWidthMenu.test.js
+++ b/assets/scripts/streets/__tests__/StreetMetaWidthMenu.test.js
@@ -59,7 +59,7 @@ describe('StreetMetaWidthMenu', () => {
           width: 40,
           occupiedWidth: 10
         }}
-        editable
+        editable={true}
         onChange={handleChange}
       />
     )

--- a/assets/scripts/streets/__tests__/StreetName.test.js
+++ b/assets/scripts/streets/__tests__/StreetName.test.js
@@ -32,7 +32,7 @@ describe('StreetName', () => {
   })
 
   it('shows a "Click to edit" message when mouse is hovering over it', () => {
-    const wrapper = renderWithIntl(<StreetName editable />)
+    const wrapper = renderWithIntl(<StreetName editable={true} />)
     fireEvent.mouseOver(wrapper.getByText('Unnamed St'))
     expect(wrapper.getByText('Click to rename')).toBeInTheDocument()
   })

--- a/assets/scripts/ui/__tests__/Checkbox.test.js
+++ b/assets/scripts/ui/__tests__/Checkbox.test.js
@@ -11,7 +11,13 @@ describe('Checkbox', () => {
 
   it('renders snapshot with all props', () => {
     const wrapper = render(
-      <Checkbox checked disabled value="bar" id="baz" onChange={jest.fn()}>
+      <Checkbox
+        checked={true}
+        disabled={true}
+        value="bar"
+        id="baz"
+        onChange={jest.fn()}
+      >
         foo
       </Checkbox>
     )

--- a/assets/scripts/ui/__tests__/CloseButton.test.js
+++ b/assets/scripts/ui/__tests__/CloseButton.test.js
@@ -16,8 +16,8 @@ describe('CloseButton', () => {
         onClick={jest.fn()}
         title="foofoo"
         className="my-class"
-        disabled
-        hidden
+        disabled={true}
+        hidden={true}
       />
     )
     expect(wrapper.asFragment()).toMatchSnapshot()


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md

Default value of this rule goes against React [recommendations](https://reactjs.org/docs/jsx-in-depth.html#props-default-to-true). 

I agree with this; being explicit makes more sense to me (Python habits die hard). 

@louh says:

"I actually agree with you here. It makes it easier to toggle a true value to false (or vice versa) without having to fiddle with the syntax...

This means people learning "best practices" (or at least, normalized practices) in React see a contradiction between React docs and our implementation of it, and we have no good rationale other than "this is what the "standard" eslint rules enforce." Normally I would hesitate to make a bikeshed argument against standard's rules but this might be a warranted case."

So this PR represents the consequences of us changing this rule for our codebase. 