### PR TITLE
refactor: path definitions include initial slash

### DIFF
--- a/app.js
+++ b/app.js
@@ -216,14 +216,11 @@ app.get('/terms-of-service', (req, res) => res.render('tos'))
 
 app.get('/twitter-sign-in', controllers.twitter_sign_in.get)
 app.get(
-  '/' + config.twitter.oauth_callback_path,
+  config.twitter.oauth_callback_path,
   controllers.twitter_sign_in_callback.get
 )
 // Auth0
-app.get(
-  '/' + config.auth0.callback_path,
-  controllers.auth0_sign_in_callback.get
-)
+app.get(config.auth0.callback_path, controllers.auth0_sign_in_callback.get)
 
 // API routes
 app.use('', apiRoutes)

--- a/app/resources/v1/votes.js
+++ b/app/resources/v1/votes.js
@@ -4,7 +4,7 @@ const { v4: uuidv4 } = require('uuid')
 const logger = require('../../../lib/logger.js')()
 
 const MAX_COMMENT_LENGTH = 280
-const SURVEY_FINISHED = '/survey-finished'
+const SURVEY_FINISHED_PATH = '/survey-finished'
 
 const generateRandomBallotFetch = ({ redirect = false }) => {
   return async function (req, res) {
@@ -118,7 +118,7 @@ const generateRandomBallotFetch = ({ redirect = false }) => {
         if (!ballots || ballots.length === 0) {
           // no ballots remaining
           if (redirect) {
-            return res.redirect(SURVEY_FINISHED)
+            return res.redirect(SURVEY_FINISHED_PATH)
           } else {
             return res.status(204).json({
               status: 204,

--- a/app/resources/v1/votes.js
+++ b/app/resources/v1/votes.js
@@ -4,7 +4,7 @@ const { v4: uuidv4 } = require('uuid')
 const logger = require('../../../lib/logger.js')()
 
 const MAX_COMMENT_LENGTH = 280
-const SURVEY_FINISHED = 'survey-finished'
+const SURVEY_FINISHED = '/survey-finished'
 
 const generateRandomBallotFetch = ({ redirect = false }) => {
   return async function (req, res) {
@@ -118,7 +118,7 @@ const generateRandomBallotFetch = ({ redirect = false }) => {
         if (!ballots || ballots.length === 0) {
           // no ballots remaining
           if (redirect) {
-            return res.redirect(`/${SURVEY_FINISHED}`)
+            return res.redirect(SURVEY_FINISHED)
           } else {
             return res.status(204).json({
               status: 204,

--- a/assets/scripts/app/constants.js
+++ b/assets/scripts/app/constants.js
@@ -13,13 +13,13 @@ export const AUTH0_SIGN_IN_CALLBACK_URL = new URL(
   window.location.origin
 ).href
 
-export const JUST_SIGNED_IN_PATH = 'just-signed-in'
+export const JUST_SIGNED_IN_PATH = '/just-signed-in'
 export const JUST_SIGNED_IN_URL = new URL(
   JUST_SIGNED_IN_PATH,
   window.location.origin
 ).href
 
-export const TWITTER_SIGN_IN_PATH = 'twitter-sign-in'
+export const TWITTER_SIGN_IN_PATH = '/twitter-sign-in'
 export const TWITTER_URL_SIGN_IN_REDIRECT =
   TWITTER_SIGN_IN_PATH +
   '?callbackUri=' +
@@ -28,26 +28,26 @@ export const TWITTER_URL_SIGN_IN_REDIRECT =
   JUST_SIGNED_IN_URL
 
 // Path segments
-export const URL_NEW_STREET = 'new'
-export const URL_NEW_STREET_COPY_LAST = 'copy-last'
-export const URL_GLOBAL_GALLERY = 'gallery'
-export const URL_ERROR = 'error'
-export const URL_NO_USER = '-'
-export const URL_HELP = 'help'
+export const URL_NEW_STREET = '/new'
+export const URL_NEW_STREET_COPY_LAST = '/copy-last'
+export const URL_GLOBAL_GALLERY = '/gallery'
+export const URL_ERROR = '/error'
+export const URL_HELP = '/help'
+export const SURVEY_FINISHED = '/survey-finished'
 
-export const URL_ERROR_ACCESS_DENIED = 'access-denied'
-export const URL_ERROR_NO_ACCESS_TOKEN = 'no-access-token'
-
+// Error fragments that occur after /error/
 export const URL_ERROR_NO_TWITTER_REQUEST_TOKEN = 'no-twitter-request-token'
 export const URL_ERROR_NO_TWITTER_ACCESS_TOKEN = 'no-twitter-access-token'
+export const URL_ERROR_NO_ACCESS_TOKEN = 'no-access-token'
 export const URL_ERROR_AUTHENTICATION_API_PROBLEM = 'authentication-api-problem'
-export const SURVEY_FINISHED = 'survey-finished'
+export const URL_ERROR_ACCESS_DENIED = 'access-denied'
 
-export const URL_EXAMPLE_STREET = 'streetmix/7'
+export const URL_EXAMPLE_STREET = '/streetmix/7'
 
 // Since URLs like “streetmix.net/new” are reserved, but we still want
 // @new to be able to use Streetmix, we prefix any reserved URLs with ~
 export const RESERVED_URLS = [
+  'services',
   TWITTER_SIGN_IN_PATH,
   TWITTER_SIGN_IN_CALLBACK_PATH,
   AUTH0_SIGN_IN_CALLBACK_PATH,
@@ -66,5 +66,3 @@ export const RESERVED_URLS = [
 ]
 
 export const URL_RESERVED_PREFIX = '~'
-
-export const MAX_COMMENT_LENGTH = 280

--- a/assets/scripts/app/constants.js
+++ b/assets/scripts/app/constants.js
@@ -33,7 +33,7 @@ export const URL_NEW_STREET_COPY_LAST = '/copy-last'
 export const URL_GLOBAL_GALLERY = '/gallery'
 export const URL_ERROR = '/error'
 export const URL_HELP = '/help'
-export const SURVEY_FINISHED = '/survey-finished'
+export const URL_SURVEY_FINISHED = '/survey-finished'
 
 // Error fragments that occur after /error/
 export const URL_ERROR_NO_TWITTER_REQUEST_TOKEN = 'no-twitter-request-token'
@@ -57,7 +57,7 @@ export const RESERVED_URLS = [
   URL_HELP,
   URL_GLOBAL_GALLERY,
   URL_ERROR,
-  SURVEY_FINISHED,
+  URL_SURVEY_FINISHED,
   'streets',
   'terms-of-service',
   'privacy-policy',

--- a/assets/scripts/app/errors.js
+++ b/assets/scripts/app/errors.js
@@ -2,9 +2,9 @@ import { hideLoadingScreen } from './load_resources'
 import {
   URL_ERROR_NO_TWITTER_REQUEST_TOKEN,
   URL_ERROR_NO_TWITTER_ACCESS_TOKEN,
+  URL_ERROR_NO_ACCESS_TOKEN,
   URL_ERROR_AUTHENTICATION_API_PROBLEM,
-  URL_ERROR_ACCESS_DENIED,
-  URL_ERROR_NO_ACCESS_TOKEN
+  URL_ERROR_ACCESS_DENIED
 } from './constants'
 import store from '../store'
 import { showError as showErrorAction } from '../store/slices/errors'

--- a/assets/scripts/app/page_url.js
+++ b/assets/scripts/app/page_url.js
@@ -7,7 +7,7 @@ import {
   URL_ERROR,
   URL_GLOBAL_GALLERY,
   URL_RESERVED_PREFIX,
-  SURVEY_FINISHED,
+  URL_SURVEY_FINISHED,
   RESERVED_URLS
 } from './constants'
 import { normalizeSlug } from '../util/helpers'
@@ -62,7 +62,7 @@ export function processUrl () {
     setMode(MODES.GLOBAL_GALLERY)
 
     // Survey finished
-  } else if (pathname === SURVEY_FINISHED) {
+  } else if (pathname === URL_SURVEY_FINISHED) {
     setMode(MODES.SURVEY_FINISHED)
 
     // User gallery

--- a/assets/scripts/app/page_url.js
+++ b/assets/scripts/app/page_url.js
@@ -6,7 +6,6 @@ import {
   JUST_SIGNED_IN_PATH,
   URL_ERROR,
   URL_GLOBAL_GALLERY,
-  URL_NO_USER,
   URL_RESERVED_PREFIX,
   SURVEY_FINISHED,
   RESERVED_URLS
@@ -16,6 +15,9 @@ import store from '../store'
 import { setGalleryUserId } from '../store/slices/gallery'
 import { saveCreatorId, saveStreetId } from '../store/slices/street'
 
+// Used as a placeholder in URLs when the street is by an anonymous user
+export const ANONYMOUS_USER_ID_FRAGMENT = '-'
+
 let errorUrl = ''
 
 export function getErrorUrl () {
@@ -23,69 +25,64 @@ export function getErrorUrl () {
 }
 
 export function processUrl () {
-  var url = window.location.pathname
+  // Get current pathname. The pathname will contain an initial `/` followed
+  // by the path of the URL. The root pathname should always be `/`. It may
+  // be possible for the URL to contain a trailing slash, but we don't want
+  // that, so remove it, if present. This will cause the root pathname to be
+  // an empty string.
+  const pathname = window.location.pathname.replace(/\/+$/, '')
 
-  // Remove heading slash
-  if (!url) {
-    url = '/'
-  }
-  url = url.substr(1)
+  // parts being split, although we really don't need to
+  // filter out empty string parts
+  const urlParts = pathname.split(/\//).filter((x) => x !== '')
 
-  // Remove trailing slashes
-  url = url.replace(/\/+$/, '')
-
-  var urlParts = url.split(/\//)
-
-  if (!url) {
-    // Continue where we left off… or start with a default (demo) street
-
+  // Continue where we left off… or start with a default (demo) street
+  if (pathname === '/' || pathname === '') {
     setMode(MODES.CONTINUE)
-  } else if (urlParts.length === 1 && urlParts[0] === URL_NEW_STREET) {
+
     // New street
-
+  } else if (pathname === URL_NEW_STREET) {
     setMode(MODES.NEW_STREET)
-  } else if (
-    urlParts.length === 1 &&
-    urlParts[0] === URL_NEW_STREET_COPY_LAST
-  ) {
+
     // New street (but start with copying last street)
-
+  } else if (pathname === URL_NEW_STREET_COPY_LAST) {
     setMode(MODES.NEW_STREET_COPY_LAST)
-  } else if (urlParts.length === 1 && urlParts[0] === JUST_SIGNED_IN_PATH) {
+
     // Coming back from a successful sign in
-
+  } else if (pathname === JUST_SIGNED_IN_PATH) {
     setMode(MODES.JUST_SIGNED_IN)
-  } else if (urlParts.length >= 1 && urlParts[0] === URL_ERROR) {
-    // Error
 
+    // Error
+  } else if (pathname.startsWith(URL_ERROR)) {
     setMode(MODES.ERROR)
     errorUrl = urlParts[1]
-  } else if (urlParts.length === 1 && urlParts[0] === URL_GLOBAL_GALLERY) {
+
     // Global gallery
-
+  } else if (pathname === URL_GLOBAL_GALLERY) {
     setMode(MODES.GLOBAL_GALLERY)
-  } else if (urlParts.length === 1 && urlParts[0] === SURVEY_FINISHED) {
+
+    // Survey finished
+  } else if (pathname === SURVEY_FINISHED) {
     setMode(MODES.SURVEY_FINISHED)
-  } else if (urlParts.length === 1 && urlParts[0]) {
+
     // User gallery
-
+  } else if (urlParts.length === 1 && urlParts[0]) {
     store.dispatch(setGalleryUserId(urlParts[0]))
-
     setMode(MODES.USER_GALLERY)
-  } else if (
-    urlParts.length === 2 &&
-    urlParts[0] === URL_NO_USER &&
-    urlParts[1]
-  ) {
+
     // TODO add is integer urlParts[1]
     // Existing street by an anonymous person
-
+  } else if (
+    urlParts.length === 2 &&
+    urlParts[0] === ANONYMOUS_USER_ID_FRAGMENT &&
+    urlParts[1]
+  ) {
     store.dispatch(saveCreatorId(null))
     store.dispatch(saveStreetId(null, urlParts[1]))
-
     setMode(MODES.EXISTING_STREET)
-  } else if (urlParts.length >= 2 && urlParts[0] && urlParts[1]) {
+
     // Existing street by a user person
+  } else if (urlParts.length >= 2 && urlParts[0] && urlParts[1]) {
     let creatorId = urlParts[0]
 
     if (creatorId.charAt(0) === URL_RESERVED_PREFIX) {
@@ -102,6 +99,8 @@ export function processUrl () {
       store.dispatch(saveStreetId(null, urlParts[1]))
       setMode(MODES.EXISTING_STREET)
     }
+
+    // 404: Catch-all
   } else {
     setMode(MODES.NOT_FOUND)
   }
@@ -116,7 +115,7 @@ export function getStreetUrl (street) {
 
     url += street.creatorId
   } else {
-    url += URL_NO_USER
+    url += ANONYMOUS_USER_ID_FRAGMENT
   }
 
   url += '/'

--- a/assets/scripts/app/routing.js
+++ b/assets/scripts/app/routing.js
@@ -17,9 +17,9 @@ export function goHome () {
 
 export function goNewStreet (sameWindow) {
   if (sameWindow) {
-    window.location.replace('/' + URL_NEW_STREET)
+    window.location.replace(URL_NEW_STREET)
   } else {
-    window.location.href = '/' + URL_NEW_STREET
+    window.location.href = URL_NEW_STREET
   }
 }
 

--- a/assets/scripts/gallery/GalleryContents.jsx
+++ b/assets/scripts/gallery/GalleryContents.jsx
@@ -86,7 +86,7 @@ function GalleryContents (props) {
           <div className="gallery-user-buttons">
             <a
               className="button-like gallery-new-street"
-              href={`/${URL_NEW_STREET}`}
+              href={URL_NEW_STREET}
               rel="noopener noreferrer"
               target="_blank"
             >
@@ -98,7 +98,7 @@ function GalleryContents (props) {
             {selectedStreet !== null ? (
               <a
                 className="button-like gallery-copy-last-street"
-                href={`/${URL_NEW_STREET_COPY_LAST}`}
+                href={URL_NEW_STREET_COPY_LAST}
                 rel="noopener noreferrer"
                 target="_blank"
               >

--- a/config/default.js
+++ b/config/default.js
@@ -13,7 +13,7 @@ module.exports = {
     oauth_consumer_key: process.env.TWITTER_OAUTH_CONSUMER_KEY,
     oauth_consumer_secret: process.env.TWITTER_OAUTH_CONSUMER_SECRET,
     oauth_version: '1.0A',
-    oauth_callback_path: 'twitter-sign-in-callback',
+    oauth_callback_path: '/twitter-sign-in-callback',
     oauth_signature_method: 'HMAC-SHA1',
     timeout_ms: 500
   },
@@ -26,7 +26,7 @@ module.exports = {
     audience: 'https://streetmix.auth0.com/api/v2/',
     screen_name_custom_claim: 'https://twitter.com/screen_name',
     management_scope: 'read:users write:users',
-    callback_path: 'sign-in-callback'
+    callback_path: '/sign-in-callback'
   },
   monetization: process.env.WEB_MONETIZATION_PAYMENT_POINTER,
   facebook_app_id: '204327799717656',


### PR DESCRIPTION
This change makes strings for absolute paths more clear by including the initial slash (`/`)
in the string. This also avoids situations where we must manually strip the initial slash
from global variables (e.g. `window.location.pathname`) that include it, and or have to add
the initial slash when routing the browser.

This commit also changes how "url parts" are compared during page load. In theory, a direct
string equality comparison achieves the same thing as splitting the path on the slashes and
comparing individual string fragments, for most paths. The only time we need to split the
path is when we have paths such as `user/1/street-name`.