### PR TITLE
fix: correct .prettierrc so it no longer conflicts with linting rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,7 @@
     {
       "files": ["*.js", "*.jsx"],
       "options": {
+        "trailingComma": "none",
         "semi": false,
         "singleQuote": true,
         "arrowParens": "always",


### PR DESCRIPTION
Previously, setting an IDE auto-apply prettier rules on save would cause eslint errors to appear for trailing commas. This fixes the issue so prettier and eslint agree 🤝 