### PR TITLE
feat: use nanoid to make random seeds

### DIFF
--- a/assets/scripts/segments/SegmentForPalette.jsx
+++ b/assets/scripts/segments/SegmentForPalette.jsx
@@ -32,7 +32,7 @@ SegmentForPalette.propTypes = {
   type: PropTypes.string.isRequired,
   variantString: PropTypes.string.isRequired,
   onPointerOver: PropTypes.func,
-  randSeed: PropTypes.number,
+  randSeed: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   disabled: PropTypes.bool,
   tooltipTarget: PropTypes.object
 }

--- a/assets/scripts/util/random.js
+++ b/assets/scripts/util/random.js
@@ -1,9 +1,6 @@
-const MAX_RAND_SEED = 999999999
+import { nanoid } from 'nanoid'
 
-/**
- * Returns a random integer between 0 and MAX_RAND_SEED. This value should
- * always be greater than 0.
- */
+// Returns a random string for seeding.
 export function generateRandSeed () {
-  return Math.ceil(Math.random() * MAX_RAND_SEED)
+  return nanoid()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17676,6 +17676,11 @@
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "jwt-decode": "2.2.0",
     "leaflet": "1.6.0",
     "lodash": "4.17.19",
+    "nanoid": "3.1.12",
     "newrelic": "6.8.0",
     "oauth": "0.9.15",
     "parcel-bundler": "1.12.4",


### PR DESCRIPTION
See https://github.com/streetmix/streetmix/issues/1857
This doesn't completely remove `randSeed` as a concept from the codebase, but accomplishes what we want the end-user to experience and also ensures that we can handle using a string instead of a number with a smooth transition. This attribute is already being stored on the backend and we can switch over segments to using it by adding `needRandSeed: true` to the segment definitions in `assets/scripts/segments/segment-lookup.json`.
