### PR TITLE
Add unique IDs to each segment in the street (resolves #1857)

### DIFF
--- a/app/api_routes.js
+++ b/app/api_routes.js
@@ -132,13 +132,14 @@ const jwtCheck = require('./authentication')
  *       - width
  *       - variantString
  *     properties:
+ *       id:
+ *         type: string
+ *         format: nanoid
  *       type:
  *         type: string
  *       variantString:
  *         type: string
  *       width:
- *         type: integer
- *       randSeed:
  *         type: integer
  *   StreetData:
  *     type: object

--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -155,13 +155,14 @@ export class StreetEditable extends React.Component {
 
   renderStreetSegments = () => {
     const { segments, units, immediateRemoval } = this.props.street
+    const streetId = this.props.street.id
 
     return segments.map((segment, i) => {
       const segmentPos = this.calculateSegmentPos(i)
 
       const segmentEl = (
         <CSSTransition
-          key={segment.id}
+          key={`${streetId}.${segment.id}`}
           timeout={250}
           classNames="switching-away"
           exit={!immediateRemoval}
@@ -169,7 +170,6 @@ export class StreetEditable extends React.Component {
           unmountOnExit={true}
         >
           <Segment
-            key={segment.id}
             dataNo={i}
             segment={{ ...segment }}
             actualWidth={segment.width}

--- a/assets/scripts/app/__tests__/StreetEditable.test.js
+++ b/assets/scripts/app/__tests__/StreetEditable.test.js
@@ -29,7 +29,7 @@ describe('StreetEditable', () => {
   const updatePerspective = () => {}
   const type = 'streetcar'
   const variantString = 'inbound|regular'
-  const segment = { variantString, id: '1', width: 400, randSeed: 1, type }
+  const segment = { variantString, id: '1', width: 400, type }
 
   beforeEach(() => {
     const variant = SEGMENT_INFO[type].details[variantString]

--- a/assets/scripts/app/__tests__/WelcomePanel.test.js
+++ b/assets/scripts/app/__tests__/WelcomePanel.test.js
@@ -40,7 +40,7 @@ describe('WelcomePanel', () => {
     const originalStreetId = '2'
     const type = 'streetcar'
     const variantString = 'inbound|regular'
-    const segment = { variantString, id: '1', width: 400, randSeed: 1, type }
+    const segment = { variantString, id: '1', width: 400, type }
     const street = {
       id: '3',
       namespaceId: '4',

--- a/assets/scripts/info_bubble/__tests__/WidthControl.test.js
+++ b/assets/scripts/info_bubble/__tests__/WidthControl.test.js
@@ -17,8 +17,7 @@ describe('WidthControl', () => {
       variantString: 'inbound|regular',
       segmentType: 'streetcar',
       id: '1',
-      width: 200,
-      randSeed: 1
+      width: 200
     }
   })
 

--- a/assets/scripts/segments/README.md
+++ b/assets/scripts/segments/README.md
@@ -1,73 +1,54 @@
-Segment info
-------------
+## Segment info
 
-Each segment is an object. It is named with a string, e.g. 'parklet'
-that Streetmix uses internally to refer to the segment. Variants are
-sub-types of a segment, also named with strings. New segments and
-variants can generally be created without much hassle. However,
-once created (and running on the production server), modifying
-the names of segments and variants means you would need to
-update `streets/data_model.js` to make sure that existing streets
-will migrate its schemas to the latest versions, otherwise
-Streetmix will break during loading - it will try to read variants
-and segments that don't exist.
+Each segment is an object. It is named with a string, e.g. 'parklet' that Streetmix uses internally to refer to the segment. Variants are sub-types of a segment, also named with strings. New segments and variants can generally be created without much hassle. However, once created (and running on the production server), modifying the names of segments and variants means you would need to update `streets/data_model.js` to make sure that existing streets will migrate its schemas to the latest versions, otherwise Streetmix will break during loading - it will try to read variants and segments that don't exist.
 
 How to fill in the data for a segment:
 
-property        | type         | required?  | description
-----------------|--------------|------------|----------------------------------
-`name`          | *String*     | required   | Display name of a segment. Always use sentence case. 'Parking lot', not 'Parking Lot'
-`owner`         | *String*     | optional   | See `SegmentTypes` constant variable container. Segments without an owner or type should default to `SegmentTypes.NONE`.
-`zIndex`        | *Integer*    | required   | Layering priority. Higher numbers will always display overlapping those with lower numbers. If zIndex is equal, DOM order will determine what is overlapping something else.
-`defaultWidth`  | *Number*     | required   | Default width in feet. Decimal numbers are allowed.
-`needRandSeed`  | *Boolean*    | optional   | Default value: `false`. Set as true if the segment needs a random number generator. For instance sidewalk pedestrians are randomly generated each time.
-`variants`      | Array of *strings* | required | Sub-types of the segment, e.g. 'orientation' and 'color'. If there are no variants, use an array of a single empty string, `['']`.
-`enableWithFlag`| String       | optional   | Default value: none. If set, the segment is hidden from users unless the its corresponding flag is set to `true`. These segments may not be ready for production or are only enabled under certain conditions.
-`description`   | Object       | optional   | If present, a "learn more" feature is added to the segment's info box. For more info see below.
-`details`       | Object       | required   | Details of every variant of the segment. Each variant is named with a string. For segments that have multiple variants, separate each variant with the variant separator '|' (pipe)
+| property | type | required? | description |
+| --- | --- | --- | --- |
+| `name` | _String_ | required | Display name of a segment. Always use sentence case. 'Parking lot', not 'Parking Lot' |
+| `owner` | _String_ | optional | See `SegmentTypes` constant variable container. Segments without an owner or type should default to `SegmentTypes.NONE`. |
+| `zIndex` | _Integer_ | required | Layering priority. Higher numbers will always display overlapping those with lower numbers. If zIndex is equal, DOM order will determine what is overlapping something else. |
+| `defaultWidth` | _Number_ | required | Default width in feet. Decimal numbers are allowed. |
+| `variants` | Array of _strings_ | required | Sub-types of the segment, e.g. 'orientation' and 'color'. If there are no variants, use an array of a single empty string, `['']`. |
+| `enableWithFlag` | String | optional | Default value: none. If set, the segment is hidden from users unless the its corresponding flag is set to `true`. These segments may not be ready for production or are only enabled under certain conditions. |
+| `description` | Object | optional | If present, a "learn more" feature is added to the segment's info box. For more info see below. |
+| `details` | Object | required | Details of every variant of the segment. Each variant is named with a string. For segments that have multiple variants, separate each variant with the variant separator ' | ' (pipe) |
 
 ### Settings for description
 
-property        | type         | required?  | description
-----------------|--------------|------------|----------------------------------
-`prompt`        | String       | required   | The text on the "learn more" button, e.g. 'Learn more about parklets'. There's no magic processing on it, you have to write 'Learn more about' each time.
-`image`         | String       | required   | Filename for an image. The file is assumed to be located in /public/images/info-bubble-examples
-`imageCaption`  | String       | optional   | Caption text / credits for the image.
-`lede`          | String       | optional   | A brief statement about the segment that will be displayed in a larger font size.
-`text`          | Array of *strings* | required | Each string in the array will be wrapped in a `<p>` tag. Inline HTML is allowed, for links, emphasis, etc.
+| property | type | required? | description |
+| --- | --- | --- | --- |
+| `prompt` | String | required | The text on the "learn more" button, e.g. 'Learn more about parklets'. There's no magic processing on it, you have to write 'Learn more about' each time. |
+| `image` | String | required | Filename for an image. The file is assumed to be located in /public/images/info-bubble-examples |
+| `imageCaption` | String | optional | Caption text / credits for the image. |
+| `lede` | String | optional | A brief statement about the segment that will be displayed in a larger font size. |
+| `text` | Array of _strings_ | required | Each string in the array will be wrapped in a `<p>` tag. Inline HTML is allowed, for links, emphasis, etc. |
 
 ### Settings for variant details
 
-property        | type         | required?  | description
-----------------|--------------|------------|----------------------------------
-`name`          | String       | optional   | If set, this overrides the display name of the segment. Always use sentence case.
-`minWidth`      | Number       | optional   | Minimum width for this variant in feet. If set, Streetmix throw up a warning if a user makes this segment go below this width, but doesn't prevent a user from doing so.
-`maxWidth`      | Number       | optional   | Maximum width for this variant in feet.
-`description`   | Object       | optional   | If present, a "learn more" feature is added to the segment's info box. This is identical to the description object on the parent segment, but it allows the variant to have its own description which will override the parent segment's description. You can also make a variant have a description even if the parent segment does not. Note that for each variant that has the same description you will have to duplicate this description object across multiple variants right now.
-`graphics`      | Object       | required   | Defines which sprites are needed to draw the segment
+| property | type | required? | description |
+| --- | --- | --- | --- |
+| `name` | String | optional | If set, this overrides the display name of the segment. Always use sentence case. |
+| `minWidth` | Number | optional | Minimum width for this variant in feet. If set, Streetmix throw up a warning if a user makes this segment go below this width, but doesn't prevent a user from doing so. |
+| `maxWidth` | Number | optional | Maximum width for this variant in feet. |
+| `description` | Object | optional | If present, a "learn more" feature is added to the segment's info box. This is identical to the description object on the parent segment, but it allows the variant to have its own description which will override the parent segment's description. You can also make a variant have a description even if the parent segment does not. Note that for each variant that has the same description you will have to duplicate this description object across multiple variants right now. |
+| `graphics` | Object | required | Defines which sprites are needed to draw the segment |
 
 ## Graphics settings
 
-Each graphics object has sub-objects whose key names are how they are intended
-to display inside of the segment. There are four ways to display something:
+Each graphics object has sub-objects whose key names are how they are intended to display inside of the segment. There are four ways to display something:
 
-property    | description
-------------|------------------------------------------------------------
-`center`    | The sprite is centered inside the segment.
-`repeat`    | The sprite repeats horizontally across the segment.
-`left`      | The sprite is aligned to the left side of the segment.
-`right`     | The sprite is aligned to the right side of the segment.
+| property | description                                             |
+| -------- | ------------------------------------------------------- |
+| `center` | The sprite is centered inside the segment.              |
+| `repeat` | The sprite repeats horizontally across the segment.     |
+| `left`   | The sprite is aligned to the left side of the segment.  |
+| `right`  | The sprite is aligned to the right side of the segment. |
 
-Any combination of these can be applied at once, but there should always be
-at least one sprite. All graphic elements of a segment are defined here, and
-that includes not just the primary graphic element itself (like a car or a tree)
-but also the surface it's on (whether asphalt or sidewalk), and any road
-markings.
+Any combination of these can be applied at once, but there should always be at least one sprite. All graphic elements of a segment are defined here, and that includes not just the primary graphic element itself (like a car or a tree) but also the surface it's on (whether asphalt or sidewalk), and any road markings.
 
-A display type is usually a string or an array of strings referring to at least
-one sprite definition, but in place of a string id, it can also be an object with
-`id` as a property and any number of other properties, which will override
-the corresponding property on the sprite definition.
+A display type is usually a string or an array of strings referring to at least one sprite definition, but in place of a string id, it can also be an object with `id` as a property and any number of other properties, which will override the corresponding property on the sprite definition.
 
 e.g. for one centered sprite
 
@@ -91,19 +72,14 @@ for two (or more) centered sprites
 
 These are the properties of each graphic display type.
 
-This section is a work in progress as we reverse engineer from what
-actually built (but did not ever document anywhere)
+This section is a work in progress as we reverse engineer from what actually built (but did not ever document anywhere)
 
-One thing to keep in mind that on our tilesheets, the scale
-is 24 pixels equals one foot. Some measurement numbers are in
-feet (e.g. '3', meaning 3 feet) will be translated to pixels (so 96 pixels)
-Decimal values are acceptable.
+One thing to keep in mind that on our tilesheets, the scale is 24 pixels equals one foot. Some measurement numbers are in feet (e.g. '3', meaning 3 feet) will be translated to pixels (so 96 pixels) Decimal values are acceptable.
 
-0, 0 (origin) of the tilesheet and of the sprite are the UPPER LEFT corner
-All distances are measured from this origin point.
+0, 0 (origin) of the tilesheet and of the sprite are the UPPER LEFT corner All distances are measured from this origin point.
 
-property        | type         | required?  | description
-----------------|--------------|------------|----------------------------------
-`id`            | String       | required   | Refers to an SVG sprite
-`offsetX`       | Number       | optional   | Units: pixels (24 pixels = 1 foot). Horizontal position to offset the sprite from the attachment spot. The 0 position depends on whether the sprite is attached to the left/right or center of segment.
-`offsetY`       | Number       | optional   | Units: 1 = 24 pixels (1 feet)). Vertical position to offset the sprite. The attachment point is something like 10 feet above ground. A positive value pushes the sprite downward.
+| property | type | required? | description |
+| --- | --- | --- | --- |
+| `id` | String | required | Refers to an SVG sprite |
+| `offsetX` | Number | optional | Units: pixels (24 pixels = 1 foot). Horizontal position to offset the sprite from the attachment spot. The 0 position depends on whether the sprite is attached to the left/right or center of segment. |
+| `offsetY` | Number | optional | Units: 1 = 24 pixels (1 feet)). Vertical position to offset the sprite. The attachment point is something like 10 feet above ground. A positive value pushes the sprite downward. |

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -189,8 +189,9 @@ export class Segment extends React.Component {
     const isOldVariant = variantType === 'old'
     const { segment, connectDragSource, connectDropTarget } = this.props
 
-    // uses the segment UUID as seed if a randseed isn't available
-    const randSeed = segment.randSeed ?? segment.id
+    // The segment ID is a string that uniquely identifies the segment
+    // and can be used as a consistent and reliable seed for a PRNG
+    const randSeed = segment.id
 
     return connectDragSource(
       connectDropTarget(
@@ -402,9 +403,7 @@ function mapStateToProps (state) {
     locale: state.locale.locale,
     descriptionVisible: state.infoBubble.descriptionVisible,
     activeSegment:
-      typeof state.ui.activeSegment === 'number'
-        ? state.ui.activeSegment
-        : null
+      typeof state.ui.activeSegment === 'number' ? state.ui.activeSegment : null
   }
 }
 

--- a/assets/scripts/segments/SegmentForPalette.jsx
+++ b/assets/scripts/segments/SegmentForPalette.jsx
@@ -32,7 +32,7 @@ SegmentForPalette.propTypes = {
   type: PropTypes.string.isRequired,
   variantString: PropTypes.string.isRequired,
   onPointerOver: PropTypes.func,
-  randSeed: PropTypes.number,
+  randSeed: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   disabled: PropTypes.bool,
   tooltipTarget: PropTypes.object
 }

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -5,7 +5,6 @@ import { infoBubble } from '../info_bubble/info_bubble'
 import { app } from '../preinit/app_settings'
 import { setIgnoreStreetChanges } from '../streets/data_model'
 import { getElAbsolutePos } from '../util/helpers'
-import { generateRandSeed } from '../util/random'
 import { SegmentTypes, getSegmentInfo, getSegmentVariantInfo } from './info'
 import {
   RESIZE_TYPE_INITIAL,
@@ -435,13 +434,12 @@ export const segmentSource = {
     store.dispatch(setDraggingType(DRAGGING_TYPE_MOVE))
 
     return {
+      id: props.segment.id,
       dataNo: props.dataNo,
       variantString: props.segment.variantString,
       type: props.segment.type,
       label: props.segment.label,
-      randSeed: props.segment.randSeed,
-      actualWidth: props.segment.width,
-      id: props.segment.id
+      actualWidth: props.segment.width
     }
   },
 
@@ -483,7 +481,6 @@ export const paletteSegmentSource = {
     return {
       variantString: Object.keys(segmentInfo.details).shift(),
       type: props.type,
-      randSeed: segmentInfo.needRandSeed && generateRandSeed(),
       actualWidth: segmentInfo.defaultWidth
     }
   },
@@ -654,12 +651,11 @@ function handleSegmentCanvasDrop (draggedItem, type) {
   }
 
   const newSegment = {
+    id: draggedItem.id ?? nanoid(),
     variantString: draggedItem.variantString,
     width: draggedItem.actualWidth,
     type: draggedItem.type,
-    label: draggedItem.label,
-    randSeed: draggedItem.randSeed,
-    id: draggedItem.id ?? nanoid()
+    label: draggedItem.label
   }
 
   newSegment.variant =

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
+import { nanoid } from 'nanoid'
 import { trackEvent } from '../app/event_tracking'
 import { loseAnyFocus } from '../util/focus'
 import { infoBubble } from '../info_bubble/info_bubble'
@@ -659,7 +659,7 @@ function handleSegmentCanvasDrop (draggedItem, type) {
     type: draggedItem.type,
     label: draggedItem.label,
     randSeed: draggedItem.randSeed,
-    id: draggedItem.id ?? uuidv4()
+    id: draggedItem.id ?? nanoid()
   }
 
   newSegment.variant =

--- a/assets/scripts/segments/info.json
+++ b/assets/scripts/segments/info.json
@@ -5,7 +5,6 @@
     "owner": "PEDESTRIAN",
     "zIndex": 30,
     "defaultWidth": 6,
-    "needRandSeed": true,
     "variants": ["sidewalk-density"],
     "details": {
       "dense": {

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -5,7 +5,6 @@
     "owner": "PEDESTRIAN",
     "zIndex": 30,
     "defaultWidth": 6,
-    "needRandSeed": true,
     "rules": {
       "minWidth": 6
     },
@@ -2868,7 +2867,6 @@
     "owner": "CAR",
     "zIndex": 14,
     "defaultWidth": 10,
-    "needRandSeed": true,
     "rules": {
       "minWidth": 8,
       "maxWidth": 11.9

--- a/assets/scripts/store/__tests__/street.integration.test.js
+++ b/assets/scripts/store/__tests__/street.integration.test.js
@@ -130,7 +130,7 @@ describe('street integration test', () => {
     let apiMock
     const type = 'streetcar'
     const variantString = 'inbound|regular'
-    const segment = { variantString, id: '1', width: 400, randSeed: 1, type }
+    const segment = { variantString, id: '1', width: 400, type }
     const street = {
       segments: [segment],
       width: 100

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -1,4 +1,3 @@
-import { nanoid } from 'nanoid'
 import { cloneDeep } from 'lodash'
 import {
   RESIZE_TYPE_INCREMENT,
@@ -122,7 +121,6 @@ const createStreetFromResponse = (response) => {
   street.location = response.data.street.location || null
   street.editCount = response.data.street.editCount || 0
   street.segments = street.segments.map((segment) => {
-    segment.id = nanoid()
     segment.warnings = []
     segment.variant = getVariantArray(segment.type, segment.variantString)
     return segment

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
+import { nanoid } from 'nanoid'
 import { cloneDeep } from 'lodash'
 import {
   RESIZE_TYPE_INCREMENT,
@@ -122,7 +122,7 @@ const createStreetFromResponse = (response) => {
   street.location = response.data.street.location || null
   street.editCount = response.data.street.editCount || 0
   street.segments = street.segments.map((segment) => {
-    segment.id = uuidv4()
+    segment.id = nanoid()
     segment.warnings = []
     segment.variant = getVariantArray(segment.type, segment.variantString)
     return segment

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid'
+import { nanoid } from 'nanoid'
 import cloneDeep from 'lodash/cloneDeep'
 import { DEFAULT_SEGMENTS } from '../segments/default'
 import { getSegmentInfo } from '../segments/info'
@@ -307,7 +307,7 @@ export function updateToLatestSchemaVersion (street) {
 
     // Add uuids to segments
     if (!segment.id) {
-      segment.id = uuidv4()
+      segment.id = nanoid()
     }
 
     return segment
@@ -416,7 +416,7 @@ function fillDefaultSegments (units) {
 
   for (const i in DEFAULT_SEGMENTS[leftHandTraffic]) {
     const segment = cloneDeep(DEFAULT_SEGMENTS[leftHandTraffic][i])
-    segment.id = uuidv4()
+    segment.id = nanoid()
     segment.warnings = []
     segment.variantString = getVariantString(segment.variant)
     segment.width = normalizeSegmentWidth(

--- a/assets/scripts/streets/thumbnail.js
+++ b/assets/scripts/streets/thumbnail.js
@@ -46,10 +46,7 @@ function drawWatermark (ctx, dpi, invert) {
     : images.get('/images/wordmark_black.svg')
 
   // Separate string so that we can render a wordmark with an image
-  const strings = text
-    .replace(/{/g, '||{{')
-    .replace(/}/g, '}}||')
-    .split('||')
+  const strings = text.replace(/{/g, '||{{').replace(/}/g, '}}||').split('||')
 
   // Set text render options
   ctx.textAlign = 'right'
@@ -449,6 +446,7 @@ export function drawStreetThumbnail (
           segment.variantString
         )
         const dimensions = getVariantInfoDimensions(variantInfo, segment.width)
+        const randSeed = segment.id
 
         drawSegmentContents(
           ctx,
@@ -457,7 +455,7 @@ export function drawStreetThumbnail (
           segment.width,
           offsetLeft + dimensions.left * TILE_SIZE * multiplier,
           groundLevel,
-          segment.randSeed,
+          randSeed,
           multiplier,
           dpi
         )

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -394,7 +394,7 @@ export function unpackServerStreetData (
 
 export function packServerStreetData () {
   var data = {}
-  data.street = trimStreetData(store.getState().street, false)
+  data.street = trimStreetData(store.getState().street)
 
   // Those go above data in the structure, so they need to be cleared here
   delete data.street.name

--- a/assets/scripts/util/random.js
+++ b/assets/scripts/util/random.js
@@ -1,9 +1,6 @@
-const MAX_RAND_SEED = 999999999
+import { nanoid } from 'nanoid'
 
-/**
- * Returns a random integer between 0 and MAX_RAND_SEED. This value should
- * always be greater than 0.
- */
+// Returns a random string for seeding.
 export function generateRandSeed () {
-  return Math.ceil(Math.random() * MAX_RAND_SEED)
+  return nanoid()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17676,6 +17676,11 @@
       "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "jwt-decode": "2.2.0",
     "leaflet": "1.6.0",
     "lodash": "4.17.19",
+    "nanoid": "3.1.12",
     "newrelic": "6.8.0",
     "oauth": "0.9.15",
     "parcel-bundler": "1.12.4",


### PR DESCRIPTION
Resolves #1857.

Summary of changes:

- All street segments are now given a persistent unique ID (generated by [nanoid](https://npmjs.com/package/nanoid)) when they are created. The ID is stored in the database. This differs from previous implementation:
  - Previously, IDs were only generated client-side and then discarded at the end of a session. They were not persistent.
  - Previously, IDs were generated with the `uuid` library. `nanoid` is used because it's smaller, faster, and strings take up less space in the database than uuids.
- Because unique IDs persist and are random, it replaces the concept of `randSeed` for segments. All segments now have a unique value to generate randomness. Random seed requirements no longer need to be specified on a per-segment-type basis in segment definition.
- `generateRandSeed()` implementation also now uses `nanoid` internally rather than rely on `Math.random()`.