### PR TITLE
Add a range slider UI component

### DIFF
--- a/assets/scripts/dialogs/SaveAsImageDialog.scss
+++ b/assets/scripts/dialogs/SaveAsImageDialog.scss
@@ -90,7 +90,8 @@
 .save-as-image-download {
   text-align: center;
 
-  a.button-like {
-    margin-top: 0;
+  /* Override a reset to this line-height */
+  button {
+    line-height: inherit;
   }
 }

--- a/assets/scripts/dialogs/__tests__/__snapshots__/SaveAsImageDialog.test.js.snap
+++ b/assets/scripts/dialogs/__tests__/__snapshots__/SaveAsImageDialog.test.js.snap
@@ -38,12 +38,12 @@ exports[`SaveAsImageDialog renders snapshot 1`] = `
               class="checkbox-item"
             >
               <input
-                id="checkbox-id-4"
+                id="checkbox-id-1"
                 type="checkbox"
                 value=""
               />
               <label
-                for="checkbox-id-4"
+                for="checkbox-id-1"
               >
                 Segment names and widths
               </label>
@@ -55,12 +55,12 @@ exports[`SaveAsImageDialog renders snapshot 1`] = `
               class="checkbox-item"
             >
               <input
-                id="checkbox-id-5"
+                id="checkbox-id-2"
                 type="checkbox"
                 value=""
               />
               <label
-                for="checkbox-id-5"
+                for="checkbox-id-2"
               >
                 Street name
               </label>
@@ -72,12 +72,12 @@ exports[`SaveAsImageDialog renders snapshot 1`] = `
               class="checkbox-item"
             >
               <input
-                id="checkbox-id-6"
+                id="checkbox-id-3"
                 type="checkbox"
                 value=""
               />
               <label
-                for="checkbox-id-6"
+                for="checkbox-id-3"
               >
                 Transparent sky
               </label>
@@ -91,12 +91,12 @@ exports[`SaveAsImageDialog renders snapshot 1`] = `
               <input
                 checked=""
                 disabled=""
-                id="checkbox-id-7"
+                id="checkbox-id-4"
                 type="checkbox"
                 value=""
               />
               <label
-                for="checkbox-id-7"
+                for="checkbox-id-4"
               >
                 Watermark
               </label>

--- a/assets/scripts/ui/Checkbox.jsx
+++ b/assets/scripts/ui/Checkbox.jsx
@@ -2,14 +2,14 @@
  * Custom stylized checkbox component, so we control the look and
  * feel instead of relying on browser's default styles.
  */
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ICON_CHECK } from '../ui/icons'
 import './Checkbox.scss'
 
 // This stores an incrementing number for unique IDs.
-let idCounter = 0
+let idCounter = 1
 
 Checkbox.propTypes = {
   // Child nodes are wrapped in <label> when rendered.
@@ -29,6 +29,9 @@ Checkbox.propTypes = {
   // The handler function that's called when the value of the input changes.
   onChange: PropTypes.func,
 
+  // Class name applied to containing element
+  className: PropTypes.string,
+
   // An `id` is associates a `label` with an `input` element. If you don't
   // provide one, the component automatically generates a unique ID. IDs
   // are meant "for internal use only".
@@ -42,17 +45,34 @@ function Checkbox (props) {
     disabled = false,
     value,
     onChange = () => {},
+    id,
+    className,
 
-    // An `id` is required to associate a `label` with an `input` element.
-    // You can provide one manually in props, otherwise, this component
-    // will generate a unique ID on each render.
-    id = `checkbox-id-${idCounter++}`
+    // Remainder of props will be applied to the containing <div> element
+    // for instance, `style`, data attributes, etc.
+    ...restProps
   } = props
 
   // This is a controlled component. The `useState` hook maintains
   // this component's internal state, and sets the initial state
   // based on the `checked` prop (which is `false` by default).
   const [isChecked, setChecked] = useState(checked)
+
+  // An `id` is required to associate a `label` with an `input` element.
+  // You can provide one manually in props, otherwise, this component
+  // will generate a unique id value for each instance. Generated ids
+  // are not meant to be accessed by other code or CSS selectors.
+  const elementId = useRef(id)
+  if (!elementId.current) {
+    // This exists in an if statement to check if the ref value is present
+    // to prevent the counter from incrementing on every render
+    elementId.current = `checkbox-id-${idCounter++}`
+  }
+
+  const classNames = ['checkbox-item']
+  if (className) {
+    classNames.push(className)
+  }
 
   // When the value is changed, we update the state, and we also call
   // any `onChange` handler that is provided by the parent via props.
@@ -62,18 +82,16 @@ function Checkbox (props) {
   }
 
   return (
-    <div className="checkbox-item">
+    <div className={classNames.join(' ')} {...restProps}>
       <input
         type="checkbox"
-        id={id}
+        id={elementId.current}
         checked={isChecked}
         value={value}
         disabled={disabled}
         onChange={handleChange}
       />
-      <label htmlFor={id}>
-        {children}
-      </label>
+      <label htmlFor={elementId.current}>{children}</label>
       {/* The visual state of this checkbox is affected by the value of the input, via CSS. */}
       <FontAwesomeIcon icon={ICON_CHECK} />
     </div>

--- a/assets/scripts/ui/Checkbox.scss
+++ b/assets/scripts/ui/Checkbox.scss
@@ -1,9 +1,11 @@
+@import "../../styles/variables.scss";
+
 // UI color ramp
-$color-1: #a6b2c8;
-$color-2: #55a2ae;
+$color-1: $colour-midnight-300 !default;
+$color-2: $colour-turquoise-500 !default;
 
 // Special colors
-$disabled-color: #a6b2c8;
+$disabled-color: $colour-midnight-300 !default;
 
 // Colors for stylized checkbox input
 $input-default-border-color: $color-1;
@@ -71,7 +73,7 @@ $label-outline-color: $color-2;
     height: 1em;
     width: 1em;
     background-color: $input-unchecked-background-color;
-    border-radius: 2px;
+    border-radius: $border-radius-small;
     border: 1px solid $input-default-border-color;
     color: inherit;
     transition: background-color 60ms, color 60ms;

--- a/assets/scripts/ui/RangeSlider.jsx
+++ b/assets/scripts/ui/RangeSlider.jsx
@@ -1,0 +1,84 @@
+import React, { useRef } from 'react'
+import PropTypes from 'prop-types'
+import './RangeSlider.scss'
+
+// This stores an incrementing number for unique IDs.
+let idCounter = 1
+
+RangeSlider.propTypes = {
+  // Child nodes are wrapped in <label> when rendered.
+  children: PropTypes.node.isRequired,
+
+  // Values for the slider element, matches vanilla HTML usage.
+  min: PropTypes.number,
+  max: PropTypes.number,
+  step: PropTypes.number,
+
+  // Whether or not the input is disabled.
+  disabled: PropTypes.bool,
+
+  // The value of a checkbox input can be optionally set.
+  value: PropTypes.number,
+
+  // The handler function that's called when the value of the input changes.
+  onChange: PropTypes.func,
+
+  // Class name applied to containing element
+  className: PropTypes.string,
+
+  // An `id` is associates a `label` with an `input` element. If you don't
+  // provide one, the component automatically generates one.
+  id: PropTypes.string
+}
+
+function RangeSlider (props) {
+  const {
+    children,
+    min = 0,
+    max = 100,
+    step = 1,
+    disabled = false,
+    value,
+    onChange = () => {},
+    id,
+    className,
+
+    // Remainder of props will be applied to the containing <div> element
+    // for instance, `style`, data attributes, etc.
+    ...restProps
+  } = props
+
+  // An `id` is required to associate a `label` with an `input` element.
+  // You can provide one manually in props, otherwise, this component
+  // will generate a unique id value for each instance. Generated ids
+  // are not meant to be accessed by other code or CSS selectors.
+  const elementId = useRef(id)
+  if (!elementId.current) {
+    // This exists in an if statement to check if the ref value is present
+    // to prevent the counter from incrementing on every render
+    elementId.current = `rangeslider-id-${idCounter++}`
+  }
+
+  const classNames = ['range-slider-item']
+  if (className) {
+    classNames.push(className)
+  }
+
+  return (
+    <div className={classNames.join(' ')} {...restProps}>
+      <label htmlFor={elementId.current}>{children}</label>{' '}
+      <input
+        type="range"
+        id={elementId.current}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        value={value}
+        onChange={onChange}
+      />
+    </div>
+  )
+}
+
+export default RangeSlider

--- a/assets/scripts/ui/RangeSlider.scss
+++ b/assets/scripts/ui/RangeSlider.scss
@@ -1,0 +1,91 @@
+@import "../../styles/variables.scss";
+
+$range-handle-color: $colour-midnight-500 !default;
+$range-handle-color-hover: $colour-turquoise-500 !default;
+$range-handle-color-focus: $colour-turquoise-500 !default;
+$range-handle-size: 16px !default;
+
+$range-track-color: transparent !default;
+$range-track-border-color: $colour-midnight-300 !default;
+$range-track-height: 6px !default;
+
+.range-slider-item {
+  position: relative;
+
+  input {
+    appearance: none;
+    width: 100%;
+    height: $range-track-height;
+    border-radius: $border-radius-small;
+    border: 1px solid $range-track-border-color;
+    background: $range-track-color;
+    outline: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+
+    // Range Handle
+    &::-webkit-slider-thumb {
+      appearance: none;
+      width: $range-handle-size;
+      height: $range-handle-size;
+      border-radius: 50%;
+      background: $range-handle-color;
+      cursor: pointer;
+
+      &:hover {
+        background: $range-handle-color-hover;
+      }
+    }
+
+    &:active::-webkit-slider-thumb {
+      background: $range-handle-color-hover;
+    }
+
+    &::-moz-range-thumb {
+      width: $range-handle-size;
+      height: $range-handle-size;
+      border: 0;
+      border-radius: 50%;
+      background: $range-handle-color;
+      cursor: pointer;
+
+      &:hover {
+        background: $range-handle-color-hover;
+      }
+    }
+
+    &:active::-moz-range-thumb {
+      background: $range-handle-color-hover;
+    }
+
+    // Focus state
+    &:focus {
+      &::-webkit-slider-thumb {
+        box-shadow: inset 0 0 0 1px white,
+          // Match background color
+            0 0 0 1px white,
+          0 0 0 3px $colour-emerald-400;
+      }
+    }
+
+    // Firefox Overrides
+    &::-moz-range-track {
+      background: $range-track-color;
+      border: 0;
+    }
+
+    &::-moz-focus-inner,
+    &::-moz-focus-outer {
+      border: 0;
+    }
+  }
+
+  /* Positions the label */
+  label {
+    display: inline-block;
+    position: relative;
+    padding: 0 0.5rem; /* Breathing room around outline property */
+    cursor: pointer;
+  }
+}

--- a/assets/scripts/ui/__tests__/Checkbox.test.js
+++ b/assets/scripts/ui/__tests__/Checkbox.test.js
@@ -17,6 +17,8 @@ describe('Checkbox', () => {
         value="bar"
         id="baz"
         onChange={jest.fn()}
+        className="custom-classname"
+        style={{ color: 'blue' }}
       >
         foo
       </Checkbox>
@@ -25,7 +27,7 @@ describe('Checkbox', () => {
     expect(wrapper.asFragment()).toMatchSnapshot()
   })
 
-  it('handles click', () => {
+  it('handles click on the label text', () => {
     const handleChange = jest.fn()
     const { getByText } = render(
       <Checkbox onChange={handleChange}>foo</Checkbox>

--- a/assets/scripts/ui/__tests__/RangeSlider.test.js
+++ b/assets/scripts/ui/__tests__/RangeSlider.test.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+import React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import RangeSlider from '../RangeSlider'
+
+describe('RangeSlider', () => {
+  it('renders default snapshot', () => {
+    const wrapper = render(<RangeSlider>foo</RangeSlider>)
+    expect(wrapper.asFragment()).toMatchSnapshot()
+  })
+
+  it('renders snapshot with all props', () => {
+    const wrapper = render(
+      <RangeSlider
+        min={0}
+        max={2000}
+        step={10}
+        disabled={true}
+        value={1000}
+        id="baz"
+        onChange={jest.fn()}
+        className="custom-classname"
+        style={{ color: 'blue' }}
+      >
+        foo
+      </RangeSlider>
+    )
+
+    expect(wrapper.asFragment()).toMatchSnapshot()
+  })
+
+  it('handles value change', () => {
+    const handleChange = jest.fn((event) => {
+      // We must persist React's synthetic event in the handler so that
+      // we are able to use the `.toHaveBeenCalledWith()` method below.
+      event.persist()
+    })
+    const { getByLabelText } = render(
+      <RangeSlider onChange={handleChange}>foo</RangeSlider>
+    )
+    const input = getByLabelText('foo')
+
+    // Initial value is expected to be halfway between the default
+    // mininum and maximum range, and per HTML spec, the value is
+    // of type string
+    expect(input.value).toBe('50')
+
+    // Change the value
+    fireEvent.change(input, { target: { value: 5 } })
+    expect(input.value).toBe('5')
+
+    // Test the handler
+    expect(handleChange).toHaveBeenCalledTimes(1)
+    expect(handleChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({
+          value: '5'
+        })
+      })
+    )
+  })
+})

--- a/assets/scripts/ui/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/assets/scripts/ui/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -6,12 +6,12 @@ exports[`Checkbox renders default snapshot 1`] = `
     class="checkbox-item"
   >
     <input
-      id="checkbox-id-0"
+      id="checkbox-id-1"
       type="checkbox"
       value=""
     />
     <label
-      for="checkbox-id-0"
+      for="checkbox-id-1"
     >
       foo
     </label>
@@ -25,7 +25,8 @@ exports[`Checkbox renders default snapshot 1`] = `
 exports[`Checkbox renders snapshot with all props 1`] = `
 <DocumentFragment>
   <div
-    class="checkbox-item"
+    class="checkbox-item custom-classname"
+    style="color: blue;"
   >
     <input
       checked=""

--- a/assets/scripts/ui/__tests__/__snapshots__/RangeSlider.test.js.snap
+++ b/assets/scripts/ui/__tests__/__snapshots__/RangeSlider.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RangeSlider renders default snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="range-slider-item"
+  >
+    <label
+      for="rangeslider-id-1"
+    >
+      foo
+    </label>
+     
+    <input
+      id="rangeslider-id-1"
+      max="100"
+      min="0"
+      step="1"
+      type="range"
+      value=""
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`RangeSlider renders snapshot with all props 1`] = `
+<DocumentFragment>
+  <div
+    class="range-slider-item custom-classname"
+    style="color: blue;"
+  >
+    <label
+      for="baz"
+    >
+      foo
+    </label>
+     
+    <input
+      disabled=""
+      id="baz"
+      max="2000"
+      min="0"
+      step="10"
+      type="range"
+      value="1000"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/assets/styles/_buttons.scss
+++ b/assets/styles/_buttons.scss
@@ -42,14 +42,12 @@ a.button-like {
   }
 
   &[disabled] {
-    border-top-color: desaturate($ui-colour, 100%);
-    border-bottom-color: desaturate($ui-colour, 100%);
-    background-color: desaturate(fade-out($ui-colour, 0.7), 100%);
+    background-color: desaturate(fade-out($ui-colour, 0.7), 100%) !important;
     color: #999 !important;
     cursor: auto;
 
     &:hover {
-      background-color: desaturate(fade-out($ui-colour, 0.7), 100%);
+      background-color: desaturate(fade-out($ui-colour, 0.7), 100%) !important;
     }
   }
 }


### PR DESCRIPTION
This PR introduces a reusable range slider UI React component, as seen below.

![image](https://user-images.githubusercontent.com/2553268/84164547-a1f46a00-aa40-11ea-8e3b-ca115c7f5a98.png)

In addition, the Checkbox UI component has been updated to bring its functionality in line with the RangeSlider component. Improvements include:

- If `id` attributes are automatically generated, use a ref to keep the values stable across subsequent renders of the same instance of the component. Previously, the counter would increment on every render.
- Checkbox styles now use variables for color and border radius, which were not standardized before this component was initially written.
- Class names and other props (attributes) passed to the Checkbox component will now be applied to the containing `<div>` element that it renders.

The RangeSlider UI component is intended to be used as an input in the SaveAsImageDialog to change the resolution of the exportable image. This functionality is not yet live to a general audience. To test this, activate the `SAVE_AS_IMAGE_CUSTOM_DPI` feature flag. This feature is also not yet complete, but this PR introduces a few changes to the dialog box to facilitate testing the RangeSlider:

- Previously, changing any of the inputs into the exportable image renders a new preview. When we introduced the scale slider, rendering a 10x image causes the image pending status to wait a very long time. Each time the slider changes value, it would attempt to re-render the image at that scale, a very time consuming an expensive process, for no additional end-user value because the preview image would be shrunk to the same size. Instead, we now render the preview image at the same scale regardless of the slider value, and only generate the image when the "Download" button is clicked. 
- The "Download" button is disabled when the render process is occurring to prevent multiple clicks on the element. This is not complete. In the future we will need some additional visual indicator of pending status.
- This change in behavior means that right-click on the image to save (or open in a new window), or accessing the button link directly for the image, no longer works as intended.

Please note that the review here is for the RangeSlider UI component only. I welcome questions and suggestions to how this is used in the SaveAsImageDialog but the feature progress here is not intended to be complete or final.