### PR TITLE
fix: auth0 twitter login should not rely on screen name

### DIFF
--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -47,7 +47,7 @@ exports.post = async function (req, res) {
     try {
       let user
       if (credentials.screenName) {
-        user = await User.findOne({ where: { id: credentials.screenName } })
+        user = await User.findOne({ where: { auth0Id: credentials.auth0Id } })
       }
       if (!user) {
         const newUserData = {


### PR DESCRIPTION
🔨 🤕 
Auth code made some assumptions around the nature of twitter profiles that is causing some twitter users to succeed at initial login, but fail at the POST to `v1/users` that should update their info afterwards. If the user is not found by their screen name, the server attempts to make a new user with the same ID, which violates our uniqueness constraints. 

This change ensures the correct user is always found, since all users now have an auth0 ID for login. 