### PR TITLE
Allow items in a randomly selected pool to be weighted

### DIFF
--- a/assets/scripts/segments/__mocks__/people.json
+++ b/assets/scripts/segments/__mocks__/people.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "Ashe",
+    "id": "character-01",
+    "width": 2
+  },
+  {
+    "name": "Bob",
+    "id": "character-02",
+    "width": 2
+  },
+  {
+    "name": "The fast-follower",
+    "id": "character-03",
+    "width": 2,
+    "disallowFirst": true
+  },
+  {
+    "name": "The shy one",
+    "id": "character-04",
+    "width": 2,
+    "disallowFirst": true,
+    "weight": 20
+  },
+  {
+    "name": "The popular one",
+    "id": "character-05",
+    "width": 2,
+    "weight": 100
+  },
+  {
+    "name": "The rare one",
+    "id": "character-06",
+    "width": 2,
+    "weight": 5
+  },
+  {
+    "id": "The flaky one",
+    "width": 2,
+    "weight": 30
+  },
+  {
+    "id": "The thicc one",
+    "width": 3
+  },
+  {
+    "id": "The boisterous one",
+    "width": 3,
+    "weight": 65
+  },
+  {
+    "id": "The regular one",
+    "width": 2
+  }
+]

--- a/assets/scripts/segments/__tests__/__snapshots__/scatter.test.js.snap
+++ b/assets/scripts/segments/__tests__/__snapshots__/scatter.test.js.snap
@@ -28,50 +28,58 @@ Array [
 exports[`scatter objects in segments picks people at dense density 1`] = `
 Array [
   Object {
-    "id": "people-23",
+    "id": "The thicc one",
     "left": 0,
-    "name": "Katie",
     "width": 3,
   },
   Object {
-    "id": "people-28",
+    "id": "The boisterous one",
     "left": 3.7407393094867594,
+    "weight": 65,
     "width": 3,
   },
   Object {
-    "id": "people-21",
+    "id": "The thicc one",
     "left": 6.615210042353208,
-    "width": 1,
+    "width": 3,
   },
   Object {
-    "id": "people-22",
-    "left": 7.860021493652412,
-    "width": 1,
+    "id": "The boisterous one",
+    "left": 9.860021493652411,
+    "weight": 65,
+    "width": 3,
   },
   Object {
-    "id": "people-25",
-    "left": 9.368637363837973,
+    "disallowFirst": true,
+    "id": "character-04",
+    "left": 12.762151044236404,
+    "name": "The shy one",
+    "weight": 20,
     "width": 2,
   },
   Object {
-    "id": "people-12",
-    "left": 11.270766914421966,
+    "id": "The thicc one",
+    "left": 15.475059644902876,
+    "width": 3,
+  },
+  Object {
+    "id": "character-05",
+    "left": 19.110244481261418,
+    "name": "The popular one",
+    "weight": 100,
     "width": 2,
   },
   Object {
-    "id": "people-24",
-    "left": 13.983675515088438,
-    "width": 4,
-  },
-  Object {
-    "id": "people-15",
-    "left": 18.618860351446976,
+    "id": "The regular one",
+    "left": 21.565549615693314,
     "width": 2,
   },
   Object {
-    "id": "people-29",
-    "left": 21.074165485878872,
-    "width": 4,
+    "disallowFirst": true,
+    "id": "character-03",
+    "left": 24.361170221247555,
+    "name": "The fast-follower",
+    "width": 2,
   },
 ]
 `;
@@ -79,34 +87,33 @@ Array [
 exports[`scatter objects in segments picks people at normal density 1`] = `
 Array [
   Object {
-    "id": "people-23",
+    "id": "The thicc one",
     "left": 0,
-    "name": "Katie",
     "width": 3,
   },
   Object {
-    "id": "people-28",
+    "id": "The boisterous one",
     "left": 6.6357976982892,
+    "weight": 65,
     "width": 3,
   },
   Object {
-    "id": "people-21",
+    "id": "The thicc one",
     "left": 10.384033474510698,
-    "width": 1,
+    "width": 3,
   },
   Object {
-    "id": "people-22",
-    "left": 13.36673831217471,
-    "width": 1,
+    "id": "The boisterous one",
+    "left": 15.36673831217471,
+    "weight": 65,
+    "width": 3,
   },
   Object {
-    "id": "people-25",
-    "left": 17.228791212793247,
-    "width": 2,
-  },
-  Object {
-    "id": "people-12",
-    "left": 20.069223048073223,
+    "disallowFirst": true,
+    "id": "character-04",
+    "left": 19.207170147454686,
+    "name": "The shy one",
+    "weight": 20,
     "width": 2,
   },
 ]
@@ -115,20 +122,20 @@ Array [
 exports[`scatter objects in segments picks people at sparse density 1`] = `
 Array [
   Object {
-    "id": "people-23",
+    "id": "The thicc one",
     "left": 0,
-    "name": "Katie",
     "width": 3,
   },
   Object {
-    "id": "people-28",
+    "id": "The boisterous one",
     "left": 12.892968591830677,
+    "weight": 65,
     "width": 3,
   },
   Object {
-    "id": "people-21",
+    "id": "The thicc one",
     "left": 20.973353230628,
-    "width": 1,
+    "width": 3,
   },
 ]
 `;

--- a/assets/scripts/segments/__tests__/__snapshots__/scatter.test.js.snap
+++ b/assets/scripts/segments/__tests__/__snapshots__/scatter.test.js.snap
@@ -28,54 +28,50 @@ Array [
 exports[`scatter objects in segments picks people at dense density 1`] = `
 Array [
   Object {
-    "id": "people-25",
+    "id": "people-23",
     "left": 0,
+    "name": "Katie",
+    "width": 3,
+  },
+  Object {
+    "id": "people-28",
+    "left": 3.7407393094867594,
+    "width": 3,
+  },
+  Object {
+    "id": "people-21",
+    "left": 6.615210042353208,
+    "width": 1,
+  },
+  Object {
+    "id": "people-22",
+    "left": 7.860021493652412,
+    "width": 1,
+  },
+  Object {
+    "id": "people-25",
+    "left": 9.368637363837973,
     "width": 2,
   },
   Object {
-    "disallowFirst": true,
-    "id": "johnny-01",
-    "left": 2.74073930948676,
-    "name": "Johnny",
-    "width": 3,
+    "id": "people-12",
+    "left": 11.270766914421966,
+    "width": 2,
   },
   Object {
     "id": "people-24",
-    "left": 5.615210042353209,
+    "left": 13.983675515088438,
     "width": 4,
   },
   Object {
-    "id": "people-25",
-    "left": 9.860021493652413,
+    "id": "people-15",
+    "left": 18.618860351446976,
     "width": 2,
   },
   Object {
-    "id": "people-27",
-    "left": 12.368637363837975,
-    "width": 2,
-  },
-  Object {
-    "id": "people-13",
-    "left": 14.270766914421968,
-    "width": 2,
-  },
-  Object {
-    "id": "people-26",
-    "left": 16.98367551508844,
-    "width": 3,
-  },
-  Object {
-    "id": "people-16",
-    "left": 20.61886035144698,
-    "name": "Lou",
-    "width": 3,
-  },
-  Object {
-    "disallowFirst": true,
-    "id": "johnny-01",
-    "left": 24.074165485878876,
-    "name": "Johnny",
-    "width": 3,
+    "id": "people-29",
+    "left": 21.074165485878872,
+    "width": 4,
   },
 ]
 `;
@@ -83,35 +79,34 @@ Array [
 exports[`scatter objects in segments picks people at normal density 1`] = `
 Array [
   Object {
-    "id": "people-25",
+    "id": "people-23",
     "left": 0,
-    "width": 2,
-  },
-  Object {
-    "disallowFirst": true,
-    "id": "johnny-01",
-    "left": 5.6357976982892,
-    "name": "Johnny",
+    "name": "Katie",
     "width": 3,
   },
   Object {
-    "id": "people-24",
-    "left": 9.384033474510698,
-    "width": 4,
+    "id": "people-28",
+    "left": 6.6357976982892,
+    "width": 3,
+  },
+  Object {
+    "id": "people-21",
+    "left": 10.384033474510698,
+    "width": 1,
+  },
+  Object {
+    "id": "people-22",
+    "left": 13.36673831217471,
+    "width": 1,
   },
   Object {
     "id": "people-25",
-    "left": 15.36673831217471,
+    "left": 17.228791212793247,
     "width": 2,
   },
   Object {
-    "id": "people-27",
-    "left": 20.228791212793247,
-    "width": 2,
-  },
-  Object {
-    "id": "people-13",
-    "left": 23.069223048073223,
+    "id": "people-12",
+    "left": 20.069223048073223,
     "width": 2,
   },
 ]
@@ -120,21 +115,20 @@ Array [
 exports[`scatter objects in segments picks people at sparse density 1`] = `
 Array [
   Object {
-    "id": "people-25",
+    "id": "people-23",
     "left": 0,
-    "width": 2,
-  },
-  Object {
-    "disallowFirst": true,
-    "id": "johnny-01",
-    "left": 11.892968591830677,
-    "name": "Johnny",
+    "name": "Katie",
     "width": 3,
   },
   Object {
-    "id": "people-24",
-    "left": 19.973353230628,
-    "width": 4,
+    "id": "people-28",
+    "left": 12.892968591830677,
+    "width": 3,
+  },
+  Object {
+    "id": "people-21",
+    "left": 20.973353230628,
+    "width": 1,
   },
 ]
 `;

--- a/assets/scripts/segments/__tests__/scatter.test.js
+++ b/assets/scripts/segments/__tests__/scatter.test.js
@@ -2,18 +2,34 @@
 import { getRandomObjects } from '../scatter'
 import PEOPLE from '../people.json'
 
-// The unit test for `getRandomObjects()` is designed to ensure that it
-// returns the same values as previous behaviour, because we're heavily
-// refactoring how this works, and want to avoid regressions. We will need to
-// continue making sure that we return similar output against future
-// refactoring -- for instance, when transitioning from imperial to metric
-// units.
-
-// However! The output of this function is not intended to be guaranteed
-// consistent across all releases, because it can change for any reason -- for
-// example, just adding more people to people.json will result in different
-// output. As a future improvement, we can either make this test more general,
-// or roll it up into an integration test.
+// The unit test for `getRandomObjects()` is designed so that the expected
+// return values are very precise decimal numbers, on purpose. We want to see
+// the same values on each test, so that refactoring it does not cause new
+// regressions. One example of a large refactoring project that will happen
+// in the future is when we change from using imperial to metric units
+// primarily. We want the actual appearance of streets to remain as stable
+// as possible.
+//
+// However, using these exact numbers can be brittle, because there are
+// certain unavoidable cases where the resulting values will be different.
+// This usually happens when the random number generator gets called with
+// different input, for example, when the number of people in the `people.json`
+// pool have changed (this is data we have not mocked for the test).
+//
+// Another reason is if the random number generator is called in a slightly
+// different order because we have changed the logic. This is an example that
+// requires justification to break the test. Is changing the logic necessary
+// to make a performance improvement, or add a new feature? If so, then this
+// can cause a change in output that we expect, and we should update the test
+// to allow those values to change. But let's say we refactored the code to
+// make use of a new JavaScript language feature, and we do not expect the
+// output to be different. If it were (and tests fail), we can then go back
+// and see whether a mistake was made.
+//
+// (TODO) As a future improvement, we can remove the brittleness of these
+// tests by making it more generic (mocking the input object) or rolling it
+// up into an integration test (one which tests visual output but not the
+// actual mathematical values involved).
 describe('scatter objects in segments', () => {
   it('picks people at normal density', () => {
     const [people, startLeft] = getRandomObjects(
@@ -27,7 +43,7 @@ describe('scatter objects in segments', () => {
     )
 
     expect(people).toMatchSnapshot()
-    expect(startLeft).toEqual(3.7987234759633886)
+    expect(startLeft).toEqual(5.0487234759633886)
   })
 
   it('picks people at sparse density', () => {
@@ -57,7 +73,7 @@ describe('scatter objects in segments', () => {
     )
 
     expect(people).toMatchSnapshot()
-    expect(startLeft).toEqual(3.0462522570605604)
+    expect(startLeft).toEqual(4.046252257060564)
   })
 
   it('picks from a pool of one single string id', () => {

--- a/assets/scripts/segments/__tests__/scatter.test.js
+++ b/assets/scripts/segments/__tests__/scatter.test.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
-import { pickObjectsFromPool } from '../scatter'
+import { getRandomObjects } from '../scatter'
 import PEOPLE from '../people.json'
 
-// The unit test for `pickObjectsFromPool()` is designed to ensure that it
+// The unit test for `getRandomObjects()` is designed to ensure that it
 // returns the same values as previous behaviour, because we're heavily
 // refactoring how this works, and want to avoid regressions. We will need to
 // continue making sure that we return similar output against future
@@ -16,7 +16,7 @@ import PEOPLE from '../people.json'
 // or roll it up into an integration test.
 describe('scatter objects in segments', () => {
   it('picks people at normal density', () => {
-    const [people, startLeft] = pickObjectsFromPool(
+    const [people, startLeft] = getRandomObjects(
       PEOPLE,
       28.66667,
       936877893,
@@ -31,7 +31,7 @@ describe('scatter objects in segments', () => {
   })
 
   it('picks people at sparse density', () => {
-    const [people, startLeft] = pickObjectsFromPool(
+    const [people, startLeft] = getRandomObjects(
       PEOPLE,
       28.66667,
       936877893,
@@ -46,7 +46,7 @@ describe('scatter objects in segments', () => {
   })
 
   it('picks people at dense density', () => {
-    const [people, startLeft] = pickObjectsFromPool(
+    const [people, startLeft] = getRandomObjects(
       PEOPLE,
       28.66667,
       936877893,
@@ -73,7 +73,7 @@ describe('scatter objects in segments', () => {
       }
     ]
 
-    const [objects, startLeft] = pickObjectsFromPool(
+    const [objects, startLeft] = getRandomObjects(
       pool,
       20,
       0,

--- a/assets/scripts/segments/__tests__/scatter.test.js
+++ b/assets/scripts/segments/__tests__/scatter.test.js
@@ -2,6 +2,10 @@
 import { getRandomObjects } from '../scatter'
 import PEOPLE from '../people.json'
 
+// Provide mock people data to prevent changes in production data from
+// breaking the expected values of this test
+jest.mock('../people.json', () => require('../__mocks__/people.json'))
+
 // The unit test for `getRandomObjects()` is designed so that the expected
 // return values are very precise decimal numbers, on purpose. We want to see
 // the same values on each test, so that refactoring it does not cause new
@@ -14,7 +18,8 @@ import PEOPLE from '../people.json'
 // certain unavoidable cases where the resulting values will be different.
 // This usually happens when the random number generator gets called with
 // different input, for example, when the number of people in the `people.json`
-// pool have changed (this is data we have not mocked for the test).
+// pool have changed. We have mocked this data, so changing the mock data
+// is an expected cause for breaking the test and needing this to update.
 //
 // Another reason is if the random number generator is called in a slightly
 // different order because we have changed the logic. This is an example that
@@ -25,11 +30,6 @@ import PEOPLE from '../people.json'
 // make use of a new JavaScript language feature, and we do not expect the
 // output to be different. If it were (and tests fail), we can then go back
 // and see whether a mistake was made.
-//
-// (TODO) As a future improvement, we can remove the brittleness of these
-// tests by making it more generic (mocking the input object) or rolling it
-// up into an integration test (one which tests visual output but not the
-// actual mathematical values involved).
 describe('scatter objects in segments', () => {
   it('picks people at normal density', () => {
     const [people, startLeft] = getRandomObjects(
@@ -43,7 +43,7 @@ describe('scatter objects in segments', () => {
     )
 
     expect(people).toMatchSnapshot()
-    expect(startLeft).toEqual(5.0487234759633886)
+    expect(startLeft).toEqual(5.479749926272657)
   })
 
   it('picks people at sparse density', () => {
@@ -58,7 +58,7 @@ describe('scatter objects in segments', () => {
     )
 
     expect(people).toMatchSnapshot()
-    expect(startLeft).toEqual(4.846658384686)
+    expect(startLeft).toEqual(4.346658384686)
   })
 
   it('picks people at dense density', () => {
@@ -73,7 +73,7 @@ describe('scatter objects in segments', () => {
     )
 
     expect(people).toMatchSnapshot()
-    expect(startLeft).toEqual(4.046252257060564)
+    expect(startLeft).toEqual(2.9027498893762225)
   })
 
   it('picks from a pool of one single string id', () => {

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -564,7 +564,8 @@
                   {
                     "id": "plants--flowers-orange",
                     "width": 4,
-                    "disallowFirst": true
+                    "disallowFirst": true,
+                    "weight": 20
                   },
                   {
                     "id": "plants--flowers-yellow",
@@ -574,12 +575,14 @@
                   {
                     "id": "plants--flowers-white",
                     "width": 4,
-                    "disallowFirst": true
+                    "disallowFirst": true,
+                    "weight": 20
                   },
                   {
                     "id": "plants--flowers-blue",
                     "width": 4,
-                    "disallowFirst": true
+                    "disallowFirst": true,
+                    "weight": 10
                   }
                 ],
                 "minSpacing": -3,

--- a/assets/scripts/segments/people.json
+++ b/assets/scripts/segments/people.json
@@ -132,24 +132,28 @@
     "id": "johnny-01",
     "width": 3,
     "name": "Johnny",
-    "disallowFirst": true
+    "disallowFirst": true,
+    "weight": 10
   },
   {
     "id": "johnny-02",
     "width": 3,
     "name": "Johnny",
-    "disallowFirst": true
+    "disallowFirst": true,
+    "weight": 5
   },
   {
     "id": "junebug-01",
     "width": 3,
     "name": "Junebug",
-    "disallowFirst": true
+    "disallowFirst": true,
+    "weight": 10
   },
   {
     "id": "junebug-02",
     "width": 3,
     "name": "Junebug",
-    "disallowFirst": true
+    "disallowFirst": true,
+    "weight": 5
   }
 ]

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -538,6 +538,7 @@ export function drawSegmentContents (
         dpi
       )
     }
+
     if (graphics.scatter.sprites) {
       drawScatteredSprites(
         graphics.scatter.sprites,


### PR DESCRIPTION
Currently, all items in a pool of entities (people, flowers) have equal weight (that is, equal chance of individually being selected at random). This introduces an optional property of each entity called `weight` which allows the relative rarity to be adjusted. The higher the weight value, the higher the odds it can be picked relative to others. By default, all objects have a default weight of 50. Lower weights (e.g. 10) are rarer; higher weights (e.g. 70) are more common. Currently, this is being done to make some items rarer; no items are given weights above 50 yet.