### PR TITLE
feat: add to max connection pools

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -41,7 +41,16 @@ module.exports = {
       logging: true,
       database: 'streetmix_dev',
       host: process.env.PGHOST || '127.0.0.1',
-      port: process.env.PGPORT || 5432
+      port: process.env.PGPORT || 5432,
+      // surely there is a way to inherit these defaults to other config files?
+      // heroku hobby tier has max connections of 20, so this is a conservative setting
+      // you'll see h22 errors if its too high: https://devcenter.heroku.com/articles/error-codes#h22-connection-limit-reached
+      pool: {
+        max: 12,
+        min: 0,
+        acquire: 30000,
+        idle: 10000
+      }
     }
   },
   log_level: 'debug',

--- a/config/production.js
+++ b/config/production.js
@@ -14,7 +14,13 @@ module.exports = {
     sequelize: {
       // The `url` property is documented in sequelize-cli readme but not in Sequelize core
       url: process.env.DATABASE_URL,
-      logging: false
+      logging: false,
+      pool: {
+        max: 12,
+        min: 0,
+        acquire: 30000,
+        idle: 10000
+      }
     }
   },
   l10n: {

--- a/config/staging.js
+++ b/config/staging.js
@@ -9,7 +9,13 @@ module.exports = {
   db: {
     sequelize: {
       // The `url` property is documented in sequelize-cli readme but not in Sequelize core
-      url: process.env.DATABASE_URL
+      url: process.env.DATABASE_URL,
+      pool: {
+        max: 12,
+        min: 0,
+        acquire: 30000,
+        idle: 10000
+      }
     }
   },
   l10n: {


### PR DESCRIPTION
connection pooling is kind of a broad and tricky topic
luckily, I think our app setup is pretty simple, to the gist of this change is this: 

allowing more connections allows for more open database connections to be maintained, which should allow more queries against the database at a time. It avoids having to close and open connections as much to make queries. 

Unfortunately the docs around this particular implementation for sequelize are pretty poor. It's hard to always know the best settings for connection pooling cause it can depend on your app uses them. Ideally we'd have more insight here, and it would be best to test in a staging environment that can replicate production.

However, I wouldn't expect a modest setting change like this to make anything _worse_. 

