### PR TITLE
Fixes to updating street names

### DIFF
--- a/assets/scripts/store/slices/street.js
+++ b/assets/scripts/store/slices/street.js
@@ -143,9 +143,14 @@ const streetSlice = createSlice({
         const { streetName, userUpdated } = action.payload
 
         if ((state.userUpdated && userUpdated) || !state.userUpdated) {
-          // Normalize street name input
-          // TODO: Consider whether to limit street name length here
-          state.name = streetName.trim()
+          if (typeof streetName === 'string') {
+            // Normalize street name input
+            // TODO: Consider whether to limit street name length here
+            state.name = streetName.trim()
+          } else if (!streetName) {
+            // If a streetname is null or undefined, unset it
+            state.name = null
+          }
         }
 
         if (userUpdated) {

--- a/assets/scripts/store/slices/street.test.js
+++ b/assets/scripts/store/slices/street.test.js
@@ -245,8 +245,8 @@ describe('street reducer', () => {
     })
   })
 
-  describe('street name', () => {
-    it('should handle saveStreetName(), updating when edited by user', () => {
+  describe('saveStreetName()', () => {
+    it('should update a street name when set by user', () => {
       const existingStreet = {
         name: 'street name',
         userUpdated: false
@@ -260,7 +260,7 @@ describe('street reducer', () => {
       })
     })
 
-    it('should handle saveStreetName(), not overwriting user-edited name', () => {
+    it('should not update a street name set by a user, when set by automation', () => {
       const existingStreet = {
         name: 'street name',
         userUpdated: true
@@ -274,7 +274,7 @@ describe('street reducer', () => {
       })
     })
 
-    it('should handle saveStreetName(), overwriting when not user-edited', () => {
+    it('should update a street name previously set only by automation, when set by automation', () => {
       const existingStreet = {
         name: 'street name',
         userUpdated: false
@@ -285,6 +285,30 @@ describe('street reducer', () => {
       ).toEqual({
         name: 'new street name',
         userUpdated: false
+      })
+    })
+
+    it('should clear a street name set by automation, when cleared by automation', () => {
+      const existingStreet = {
+        name: 'street name',
+        userUpdated: false
+      }
+
+      expect(street(existingStreet, saveStreetName(undefined, false))).toEqual({
+        name: null,
+        userUpdated: false
+      })
+    })
+
+    it('should not clear a street name set by a user, when cleared by automation', () => {
+      const existingStreet = {
+        name: 'street name',
+        userUpdated: true
+      }
+
+      expect(street(existingStreet, saveStreetName(null, false))).toEqual({
+        name: 'street name',
+        userUpdated: true
       })
     })
   })

--- a/assets/scripts/streets/remix.js
+++ b/assets/scripts/streets/remix.js
@@ -138,7 +138,7 @@ export function addRemixSuffixToName () {
       STREET_NAME_REMIX_SUFFIX.length
     ) !== STREET_NAME_REMIX_SUFFIX
   ) {
-    street.name += ' ' + STREET_NAME_REMIX_SUFFIX
+    const newStreetName = street.name + ' ' + STREET_NAME_REMIX_SUFFIX
+    store.dispatch(saveStreetName(newStreetName, false))
   }
-  store.dispatch(saveStreetName(street.name, false))
 }


### PR DESCRIPTION
There's two commits here, both are self contained and can be reviewed separately.

The main fix is for #1920, where `addRemixSuffixToName()` is being called, which throws an error as described in that issue. This is happening because we recently ported our Redux implementation to the Redux Toolkit (#1877 - megathread for context) which enforces immutability on all Redux state. This has surfaced a number of instances where we were improperly mutating Redux state outside of the store and the dispatch cycle. The biggest concerns have been caught, but smaller edge cases like this one will likely continue to prop up from time to time.

To fix this, I'm assigning a newly created street name to a new variable (instead of appending text to the original) and dispatching that to the store.

There is a second fix to a separate but I caught while testing this, which happens when we need to clear the location (and the street name). This dispatches `saveStreetName()` with an undefined value, which should be cleared (set to `null`). Previously, this would throw an error because the undefined value will not have the `.trim()` method, which is only present on strings. The fix now accounts for this.