### PR TITLE
feat: add legacy sign-in button

### DIFF
--- a/assets/scripts/app/routing.js
+++ b/assets/scripts/app/routing.js
@@ -77,6 +77,14 @@ export function goGoogleSignIn () {
   })
 }
 
+export function goPasswordSignIn () {
+  const auth0 = Authenticate()
+  auth0.authorize({
+    redirectUri: AUTH0_SIGN_IN_CALLBACK_URL,
+    responseType: 'code'
+  })
+}
+
 export function goEmailSignIn (email, callback) {
   const auth0 = Authenticate()
   auth0.passwordlessStart(

--- a/assets/scripts/dialogs/SignInButton.js
+++ b/assets/scripts/dialogs/SignInButton.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { goPasswordSignIn } from '../app/routing'
+import { useSelector } from 'react-redux'
+
+function SignInButton () {
+  const locale = useSelector((state) => state.locale.locale)
+  const handleClick = () => goPasswordSignIn(locale)
+
+  return <button onClick={handleClick}>Auth0 Sign-In</button>
+}
+
+export default SignInButton

--- a/assets/scripts/dialogs/SignInDialog.jsx
+++ b/assets/scripts/dialogs/SignInDialog.jsx
@@ -5,6 +5,7 @@ import {
   goEmailSignIn,
   goTwitterSignIn,
   goFacebookSignIn,
+  goPasswordSignIn,
   goGoogleSignIn
 } from '../app/routing'
 import LoadingSpinner from '../ui/LoadingSpinner'
@@ -335,6 +336,7 @@ export default class SignInDialog extends React.Component {
                 />
               </p>
             </footer>
+            <button onClick={goPasswordSignIn}>Auth0 Sign-In</button>
           </div>
         )}
       </Dialog>


### PR DESCRIPTION
<img width="1532" alt="Screen Shot 2020-09-20 at 11 12 12 PM" src="https://user-images.githubusercontent.com/15174372/93730710-d1665700-fb97-11ea-9da1-65923749c86a.png">

⚠️ 
WIP change to allow users to use Auth0 dedicated login page, which includes username/password login. 

✅ i18n with locale passed from streetmix
✅ password reset
✅ new account creation