### PR TITLE
fix(auth): response formatting

### DIFF
--- a/app/controllers/refresh.js
+++ b/app/controllers/refresh.js
@@ -5,7 +5,8 @@ const config = require('config')
 // Refreshes auth0 token so user doesn't need to sign in every 30 days
 exports.post = function (req, res) {
   if (!req.body || !req.body.token) {
-    res.status(401).send({ error: 'Refresh token is required.' })
+    res.status(401).json({ status: 401, msg: 'Refresh token is required.' })
+    return
   }
 
   const endpoint = config.auth0.token_api_url
@@ -20,14 +21,14 @@ exports.post = function (req, res) {
     .post(endpoint, apiRequestBody, {})
     .then((response) => {
       if (!response.data.id_token) {
-        logger.error('Missing results from token fresh: ')
-        res.status(401).statusend({ error: 'Unable to refresh token.' })
+        logger.error('Missing results from token refresh: ')
+        res.status(401).json({ status: 401, msg: 'Unable to refresh token.' })
         return
       }
-      res.status(200).send({ token: response.data.id_token })
+      res.status(200).json({ token: response.data.id_token })
     })
     .catch((error) => {
       logger.error('Error from auth0 refreshing tokens: ' + error)
-      res.status(401).statusend({ error: 'Unable to refresh token.' })
+      res.status(401).json({ status: 401, msg: 'Unable to refresh token.' })
     })
 }


### PR DESCRIPTION
A number of fixes to the response at /services/auth/refresh-login-token:

 - A couple of instances where `.statusend()` is called on the Express
   response object, which does not exist. It is likely this is a typo
   and that `.send()` is the intended method.
 - However, we have generally standardized on using `.json()` when
   returning JSON-serializable data. Although `.send()` does send JSON
   when the body is a JavaScript object, we opt here to be explicit
   that the only data we return is of a JSON MIME type.
 - The response object is also updated to be in line with other API
   error response objects. It should contain the `status` property,
   and instead of the property `error` we use `msg`.