### PR TITLE
fix: specify where middleware should find token

### DIFF
--- a/assets/scripts/users/authentication.js
+++ b/assets/scripts/users/authentication.js
@@ -300,12 +300,7 @@ export function getAuthToken () {
 }
 
 export function getAuthHeader () {
-  const signInData = getSignInData()
-  if (signInData && signInData.token && signInData.userId) {
-    return `Bearer ${signInData.token}`
-  } else {
-    return ''
-  }
+  return ''
 }
 
 function sendSignOutToServer (quiet) {


### PR DESCRIPTION
🔧 Fixes issue where middleware detected outdated auth from headers instead of reading from cookies. 


### QA

Sign out and sign into streetmix. Check that all API calls include a `login_token` in cookies being sent, and that they do NOT include a `Authorization: Bearer [some-long-token]` in headers. 