### PR TITLE
Wschorn/fix/cookie expiration

### DIFF
--- a/app.js
+++ b/app.js
@@ -150,7 +150,9 @@ app.use(helmet(helmetConfig))
 app.use(express.json())
 app.use(compression())
 app.use(cookieParser())
-app.use(cookieSession({ secret: config.cookie_session_secret }))
+app.use(
+  cookieSession({ secret: config.cookie_session_secret, sameSite: 'strict' })
+)
 
 app.use(requestHandlers.login_token_parser)
 app.use(requestHandlers.request_log)

--- a/app/controllers/auth0_sign_in_callback.js
+++ b/app/controllers/auth0_sign_in_callback.js
@@ -34,11 +34,10 @@ const AccessTokenHandler = function (req, res) {
             ? apiRequestBody.auth0_twitter.screenName
             : apiRequestBody.auth0.nickname
 
-          const cookieOptions = { maxAge: 9000000000 }
+          const cookieOptions = { maxAge: 9000000000, sameSite: 'strict' }
           res.cookie('user_id', user.id || userAuthData, cookieOptions)
           res.cookie('refresh_token', refreshToken, cookieOptions)
           res.cookie('login_token', idToken, cookieOptions)
-          res.cookie('access_token', accessToken, cookieOptions)
           res.redirect('/just-signed-in')
         })
         .catch((error) => {

--- a/app/controllers/auth0_sign_in_callback.js
+++ b/app/controllers/auth0_sign_in_callback.js
@@ -34,10 +34,11 @@ const AccessTokenHandler = function (req, res) {
             ? apiRequestBody.auth0_twitter.screenName
             : apiRequestBody.auth0.nickname
 
-          res.cookie('user_id', user.id || userAuthData)
-          res.cookie('refresh_token', refreshToken)
-          res.cookie('login_token', idToken)
-          res.cookie('access_token', accessToken)
+          const cookieOptions = { maxAge: 9000000000 }
+          res.cookie('user_id', user.id || userAuthData, cookieOptions)
+          res.cookie('refresh_token', refreshToken, cookieOptions)
+          res.cookie('login_token', idToken, cookieOptions)
+          res.cookie('access_token', accessToken, cookieOptions)
           res.redirect('/just-signed-in')
         })
         .catch((error) => {

--- a/app/controllers/refresh.js
+++ b/app/controllers/refresh.js
@@ -25,6 +25,9 @@ exports.post = function (req, res) {
         res.status(401).json({ status: 401, msg: 'Unable to refresh token.' })
         return
       }
+
+      const cookieOptions = { maxAge: 9000000000, sameSite: 'strict' }
+      res.cookie('login_token', response.data.id_token, cookieOptions)
       res.status(200).json({ token: response.data.id_token })
     })
     .catch((error) => {

--- a/app/resources/v1/user_session.js
+++ b/app/resources/v1/user_session.js
@@ -7,9 +7,10 @@ exports.delete = async function (req, res) {
   }
 
   try {
-    res.cookie('refresh_token', '')
-    res.cookie('login_token', '')
-    res.cookie('access_token', '')
+    const cookieOptions = { maxAge: 0, sameSite: 'Strict' }
+    res.cookie('refresh_token', '', cookieOptions)
+    res.cookie('login_token', '', cookieOptions)
+    res.cookie('access_token', '', cookieOptions)
     res.status(204).end()
   } catch (err) {
     logger.error(err)

--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -94,7 +94,6 @@ export async function loadSignIn () {
       })
     )
 
-    removeSignInCookies()
     saveSignInDataLocally()
   } else {
     if (window.localStorage[LOCAL_STORAGE_SIGN_IN_ID]) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8379,34 +8379,13 @@
       }
     },
     "cookie-session": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.0.0-rc.1.tgz",
-      "integrity": "sha512-zg80EsLe7S1J4y0XxV7SZ8Fbi90ZZoampuX2bfYDOvJfc//98sSlZC41YDzTTjtVbeU1VlVdBbldXOOyi5xzEw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.4.0.tgz",
+      "integrity": "sha512-0hhwD+BUIwMXQraiZP/J7VP2YFzqo6g4WqZlWHtEHQ22t0MeZZrNBSCxC1zcaLAs8ApT3BzAKizx9gW/AP9vNA==",
       "requires": {
         "cookies": "0.8.0",
-        "debug": "3.2.6",
-        "on-headers": "~1.0.2",
-        "safe-buffer": "5.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-        }
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2"
       }
     },
     "cookie-signature": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "compression": "1.7.4",
     "config": "3.3.1",
     "cookie-parser": "1.4.5",
-    "cookie-session": "2.0.0-rc.1",
+    "cookie-session": "1.4.0",
     "copy-to-clipboard": "3.3.1",
     "core-js": "3.4.0",
     "cors": "2.8.5",


### PR DESCRIPTION
Prevents early session invalidation by correcting implementation of cookies as token storage. 

### Explanation
First, cookies were configured without an expiration date or sameSite policy. In certain browsers, this will cause the time to default to 0 and thus the cookie is wiped immediately. 
Secondly, after sign-in we were removing cookies as legacy behavior. Our existing code puts tokens in `localStorage`, but this is [less than ideal](https://stackoverflow.com/questions/44133536/is-it-safe-to-store-a-jwt-in-localstorage-with-reactjs). We will remove the `localStorage` code in a follow-up, but getting a fix out is more urgent. 


### QA

Firstly, the user should not be logged out when their session ends, it should be long-lived (90 days)

User should check that after login they have cookies with a set expiration and security policy for the app's domain.
<img width="1392" alt="Screen Shot 2020-06-18 at 12 35 51 PM" src="https://user-images.githubusercontent.com/15174372/85053606-63596080-b160-11ea-80b2-bf39a2272f37.png">


Users should also ensure they do NOT see this warning message:
<img width="1438" alt="Screen Shot 2020-06-18 at 12 01 58 PM" src="https://user-images.githubusercontent.com/15174372/85053686-8257f280-b160-11ea-9814-d7b3d9e1aa1e.png">
^ the above was being caused by incorrect configuration of cookies. 
