### PR TITLE
refactor(buttons): make primary, secondary and tertiary styles official

### DIFF
--- a/assets/scripts/app/ScrollIndicators.scss
+++ b/assets/scripts/app/ScrollIndicators.scss
@@ -14,6 +14,7 @@
     padding: 0 0.2em;
     opacity: 0.25;
     font-size: 80px;
+    font-weight: normal;
     line-height: 1;
     letter-spacing: -0.15em;
     cursor: pointer;
@@ -22,7 +23,6 @@
 
     // Override default button styles
     background-color: transparent !important;
-    border: 0 !important;
 
     &:hover {
       opacity: 0.45;

--- a/assets/scripts/app/WelcomePanel.scss
+++ b/assets/scripts/app/WelcomePanel.scss
@@ -38,7 +38,7 @@ $welcome-panel-box-shadow: $medium-box-shadow;
 
   button {
     margin: 0 0.25em;
-    font-size: 100%;
+    padding: 0.5em 1em;
   }
 
   ul,

--- a/assets/scripts/dialogs/AnalyticsDialog.jsx
+++ b/assets/scripts/dialogs/AnalyticsDialog.jsx
@@ -188,7 +188,7 @@ function AnalyticsDialog (props) {
               </Checkbox>
 
               <br />
-              <button onClick={exportCSV}>
+              <button className="button-primary" onClick={exportCSV}>
                 <FormattedMessage
                   id="dialogs.analytics.export-csv"
                   defaultMessage="Export as CSV"

--- a/assets/scripts/dialogs/Dialog.scss
+++ b/assets/scripts/dialogs/Dialog.scss
@@ -99,26 +99,15 @@ $header-text-colour: $colour-turquoise-700;
     z-index: $z-09-dialog-box;
   }
 
-  button:not(.close),
-  a.button-like {
+  // Button placement
+  button.button-primary,
+  button.button-secondary,
+  button.button-tertiary,
+  a.button-like.button-primary,
+  a.button-like.button-secondary,
+  a.button-like.button-tertiary {
     margin: 0 auto;
-    display: inline-block;
-    padding: 0.75em 2em;
     margin-top: 1em;
-  }
-
-  // New button appearance
-  button:not(.close):not(.dialog-primary-action),
-  a.button-like {
-    margin: 0 auto;
-    display: inline-block;
-    padding: 0.75em 2em;
-    margin-top: 1em;
-
-    // New button appearance
-    background-color: $colour-emerald-400;
-    color: white;
-    font-weight: bold;
   }
 }
 
@@ -158,17 +147,17 @@ button.dialog-primary-action {
   border-top: 1px solid $colour-turquoise-300;
   border-radius: 0;
   background-color: white;
+  font-weight: normal;
   width: 100%;
   text-align: center;
-  color: darken($ui-colour, 30%);
+  color: $colour-turquoise-600;
   min-height: 46px;
 
   /* override .dialog-box button */
-  padding: 1rem 2rem !important;
   margin-top: 0 !important;
 
   &:hover {
     background-color: $colour-turquoise-100;
-    color: darken($ui-colour, 50%);
+    color: $colour-turquoise-700;
   }
 }

--- a/assets/scripts/dialogs/Geotag/LocationPopup.jsx
+++ b/assets/scripts/dialogs/Geotag/LocationPopup.jsx
@@ -26,13 +26,11 @@ const LocationPopup = (props) => {
       closeButton={false}
       closeOnClick={false}
     >
-      <div>
-        {label}
-      </div>
-      {(isEditable) && (
-        (isClearable) ? (
+      <div>{label}</div>
+      {isEditable &&
+        (isClearable ? (
           <div>
-            <button className="geotag-location-button" onClick={handleClear}>
+            <button className="button-tertiary" onClick={handleClear}>
               <FormattedMessage
                 id="dialogs.geotag.clear-location"
                 defaultMessage="Clear location"
@@ -41,15 +39,14 @@ const LocationPopup = (props) => {
           </div>
         ) : (
           <div>
-            <button className="geotag-location-button" onClick={handleConfirm}>
+            <button className="button-primary" onClick={handleConfirm}>
               <FormattedMessage
                 id="dialogs.geotag.confirm-location"
                 defaultMessage="Confirm location"
               />
             </button>
           </div>
-        )
-      )}
+        ))}
     </Popup>
   )
 }

--- a/assets/scripts/dialogs/GeotagDialog.scss
+++ b/assets/scripts/dialogs/GeotagDialog.scss
@@ -47,11 +47,6 @@ $geotag-dialog-background-color: $off-white;
   cursor: pointer;
 }
 
-.geotag-location-button {
-  margin-top: 10px;
-  font-weight: bold;
-}
-
 .geotag-input {
   width: 100%;
   padding: 3px 24px 3px 6px !important;

--- a/assets/scripts/dialogs/NewsletterDialog.scss
+++ b/assets/scripts/dialogs/NewsletterDialog.scss
@@ -16,20 +16,22 @@
 
 /* Hard codes replacement button styles */
 #mc_embed_signup .button {
-  border-top: 1px solid #a9ccdb;
-  border-bottom: 1px solid #a9ccdb;
-  border-radius: 0;
-  background-color: #e6f0f5;
-  color: black;
-  text-align: center;
+  // Match UI button style
+  background-color: $colour-emerald-400;
+  padding: 0.75em 2em;
+  margin-top: 1em;
+  color: white;
+  font-weight: bold;
+
+  // Override styles supplied by mailchimp.css
+  transition: none;
   height: auto;
+  font-size: inherit;
+  line-height: inherit;
 
+  // Match UI button hover style
   &:hover {
-    background-color: mix($ui-colour, white, 70%);
-  }
-
-  &:active {
-    background-color: mix($ui-colour, white, 95%);
+    background-color: mix($colour-emerald-400, $colour-emerald-500, 75%);
   }
 }
 

--- a/assets/scripts/dialogs/SaveAsImageDialog.jsx
+++ b/assets/scripts/dialogs/SaveAsImageDialog.jsx
@@ -295,7 +295,7 @@ class SaveAsImageDialog extends React.Component {
               <div className="save-as-image-download">
                 {!this.state.errorMessage && !this.state.isSaving ? (
                   <a
-                    className="button-like"
+                    className="button-like button-primary"
                     onClick={this.handleClickDownloadImage}
                     // Sets the anchor's `download` attribute so that it saves a meaningful filename
                     // Note that this property is not supported in Safari/iOS
@@ -310,7 +310,7 @@ class SaveAsImageDialog extends React.Component {
                   </a>
                 ) : (
                   // TODO: When saving, show busy cursor and "Please wait"
-                  <button disabled={true}>
+                  <button disabled={true} className="button-primary">
                     <FormattedMessage
                       id="dialogs.save.save-button"
                       defaultMessage="Save to your computer…"

--- a/assets/scripts/dialogs/SignInDialog.jsx
+++ b/assets/scripts/dialogs/SignInDialog.jsx
@@ -255,7 +255,7 @@ export default class SignInDialog extends React.Component {
 
                 <button
                   type="submit"
-                  className="sign-in-button sign-in-email-button"
+                  className="button-primary sign-in-button sign-in-email-button"
                 >
                   <FormattedMessage
                     id="dialogs.sign-in.button.email"
@@ -275,7 +275,7 @@ export default class SignInDialog extends React.Component {
               </div>
 
               <button
-                className="sign-in-button sign-in-social-button sign-in-twitter-button"
+                className="button-tertiary sign-in-button sign-in-social-button sign-in-twitter-button"
                 onClick={this.handleTwitterSignIn}
               >
                 <Icon icon="twitter" />
@@ -286,7 +286,7 @@ export default class SignInDialog extends React.Component {
               </button>
 
               <button
-                className="sign-in-button sign-in-social-button sign-in-google-button"
+                className="button-tertiary sign-in-button sign-in-social-button sign-in-google-button"
                 onClick={this.handleGoogleSignIn}
               >
                 <Icon icon="google" />
@@ -297,7 +297,7 @@ export default class SignInDialog extends React.Component {
               </button>
 
               <button
-                className="sign-in-button sign-in-social-button sign-in-facebook-button"
+                className="button-tertiary sign-in-button sign-in-social-button sign-in-facebook-button"
                 onClick={this.handleFacebookSignIn}
               >
                 <Icon icon="facebook" />

--- a/assets/scripts/dialogs/SignInDialog.scss
+++ b/assets/scripts/dialogs/SignInDialog.scss
@@ -75,16 +75,12 @@
 .sign-in-button {
   position: relative;
   width: 100%;
-  font-weight: 700;
   display: flex !important;
   align-items: center !important;
 }
 
 .sign-in-social-button {
   text-align: left;
-  border: 1px solid $colour-turquoise-400 !important;
-  background-color: transparent !important;
-  color: black !important;
 
   /* Space for icon */
   padding-left: 54px !important;

--- a/assets/scripts/dialogs/__tests__/__snapshots__/SaveAsImageDialog.test.js.snap
+++ b/assets/scripts/dialogs/__tests__/__snapshots__/SaveAsImageDialog.test.js.snap
@@ -118,6 +118,7 @@ exports[`SaveAsImageDialog renders snapshot 1`] = `
             class="save-as-image-download"
           >
             <button
+              class="button-primary"
               disabled=""
             >
               Save to your computer…

--- a/assets/scripts/dialogs/__tests__/__snapshots__/SignInDialog.test.js.snap
+++ b/assets/scripts/dialogs/__tests__/__snapshots__/SignInDialog.test.js.snap
@@ -58,7 +58,7 @@ exports[`SignInDialog renders 1`] = `
               </small>
             </p>
             <button
-              class="sign-in-button sign-in-email-button"
+              class="button-primary sign-in-button sign-in-email-button"
               type="submit"
             >
               Continue with email
@@ -73,7 +73,7 @@ exports[`SignInDialog renders 1`] = `
             </span>
           </div>
           <button
-            class="sign-in-button sign-in-social-button sign-in-twitter-button"
+            class="button-tertiary sign-in-button sign-in-social-button sign-in-twitter-button"
           >
             <svg
               class="svg-inline--fa menu-item-icon fa-twitter"
@@ -81,7 +81,7 @@ exports[`SignInDialog renders 1`] = `
             Continue with Twitter
           </button>
           <button
-            class="sign-in-button sign-in-social-button sign-in-google-button"
+            class="button-tertiary sign-in-button sign-in-social-button sign-in-google-button"
           >
             <img
               alt=""
@@ -91,7 +91,7 @@ exports[`SignInDialog renders 1`] = `
             Continue with Google
           </button>
           <button
-            class="sign-in-button sign-in-social-button sign-in-facebook-button"
+            class="button-tertiary sign-in-button sign-in-social-button sign-in-facebook-button"
           >
             <svg
               class="svg-inline--fa menu-item-icon fa-facebook-square"

--- a/assets/scripts/gallery/Gallery.scss
+++ b/assets/scripts/gallery/Gallery.scss
@@ -51,17 +51,6 @@ body:not(.safari).gallery-visible .street-section-sky {
   button.scrollable {
     margin-top: 45px;
     width: 30px;
-    border: 0;
-    border-radius: $border-radius-medium;
-    background-color: $colour-turquoise-200;
-
-    &:hover {
-      background-color: $colour-turquoise-210;
-    }
-
-    &:active {
-      background-color: $colour-turquoise-220;
-    }
 
     &.scroll-left {
       left: -10px !important;
@@ -139,23 +128,6 @@ body:not(.safari).gallery-visible .street-section-sky {
   top: 50px;
   display: flex;
   flex-direction: row;
-}
-
-.gallery-try-again {
-  margin-left: 10px;
-  // TODO: adopt new button style via inheritance/composition
-  padding: 0.5em 1em;
-  border: 0;
-  border-radius: $border-radius-medium;
-  background-color: $colour-turquoise-200;
-
-  &:hover {
-    background-color: $colour-turquoise-210;
-  }
-
-  &:active {
-    background-color: $colour-turquoise-220;
-  }
 }
 
 .gallery-street-item {
@@ -318,19 +290,6 @@ body:not(.safari).gallery-visible .street-section-sky {
     display: flex !important;
     align-items: center !important;
     justify-content: center;
-  }
-
-  a.button-like,
-  button:not(:disabled) {
-    background-color: $colour-turquoise-200;
-
-    &:hover {
-      background-color: $colour-turquoise-210;
-    }
-
-    &:active {
-      background-color: $colour-turquoise-220;
-    }
   }
 
   [dir="rtl"] & {

--- a/assets/scripts/gallery/GalleryError.jsx
+++ b/assets/scripts/gallery/GalleryError.jsx
@@ -19,7 +19,7 @@ function GalleryError (props) {
           defaultMessage="Failed to load the gallery."
         />
       </p>
-      <button className="gallery-try-again" onClick={handleRetry}>
+      <button onClick={handleRetry}>
         <FormattedMessage id="btn.try-again" defaultMessage="Try again" />
       </button>
     </div>

--- a/assets/scripts/info_bubble/InfoBubble.scss
+++ b/assets/scripts/info_bubble/InfoBubble.scss
@@ -125,6 +125,7 @@ $info-bubble-border-radius: $border-radius;
     button {
       white-space: nowrap;
       position: relative;
+      padding: 0;
 
       .icon {
         opacity: 0.666;
@@ -141,11 +142,8 @@ $info-bubble-border-radius: $border-radius;
 
   .variant-selected,
   .variant-selected:hover {
-    background: darken($ui-colour, 10%);
-    color: black;
+    background: $colour-copper-300 !important;
     opacity: 1;
-    border-top-color: darken($ui-colour, 30%);
-    border-bottom-color: darken($ui-colour, 30%);
 
     .icon {
       // Overrides disabled button opacity

--- a/assets/scripts/menus/MenuBar.scss
+++ b/assets/scripts/menus/MenuBar.scss
@@ -83,7 +83,7 @@ $menu-bar-box-shadow: $light-box-shadow;
     }
   }
 
-  button {
+  button.menu-attached {
     @include tap-highlight-color(transparent);
 
     appearance: none;
@@ -95,6 +95,7 @@ $menu-bar-box-shadow: $light-box-shadow;
     color: inherit;
     cursor: pointer;
     line-height: 24px;
+    padding: 0 0.75em;
 
     &::after {
       content: "▼";
@@ -115,10 +116,6 @@ $menu-bar-box-shadow: $light-box-shadow;
 
     &:active {
       color: $menu-bar-text-color-active;
-    }
-
-    &[disabled] {
-      color: red;
     }
   }
 }

--- a/assets/scripts/menus/SignInButton.jsx
+++ b/assets/scripts/menus/SignInButton.jsx
@@ -9,7 +9,7 @@ SignInButton.propTypes = {
 
 function SignInButton ({ onClick = () => {} }) {
   return (
-    <button className="menu-sign-in" onClick={onClick}>
+    <button className="menu-sign-in button-secondary" onClick={onClick}>
       <FormattedMessage id="menu.item.sign-in" defaultMessage="Sign in" />
     </button>
   )

--- a/assets/scripts/menus/SignInButton.scss
+++ b/assets/scripts/menus/SignInButton.scss
@@ -1,23 +1,7 @@
 @import "../../styles/variables.scss";
 
 .menu-bar .menu-sign-in {
-  background-color: $colour-turquoise-500;
-  border-radius: $border-radius-medium;
   margin-left: 0.1em;
   margin-right: 0.1em;
-  padding: 0.2em 1em;
-  font-weight: bold;
-  color: #fff;
-
-  /* Remove down arrow applied by .menu-bar */
-  &::after {
-    content: "";
-    padding: 0;
-    font-size: 0;
-  }
-
-  &:hover {
-    background-color: $colour-turquoise-400;
-    color: #fff;
-  }
+  padding: 0.5em 1em;
 }

--- a/assets/scripts/menus/__tests__/__snapshots__/MenuBar.test.js.snap
+++ b/assets/scripts/menus/__tests__/__snapshots__/MenuBar.test.js.snap
@@ -80,7 +80,7 @@ exports[`MenuBar renders 1`] = `
       </li>
       <li>
         <button
-          class="menu-sign-in"
+          class="menu-sign-in button-secondary"
         >
           Sign in
         </button>

--- a/assets/scripts/menus/__tests__/__snapshots__/MenusContainer.test.js.snap
+++ b/assets/scripts/menus/__tests__/__snapshots__/MenusContainer.test.js.snap
@@ -80,7 +80,7 @@ exports[`MenusContainer renders 1`] = `
       </li>
       <li>
         <button
-          class="menu-sign-in"
+          class="menu-sign-in button-secondary"
         >
           Sign in
         </button>

--- a/assets/scripts/palette/Palette.scss
+++ b/assets/scripts/palette/Palette.scss
@@ -14,17 +14,6 @@
     margin-top: 10px;
     z-index: $z-04-palette-scroll;
     width: 30px;
-    border: 0;
-    border-radius: $border-radius-medium;
-    background-color: $colour-turquoise-200;
-
-    &:hover {
-      background-color: $colour-turquoise-210;
-    }
-
-    &:active {
-      background-color: $colour-turquoise-220;
-    }
 
     &.scroll-right {
       right: -20px !important;

--- a/assets/scripts/palette/PaletteCommandsLeft.scss
+++ b/assets/scripts/palette/PaletteCommandsLeft.scss
@@ -12,20 +12,10 @@
   button {
     height: $palette-height - 50px;
     width: $palette-height - 50px;
-    border: 0;
-    border-radius: $border-radius-medium;
-    background-color: $colour-turquoise-200;
+    padding: 0;
 
     // Icon style
     font-size: 1em;
-
-    &:hover {
-      background-color: $colour-turquoise-210;
-    }
-
-    &:active {
-      background-color: $colour-turquoise-220;
-    }
   }
 }
 
@@ -62,14 +52,18 @@
 
   .close {
     border: 0;
+    border-radius: 50%;
+    background: transparent;
     height: 16px;
     width: 16px;
     position: absolute;
     padding: 0;
+    top: 3px;
+    right: 3px;
 
     [dir="rtl"] & {
       right: auto;
-      left: 6px;
+      left: 3px;
     }
   }
 

--- a/assets/scripts/palette/PaletteContainer.scss
+++ b/assets/scripts/palette/PaletteContainer.scss
@@ -31,21 +31,7 @@ body.read-only .palette-container {
   button {
     height: $palette-height - 50px;
     width: $palette-height - 50px;
-    border: 0;
-    border-radius: $border-radius-medium;
-    background-color: $colour-turquoise-200;
-
-    &:hover {
-      background-color: $colour-turquoise-210;
-    }
-
-    &:active {
-      background-color: $colour-turquoise-220;
-    }
-
-    &[disabled] {
-      background-color: #e1e1e1;
-    }
+    padding: 0;
   }
 
   // Spacing between buttons

--- a/assets/scripts/ui/CloseButton.scss
+++ b/assets/scripts/ui/CloseButton.scss
@@ -23,6 +23,7 @@ button.close {
 
   // Appearance
   appearance: none;
+  padding: 0;
   border: 0;
   border-radius: 50%;
   color: $close-icon-colour;

--- a/assets/styles/_buttons.scss
+++ b/assets/styles/_buttons.scss
@@ -22,10 +22,10 @@ a.button-like {
   outline: none;
   border: 0;
   border-radius: $border-radius-medium;
-  padding-left: 10px;
-  padding-right: 10px;
-  background-color: mix($ui-colour, white, 50%);
+  padding: 0.75em 2em;
+  background-color: $colour-turquoise-200;
   color: black;
+  font-weight: bold;
   text-align: center;
   text-decoration: none;
 
@@ -34,11 +34,11 @@ a.button-like {
   }
 
   &:hover {
-    background-color: mix($ui-colour, white, 70%);
+    background-color: $colour-turquoise-210;
   }
 
   &:active {
-    background-color: mix($ui-colour, white, 95%);
+    background-color: $colour-turquoise-220;
   }
 
   &[disabled] {
@@ -46,8 +46,41 @@ a.button-like {
     color: #999 !important;
     cursor: auto;
 
+    .svg-inline--fa {
+      color: #999 !important;
+    }
+
     &:hover {
       background-color: desaturate(fade-out($ui-colour, 0.7), 100%) !important;
+    }
+  }
+
+  &.button-primary {
+    background-color: $colour-emerald-400;
+    color: white;
+
+    &:hover {
+      background-color: mix($colour-emerald-400, $colour-emerald-500, 75%);
+    }
+  }
+
+  &.button-secondary {
+    background-color: $colour-turquoise-500;
+    color: white;
+
+    &:hover {
+      background-color: mix($colour-turquoise-500, $colour-turquoise-600, 75%);
+    }
+  }
+
+  &.button-tertiary {
+    border: 1px solid $colour-turquoise-400;
+    background-color: transparent;
+    color: $colour-turquoise-600;
+
+    &:hover {
+      background-color: $colour-turquoise-100;
+      color: $colour-turquoise-700;
     }
   }
 }

--- a/assets/styles/_chrome.scss
+++ b/assets/styles/_chrome.scss
@@ -72,8 +72,6 @@ body.phone #loading {
   button,
   a.button-like {
     margin-top: 1em;
-    padding: 0.5em 1em;
-    font-size: 1em;
   }
 
   button + button {


### PR DESCRIPTION
For a long time, button UI was in a transition state between an older style (borders on top
and bottom, squared corners) to a new style (no borders, round corners, brighter colors
matching the new UI color scheme). Applying the new style to buttons all at once was difficult
because there are other types of buttons (e.g. menu bar items, the close button) that shouldn't
be targeted for change. As a result, buttons in more-recently built / refactored components
got the new button styles first. (This is why the sign in dialog and many dialog boxes had
a green button, even though in other parts of the UI the button remained blue.)

This PR finally standardizes all "default" buttons to use the same consolidated CSS.

By default, buttons will a brighter shade of light blue than the legacy version.
By applying the class `button-primary`, you can get a call-to-action style green button.
By applying the class `button-secondary`, you get a darker blue button, like the sign in button.
By applying the class `button-tertiary`, you get a lower-priority button that only has a border
and a transparent background (the social sign-on options use this).

This unification of styles will make it easier to modify all buttons at once when the UI changes.

For example, all buttons now have a standardized hover state (it darkens slightly). Previously
when buttons had to be updated individually, this behavior was inconsistent or nonexistent.

One other change that happens here is that the infobubble variant buttons have changed to be part
of this system as well. Now, seelected variants will have a highlighted copper background color
instead of being grayed out.