### PR TITLE
Feat: use refresh token to replace expired main token

### DIFF
--- a/app.js
+++ b/app.js
@@ -207,7 +207,7 @@ app.get('/help/about', (req, res) =>
 )
 app.get('/map', (req, res) => res.redirect('https://streetmix.github.io/map/'))
 app.get('/survey', controllers.survey.get)
-app.post('/refresh', cors(), controllers.refresh.post)
+app.post('/services/auth/refresh-login-token', cors(), controllers.refresh.post)
 
 app.get('/privacy-policy', (req, res) => res.render('privacy'))
 app.get('/terms-of-service', (req, res) => res.render('tos'))

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ if (process.env.NEW_RELIC_LICENSE_KEY) {
 const compression = require('compression')
 const cookieParser = require('cookie-parser')
 const cookieSession = require('cookie-session')
+const cors = require('cors')
 const express = require('express')
 const helmet = require('helmet')
 const config = require('config')
@@ -206,6 +207,7 @@ app.get('/help/about', (req, res) =>
 )
 app.get('/map', (req, res) => res.redirect('https://streetmix.github.io/map/'))
 app.get('/survey', controllers.survey.get)
+app.post('/refresh', cors(), controllers.refresh.post)
 
 app.get('/privacy-policy', (req, res) => res.render('privacy'))
 app.get('/terms-of-service', (req, res) => res.render('tos'))

--- a/app/controllers/auth0_sign_in_callback.js
+++ b/app/controllers/auth0_sign_in_callback.js
@@ -7,7 +7,6 @@ const AccessTokenHandler = function (req, res) {
   return async (response) => {
     const body = response.data
     if (body.error && body.error === 'access_denied') {
-      console.log('CODE 0')
       res.redirect('/error/access-denied')
       return
     }
@@ -42,7 +41,6 @@ const AccessTokenHandler = function (req, res) {
           res.redirect('/just-signed-in')
         })
         .catch((error) => {
-          console.log('CODE 1')
           logger.error('Error from auth0 API when signing in: ' + error)
           res.redirect('/error/authentication-api-problem')
         })

--- a/app/controllers/auth0_sign_in_callback.js
+++ b/app/controllers/auth0_sign_in_callback.js
@@ -7,6 +7,7 @@ const AccessTokenHandler = function (req, res) {
   return async (response) => {
     const body = response.data
     if (body.error && body.error === 'access_denied') {
+      console.log('CODE 0')
       res.redirect('/error/access-denied')
       return
     }
@@ -37,10 +38,11 @@ const AccessTokenHandler = function (req, res) {
           res.cookie('user_id', user.id || userAuthData)
           res.cookie('refresh_token', refreshToken)
           res.cookie('login_token', idToken)
-          res.cookie('access_token', idToken)
+          res.cookie('access_token', accessToken)
           res.redirect('/just-signed-in')
         })
         .catch((error) => {
+          console.log('CODE 1')
           logger.error('Error from auth0 API when signing in: ' + error)
           res.redirect('/error/authentication-api-problem')
         })
@@ -87,6 +89,7 @@ const getUserTwitterAuth0Info = function (user) {
 
 exports.get = function (req, res) {
   if (req.query.error) {
+    logger.error('Auth0 encountered an error: ' + req.query.error)
     res.redirect('/error/access-denied')
     return
   }

--- a/app/controllers/refresh.js
+++ b/app/controllers/refresh.js
@@ -1,0 +1,33 @@
+const axios = require('axios')
+const logger = require('../../lib/logger.js')()
+const config = require('config')
+
+// Refreshes auth0 token so user doesn't need to sign in every 30 days
+exports.post = function (req, res) {
+  if (!req.body || !req.body.token) {
+    res.status(401).send({ error: 'Refresh token is required.' })
+  }
+
+  const endpoint = config.auth0.token_api_url
+  const apiRequestBody = {
+    grant_type: 'refresh_token',
+    refresh_token: req.body.token,
+    client_id: config.auth0.client_id,
+    client_secret: config.auth0.client_secret
+  }
+
+  axios
+    .post(endpoint, apiRequestBody, {})
+    .then((response) => {
+      if (!response.data.id_token) {
+        logger.error('Missing results from token fresh: ')
+        res.status(401).statusend({ error: 'Unable to refresh token.' })
+        return
+      }
+      res.status(200).send({ token: response.data.id_token })
+    })
+    .catch((error) => {
+      logger.error('Error from auth0 refreshing tokens: ' + error)
+      res.status(401).statusend({ error: 'Unable to refresh token.' })
+    })
+}

--- a/app/db/migrations/20200614230057-remove-user-legacy-id.js
+++ b/app/db/migrations/20200614230057-remove-user-legacy-id.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('Users', '_id')
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('Users', '_id', Sequelize.DataTypes.TEXT)
+  }
+}

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -10,10 +10,6 @@ module.exports = (sequelize, DataTypes) => {
         unique: true,
         type: DataTypes.STRING
       },
-      _id: {
-        type: DataTypes.STRING,
-        allowNull: true
-      },
       twitterId: {
         type: DataTypes.STRING,
         field: 'twitter_id'

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie'
+import jwtDecode from 'jwt-decode'
 
 import USER_ROLES from '../../../app/data/user_roles'
 import { app } from '../preinit/app_settings'
@@ -23,6 +24,7 @@ import { updateStreetIdMetadata } from '../store/slices/street'
 
 const USER_ID_COOKIE = 'user_id'
 const SIGN_IN_TOKEN_COOKIE = 'login_token'
+const REFRESH_TOKEN_COOKIE = 'refresh_token'
 const LOCAL_STORAGE_SIGN_IN_ID = 'sign-in'
 
 export function doSignIn () {
@@ -74,15 +76,23 @@ function saveSignInDataLocally () {
 
 function removeSignInCookies () {
   Cookies.remove(SIGN_IN_TOKEN_COOKIE)
+  Cookies.remove(REFRESH_TOKEN_COOKIE)
   Cookies.remove(USER_ID_COOKIE)
 }
 
 export async function loadSignIn () {
   var signInCookie = Cookies.get(SIGN_IN_TOKEN_COOKIE)
+  var refreshCookie = Cookies.get(REFRESH_TOKEN_COOKIE)
   var userIdCookie = Cookies.get(USER_ID_COOKIE)
 
   if (signInCookie && userIdCookie) {
-    store.dispatch(setSignInData({ token: signInCookie, userId: userIdCookie }))
+    store.dispatch(
+      setSignInData({
+        token: signInCookie,
+        refreshToken: refreshCookie,
+        userId: userIdCookie
+      })
+    )
 
     removeSignInCookies()
     saveSignInDataLocally()
@@ -102,6 +112,14 @@ export async function loadSignIn () {
   let flagOverrides = []
 
   if (signInData && signInData.token && signInData.userId) {
+    const currentDate = new Date()
+    var decoded = jwtDecode(signInData.token)
+    const expDate = new Date(decoded.exp * 1000)
+    expDate.setDate(expDate.getDate() - 1) // refresh token one day early
+
+    if (currentDate >= expDate) {
+      await fetchFreshTokens(signInData.refreshToken)
+    }
     flagOverrides = await fetchSignInDetails(signInData.userId)
   } else {
     store.dispatch(clearSignInData())
@@ -115,6 +133,64 @@ export async function loadSignIn () {
   _signInLoaded()
 
   return true
+}
+
+/**
+ *
+ * @param {String} refreshToken
+ * @returns {Object}
+ */
+async function fetchFreshTokens (refreshToken) {
+  const requestBody = JSON.stringify({ token: refreshToken })
+  try {
+    const response = await window.fetch('/refresh', {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: requestBody
+    })
+
+    if (!response.ok) {
+      throw response
+    }
+
+    const json = await response.json()
+    const { token } = json
+
+    receiveFreshTokens({ token })
+    return
+  } catch (error) {
+    errorReceiveFreshTokens(error)
+  }
+}
+
+function receiveFreshTokens (freshTokens) {
+  const signInData = {
+    ...getSignInData(),
+    freshTokens
+  }
+  store.dispatch(setSignInData(signInData))
+  saveSignInDataLocally()
+}
+
+function errorReceiveFreshTokens (data) {
+  if (data.status === 401) {
+    trackEvent('ERROR', 'ERROR_RM1R', null, null, false)
+
+    signOut(true)
+
+    showError(ERRORS.SIGN_IN_401, true)
+    return
+  } else if (data.status === 503) {
+    trackEvent('ERROR', 'ERROR_15AR', null, null, false)
+
+    showError(ERRORS.SIGN_IN_SERVER_FAILURE, true)
+    return
+  }
+
+  // Fail silently
+  store.dispatch(clearSignInData())
 }
 
 /**

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -81,9 +81,9 @@ function removeSignInCookies () {
 }
 
 export async function loadSignIn () {
-  var signInCookie = Cookies.get(SIGN_IN_TOKEN_COOKIE)
-  var refreshCookie = Cookies.get(REFRESH_TOKEN_COOKIE)
-  var userIdCookie = Cookies.get(USER_ID_COOKIE)
+  const signInCookie = Cookies.get(SIGN_IN_TOKEN_COOKIE)
+  const refreshCookie = Cookies.get(REFRESH_TOKEN_COOKIE)
+  const userIdCookie = Cookies.get(USER_ID_COOKIE)
 
   if (signInCookie && userIdCookie) {
     store.dispatch(
@@ -113,7 +113,7 @@ export async function loadSignIn () {
 
   if (signInData && signInData.token && signInData.userId) {
     const currentDate = new Date()
-    var decoded = jwtDecode(signInData.token)
+    const decoded = jwtDecode(signInData.token)
     const expDate = new Date(decoded.exp * 1000)
     expDate.setDate(expDate.getDate() - 1) // refresh token one day early
 
@@ -143,7 +143,7 @@ export async function loadSignIn () {
 async function fetchFreshTokens (refreshToken) {
   const requestBody = JSON.stringify({ token: refreshToken })
   try {
-    const response = await window.fetch('/refresh', {
+    const response = await window.fetch('/services/auth/refresh-login-token', {
       method: 'post',
       headers: {
         'Content-Type': 'application/json'

--- a/package-lock.json
+++ b/package-lock.json
@@ -15441,6 +15441,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
+    },
     "kew": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "js-cookie": "2.2.1",
     "json2csv": "5.0.1",
     "jwks-rsa": "1.8.0",
+    "jwt-decode": "2.2.0",
     "leaflet": "1.6.0",
     "lodash": "4.17.15",
     "newrelic": "6.8.0",


### PR DESCRIPTION
## Summary

Currently, users are seeing their accounts logged out more often because we are now correctly checking the validity of tokens, and tokens expire. 

This PR adds code on page load to check if the current token expires in the next 24 hours, and if so, will fetch a fresh token and save it to the client. 🗼 


### QA
Sign out, sign in. On staging, tokens are set to expire once every 24 hours, so typically every page refresh will trigger one network request to `/refresh`. Check that this returns a 200 status and a new token.


### Misc.
Also removed the `_id` column on users once and for all, but i can break this out into a separate PR if desired. 