### PR TITLE
feat: add route to go to a random candidate street for voting

### DIFF
--- a/app/api_routes.js
+++ b/app/api_routes.js
@@ -884,4 +884,6 @@ routes.get('/api/*', (req, res) => {
     .json({ status: 404, error: 'Not found. Did you mispell something?' })
 })
 
+routes.get('/survey', resources.v1.survey.get)
+
 module.exports = routes

--- a/app/resources/v1/survey.js
+++ b/app/resources/v1/survey.js
@@ -1,0 +1,45 @@
+const Sequelize = require('sequelize')
+const { Street, Vote } = require('../../db/models')
+const logger = require('../../../lib/logger.js')()
+
+exports.get = async function (req, res) {
+  let ballot
+  try {
+    ballot = await Vote.findAll({
+      where: {
+        voterId: {
+          [Sequelize.Op.is]: null
+        }
+      },
+      order: Sequelize.literal('random()'),
+      limit: 1
+    })
+  } catch (error) {
+    logger.error(error)
+    res.status(500).json({ status: 500, msg: 'Error fetching ballot.' })
+    return
+  }
+  // const payload = { ballot }
+  let street
+  let candidateStreetUrl = '/'
+  try {
+    const streetId = ballot[0].data.street.id
+
+    if (!streetId) throw new Error('no street ID found for ballot!')
+    street = await Street.findOne({ where: { id: streetId } })
+
+    if (!street.creatorId) {
+      candidateStreetUrl = `/-/${street.namespacedId}`
+    } else {
+      candidateStreetUrl = `/${street.creatorId}/${street.namespacedId}`
+    }
+  } catch (error) {
+    logger.error(error)
+    res
+      .status(500)
+      .json({ status: 500, msg: 'Error fetching street from ballot.' })
+    return
+  }
+
+  res.redirect(candidateStreetUrl)
+}

--- a/assets/scripts/sentiment/SentimentSurvey.jsx
+++ b/assets/scripts/sentiment/SentimentSurvey.jsx
@@ -129,17 +129,19 @@ function SentimentSurvey ({ visible = false, onClose = () => {}, handleVote }) {
                 ))}
               </div>
               <p>
-                {score === null ? (
-                  <FormattedMessage
-                    id="sentiment.about-text"
-                    defaultMessage="This survey helps Streetmix learn how people feel about streets."
-                  />
-                ) : (
-                  <FormattedMessage
-                    id="sentiment.thank-you"
-                    defaultMessage="Thank you for participating in this survey!"
-                  />
-                )}
+                <a href="/survey">
+                  {score === null ? (
+                    <FormattedMessage
+                      id="sentiment.about-text"
+                      defaultMessage="This survey helps Streetmix learn how people feel about streets. Click here to see a different street."
+                    />
+                  ) : (
+                    <FormattedMessage
+                      id="sentiment.thank-you"
+                      defaultMessage="Thank you for participating in this survey! Click here to see another street."
+                    />
+                  )}
+                </a>
               </p>
             </animated.div>
           )


### PR DESCRIPTION
This adds a new route, `/survey`, which redirects the user to a new street that has yet to be voted on. It also lets the user click the message at the bottom of the survey to get a different street, before or after voting. 

### Generating Ballots
Generating 'ballot' streets can be done with a simple SQL query: 

```
WIP
```

