### PR TITLE
feat: add preview BRT segments

### DIFF
--- a/app/data/flags.json
+++ b/app/data/flags.json
@@ -65,6 +65,10 @@
     "label": "Segment — autonomous vehicles",
     "defaultValue": false
   },
+  "SEGMENT_BRT": {
+    "label": "Segment — BRT",
+    "defaultValue": false
+  },
   "SEGMENT_CAFE_SEATING": {
     "label": "Segment — café seating",
     "defaultValue": false

--- a/app/data/user_roles.json
+++ b/app/data/user_roles.json
@@ -28,6 +28,7 @@
     "flags": {
       "ENVIRONMENT_EDITOR": true,
       "LOCALES_LEVEL_1": true,
+      "SEGMENT_BRT": true,
       "SEGMENT_UTILITIES": true,
       "CUSTOM_SEGMENT_LABELS": true
     }

--- a/assets/images/icons/orientation-center.svg
+++ b/assets/images/icons/orientation-center.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 48 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g>
+        <rect x="2" y="5" width="6" height="38"/>
+        <rect x="40" y="5" width="6" height="38"/>
+        <path d="M38,24.007L25.985,34.289L25.985,13.714L38,24.007Z" style="fill-rule:nonzero;"/>
+        <path d="M21.985,13.739L21.985,34.263L10,24.007L21.985,13.739Z" style="fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/assets/images/illustrations/transit/brt-bus-inbound.svg
+++ b/assets/images/illustrations/transit/brt-bus-inbound.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 288 312" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="brt-bus-inbound" transform="matrix(1,0,0,1,-34.2,-2.6)">
+        <path d="M62.7,144.2L50.2,139.9L50.2,76.2L62.7,72L62.7,144.2Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M62.7,77.6L72.9,77L73,101.8L75.9,102.8L75.2,72L62.7,72L62.7,77.6Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M105.1,314.6L130.3,260.4L109.7,240.4" style="fill:rgb(43,43,42);fill-rule:nonzero;"/>
+        <path d="M77,240.4L83.1,314.6L105.1,314.6L109.7,240.4L77,240.4Z" style="fill:rgb(92,95,96);fill-rule:nonzero;"/>
+        <path d="M248.6,314.6L223.4,260.4L244,240.4" style="fill:rgb(43,43,42);fill-rule:nonzero;"/>
+        <path d="M276.7,240.4L270.6,314.6L248.6,314.6L244,240.4L276.7,240.4Z" style="fill:rgb(92,95,96);fill-rule:nonzero;"/>
+        <path d="M279.9,45.2L270.7,31.7L83,31.7L73.8,45.2L68.5,264.3L78.2,292.6L275.6,292.6L285.3,264.3L279.9,45.2Z" style="fill:rgb(249,187,36);fill-rule:nonzero;"/>
+        <path d="M116.3,264.3L111.5,278.5L90.6,278.5L85.8,264.3L116.3,264.3Z" style="fill:white;fill-rule:nonzero;"/>
+        <path d="M268,264.3L263.2,278.5L242.3,278.5L237.4,264.3L268,264.3Z" style="fill:white;fill-rule:nonzero;"/>
+        <path d="M273.8,41L267.4,31.7L86.3,31.7L79.9,41L79,68.3L274.7,68.3L273.8,41Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M273.9,45L79.8,45L79,68.3L274.7,68.3L273.9,45Z" style="fill:rgb(36,35,56);fill-rule:nonzero;"/>
+        <path d="M279.1,230.3L271.1,253.4L82.6,253.4L74.7,230.3L74.7,228L79,68.3L274.7,68.3L279,228L279.1,230.3Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M278.4,210.9L257.6,222.1L96.1,222.1L75.2,210.9L79,68.3L274.7,68.3L278.4,210.9Z" style="fill:rgb(73,74,114);fill-rule:nonzero;"/>
+        <path d="M288.3,186.7L300.8,190.9L300.8,217.5L288.3,221.8L288.3,186.7Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M284.4,234.8L288.3,232.4L288.3,221.8L293.1,220.2L290.9,233.5L284.6,240.4L284.4,234.8Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <g transform="matrix(1,0,0,1,34.2,2.6)">
+            <path d="M59.657,61.648L59.551,46.3L62.695,46.3L62.695,58.605L67.8,58.628L67.8,61.648L59.657,61.648Z" style="fill:rgb(249,187,36);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1.00003,0,0,1.00003,-620.794,-591.711)">
+            <path d="M726.207,640.692L726.235,648.963L734.374,649.069L734.401,655.94L737.439,655.913L737.438,640.717L734.295,640.717L734.27,646.004L729.142,646.004L729.142,640.717L726.207,640.692Z" style="fill:rgb(249,187,36);fill-rule:nonzero;"/>
+        </g>
+        <path d="M98.8,31.7L100.8,25.9L252.9,25.9L254.9,31.7L98.8,31.7Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+        <path d="M164.9,25.9L166.9,20.1L186.8,20.1L188.8,25.9L164.9,25.9Z" style="fill:rgb(53,45,39);fill-rule:nonzero;"/>
+        <g>
+            <g>
+                <g>
+                    <clipPath id="_clip1">
+                        <path d="M86.3,31.7L79.9,41L74.7,230.5L82.5,253.3L271.1,253.4L279.1,230.3L273.8,41L267.4,31.7L86.3,31.7Z"/>
+                    </clipPath>
+                    <g clip-path="url(#_clip1)">
+                        <g transform="matrix(0.7071,-0.7071,0.7071,0.7071,-55.8734,206.984)">
+                            <rect x="50.1" y="125.8" width="343.6" height="90.3" style="fill:white;fill-opacity:0.1;"/>
+                        </g>
+                        <g transform="matrix(0.7071,-0.7071,0.7071,0.7071,-59.1152,246.566)">
+                            <rect x="96.3" y="190.4" width="343.6" height="8.5" style="fill:white;fill-opacity:0.2;"/>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/images/illustrations/transit/brt-bus-outbound.svg
+++ b/assets/images/illustrations/transit/brt-bus-outbound.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 288 312" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="brt-bus-outbound" transform="matrix(1,0,0,1,-31.5,-2.6)">
+        <path d="M288.3,144.2L300.8,139.9L300.8,76.2L288.3,72L288.3,144.2Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M288.3,77.6L278,77L278,101.8L275.1,102.8L275.7,72L288.3,72L288.3,77.6Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M62.7,186.7L50.2,190.9L50.2,217.6L62.7,221.8L62.7,186.7Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M66.6,234.8L62.7,232.4L62.7,221.8L57.9,220.2L60.1,233.5L66.4,240.4L66.6,234.8Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <path d="M102.4,314.6L127.6,260.4L107,240.4" style="fill:rgb(43,43,42);fill-rule:nonzero;"/>
+        <path d="M74.3,240.4L80.4,314.6L102.4,314.6L107,240.4L74.3,240.4Z" style="fill:rgb(92,95,96);fill-rule:nonzero;"/>
+        <path d="M245.9,314.6L220.7,260.4L241.3,240.4" style="fill:rgb(43,43,42);fill-rule:nonzero;"/>
+        <path d="M274,240.4L267.9,314.6L245.9,314.6L241.3,240.4L274,240.4Z" style="fill:rgb(92,95,96);fill-rule:nonzero;"/>
+        <path d="M277.2,45.2L268,31.7L80.4,31.7L71.2,45.2L65.9,264.3L75.6,292.6L273,292.6L282.7,264.3L277.2,45.2Z" style="fill:rgb(249,187,36);fill-rule:nonzero;"/>
+        <path d="M268.4,276.6L265.6,284.8L236,284.8L233.2,276.6L268.4,276.6Z" style="fill:rgb(228,226,220);fill-rule:nonzero;"/>
+        <path d="M115.1,276.6L112.3,284.8L82.8,284.8L80,276.6L115.1,276.6Z" style="fill:rgb(228,226,220);fill-rule:nonzero;"/>
+        <path d="M232.9,43.9L115.5,43.9L115.1,63.3L233.3,63.3L232.9,43.9Z" style="fill:rgb(36,35,56);fill-rule:nonzero;"/>
+        <path d="M273.2,114.4L265.3,137.5L83,137.5L75.1,114.4L76.4,68.3L272,68.3L273.2,114.4Z" style="fill:rgb(73,74,114);fill-rule:nonzero;"/>
+        <g transform="matrix(1,0,0,1,64.0781,-0.374223)">
+            <path d="M59.657,61.648L59.551,46.3L62.695,46.3L62.695,58.605L67.8,58.628L67.8,61.648L59.657,61.648Z" style="fill:rgb(249,187,36);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1.00003,0,0,1.00003,-590.916,-594.685)">
+            <path d="M726.207,640.692L726.235,648.963L734.374,649.069L734.401,655.94L737.439,655.913L737.438,640.717L734.295,640.717L734.27,646.004L729.142,646.004L729.142,640.717L726.207,640.692Z" style="fill:rgb(249,187,36);fill-rule:nonzero;"/>
+        </g>
+        <path d="M96.1,31.7L98.1,25.9L250.3,25.9L252.3,31.7L96.1,31.7Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+        <path d="M162.2,25.9L164.2,20.1L184.1,20.1L186.1,25.9L162.2,25.9Z" style="fill:rgb(53,45,39);fill-rule:nonzero;"/>
+        <g>
+            <g>
+                <clipPath id="_clip1">
+                    <path d="M273.3,114.4L265.4,137.5L83,137.5L75.1,114.4L76.4,68.3L272.1,68.3L273.3,114.4Z"/>
+                </clipPath>
+                <g clip-path="url(#_clip1)">
+                    <g transform="matrix(0.7071,-0.7071,0.7071,0.7071,-50.729,136.857)">
+                        <rect x="-32" y="84.5" width="343.6" height="90.3" style="fill:white;fill-opacity:0.1;"/>
+                    </g>
+                    <g transform="matrix(0.7071,-0.7071,0.7071,0.7071,-53.9948,176.466)">
+                        <rect x="14.2" y="149.2" width="343.6" height="8.5" style="fill:white;fill-opacity:0.2;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+        <path d="M239.7,145.4L238.6,150.7L109.7,150.7L108.7,145.4L239.7,145.4Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+        <path d="M239.7,160.7L238.6,166L109.7,166L108.7,160.7L239.7,160.7Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+        <path d="M239.7,176L238.6,181.3L109.7,181.3L108.7,176L239.7,176Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+        <path d="M150.8,264.4L150.6,284.8L197.8,284.8L197.8,264.4L150.8,264.4Z" style="fill:rgb(247,245,240);fill-rule:nonzero;"/>
+        <path d="M86,225.3C86,229.1 82.9,232.3 79,232.3C75.2,232.3 72,229.2 72,225.3C72,221.4 75.1,218.3 79,218.3C82.9,218.4 86,221.5 86,225.3" style="fill:rgb(176,32,38);fill-rule:nonzero;"/>
+        <path d="M86,207.8C86,211.6 82.9,214.8 79,214.8C75.2,214.8 72,211.7 72,207.8C72,203.9 75.1,200.8 79,200.8C82.9,200.8 86,203.9 86,207.8" style="fill:rgb(176,32,38);fill-rule:nonzero;"/>
+        <path d="M86,189.8C86,193.6 82.9,196.8 79,196.8C75.2,196.8 72,193.7 72,189.8C72,185.9 75.1,182.8 79,182.8C82.9,182.8 86,186 86,189.8" style="fill:rgb(176,32,38);fill-rule:nonzero;"/>
+        <path d="M276.3,225.3C276.3,229.1 273.2,232.3 269.3,232.3C265.4,232.3 262.3,229.2 262.3,225.3C262.3,221.5 265.4,218.3 269.3,218.3C273.2,218.4 276.3,221.5 276.3,225.3" style="fill:rgb(176,32,38);fill-rule:nonzero;"/>
+        <path d="M276.3,207.8C276.3,211.6 273.2,214.8 269.3,214.8C265.4,214.8 262.3,211.7 262.3,207.8C262.3,203.9 265.4,200.8 269.3,200.8C273.2,200.8 276.3,203.9 276.3,207.8" style="fill:rgb(176,32,38);fill-rule:nonzero;"/>
+        <path d="M276.3,189.8C276.3,193.6 273.2,196.8 269.3,196.8C265.4,196.8 262.3,193.7 262.3,189.8C262.3,185.9 265.4,182.8 269.3,182.8C273.2,182.8 276.3,186 276.3,189.8" style="fill:rgb(176,32,38);fill-rule:nonzero;"/>
+    </g>
+</svg>

--- a/assets/images/illustrations/transit/brt-station-center.svg
+++ b/assets/images/illustrations/transit/brt-station-center.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 312 288" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="brt-station-center" transform="matrix(0.631257,0,0,0.631257,9.69601,9.3)">
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M60.4,372.6L60.4,391.3L6.5,391.3L0,372.6L60.4,372.6Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M46.6,18.7L61.5,372.6L398.1,372.6L413.9,18.7L46.6,18.7Z" style="fill:rgb(228,226,220);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M27.7,0L46.4,441.5L413.9,441.5L432.7,0L27.7,0ZM64.5,422.8L63.2,391.4L397.3,391.4L396,422.8L64.5,422.8ZM398.1,372.6L62.4,372.6L47.4,18.7L413.3,18.7L398.1,372.6Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M44.4,391.2L46.6,441.4L413.9,441.4L416.3,391.2L44.4,391.2Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M60.4,0L60.4,18.7L6.5,18.7L0,0L60.4,0Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M400.1,0L400.1,18.7L454,18.7L460.3,0L400.1,0Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <rect x="23.3" y="0" width="429.3" height="18.8" style="fill:rgb(248,187,30);"/>
+        </g>
+        <g transform="matrix(1,0,0,1,1.61609,0)">
+            <path d="M390.6,372.6L390.6,391.3L444.5,391.3L451,372.6L390.6,372.6Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(-1,0,0,1,562.272,-1.1)">
+            <g id="person-large-light-left">
+                <g>
+                    <g id="person-large-light-left1" serif:id="person-large-light-left" transform="matrix(0.889472,0,0,0.889472,25.9188,54.1587)">
+                        <g id="Layer-1">
+                            <path d="M172,147L189.9,159.2L185.5,162.7L170.6,152.2L172,147Z" style="fill:rgb(255,238,205);fill-opacity:0.7;fill-rule:nonzero;"/>
+                            <path d="M173.2,142.4L194.3,155.7L189.9,159.2L171.9,147L173.2,142.4Z" style="fill:rgb(255,238,205);fill-opacity:0.3;fill-rule:nonzero;"/>
+                            <path d="M170.6,152.2L186.6,163.4L183.9,166.3L167.9,156.3L170.6,152.2Z" style="fill:rgb(1,1,1);fill-rule:nonzero;"/>
+                            <path d="M244.9,344.2L246.3,271.8L253.4,225.9L228.8,221.3L229.8,269.8L231.4,345.2L244.9,344.2Z" style="fill:rgb(207,175,129);fill-rule:nonzero;"/>
+                            <path d="M240.5,127.5L240.2,117.2L249.9,114.3L253.9,125.2L240.5,127.5Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                            <path d="M256.2,203.4L253.5,226.1L221.7,269.2L218.1,346.7L203.8,348.8L204.4,267.7L219.4,208L256.2,203.4Z" style="fill:rgb(224,206,168);fill-rule:nonzero;"/>
+                            <path d="M253.8,125.1L256.3,203.3L219.1,207.9L224.3,143.7L239.8,127.4L253.8,125.1Z" style="fill:rgb(136,187,106);fill-rule:nonzero;"/>
+                            <path d="M225.3,173.9L192.2,166.3L187.6,171.4L228.3,184.2L250.3,147.8L241.4,141.8L225.3,173.9Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                            <path d="M254.1,131.3L249.7,150.9L238,147.1L239.7,134.1" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                            <path d="M240.5,138.4L224.3,143.8L233.3,127.5L253.7,125.1L254,131.1L240.5,138.4Z" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                            <path d="M240.6,118.8L231.3,121.8L228.1,112.1L224.6,112.3L225.6,97.1L252.4,98.8L250.2,115.9" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                            <path d="M195.2,166.9L178.1,162L171.6,166.3L179.7,174.4L190.6,172L195.2,166.9Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                            <path d="M193,166.6L183.3,163.6L185.8,160.4L193,166.6Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                            <path d="M241.9,103.6L246.2,102.2L245.9,110.6L242.6,110.8L241.9,103.6Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                            <path d="M250.5,116.1L252.6,99.5L241.1,99L240.9,103.6L246.1,102.3L245.5,110.5L240.6,111L240.1,119.7L250.5,116.1Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                            <path d="M231.8,125.1L230.4,118.4L241.8,114L245.9,115.9L231.8,125.1Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                            <path d="M231.4,343.4L209.9,348L212.9,356.1L242,355.3L244.9,344.2L231.4,343.4Z" style="fill:rgb(103,91,76);fill-rule:nonzero;"/>
+                            <path d="M203.7,345.5L218,346.3L215.1,357.4L185.8,358.2L182.8,350.1L203.7,345.5Z" style="fill:rgb(152,138,116);fill-rule:nonzero;"/>
+                            <path d="M227.2,91.5L210.5,96L215.1,101.4L232,97.6L227.2,91.5Z" style="fill:rgb(104,154,66);fill-rule:nonzero;"/>
+                            <path d="M249,86L252.6,99.3L227.1,98.2L224.1,92.7L230.9,85.9L249,86Z" style="fill:rgb(104,154,66);fill-rule:nonzero;"/>
+                            <path d="M249,86L252.6,99.3L241.2,98.8L249,86Z" style="fill:rgb(59,132,63);fill-rule:nonzero;"/>
+                        </g>
+                    </g>
+                    <g transform="matrix(0.875729,0,0,0.875729,39.4062,60.8181)">
+                        <path d="M410.3,163.7L394.3,153.7L397,149.7L412.8,160.9L410.3,163.7Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+                        <path d="M462.1,342.4L460.5,267.2L459.5,218.9L476.1,223.5L476.9,269.3L475.5,341.5L462.1,342.4Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                        <path d="M480,122.8L476,111.9L466.3,114.8L466.6,125.1L480,122.8Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                        <path d="M458.5,207.7L437.7,258.5L430,346L444.3,343.9L454.3,260.7L480,223.5L473.3,203.7L458.5,207.7Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M430.3,276.7L489.1,276.2L476.7,195.7L480,122.7L466.1,125.1L446.3,147.4L447.9,200.5L430.3,276.7Z" style="fill:rgb(253,209,88);fill-rule:nonzero;"/>
+                        <path d="M467.8,139.2L476.7,145.2L454.7,181.6L414,168.9L418.6,163.8L451.7,171.4L467.8,139.2Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M466.1,131.7L464.4,144.7L476,148.5L480.4,128.9" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+                        <path d="M480.4,128.9L480.1,122.9L459.7,125.3L446.2,147.6L466.8,136L480.4,128.9Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+                        <path d="M476.6,113.7L478.8,96.6L452,94.8L451,110L454.5,109.8L457.7,119.5L467,116.5" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M417.2,169.6L406.3,172L398.2,163.9L404.7,159.6L421.6,164.5L417.2,169.6Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M468.9,108.4L472.2,108.2L472.5,99.8L468.2,101.1L468.9,108.4Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M466.6,117.3L467.1,108.7L472,108.2L472.6,100L467.5,101.3L467.7,96.7L479.1,97.2L477,113.8L466.6,117.3Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                        <path d="M475.6,341.3L472.7,352.2L443.6,353L440.6,344.9L462.1,340.3L475.6,341.3Z" style="fill:rgb(207,175,129);fill-rule:nonzero;"/>
+                        <path d="M452,94.8L451.4,86.2L480.4,83.5L492,116.6L491,149.2L480.9,151.4L470.8,125.3L471.4,100.4L467.4,101.4L462,95.9L452,94.8Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                        <path d="M444.2,343.3L441.3,354.2L412.2,355L409.2,346.9L430,342.3L444.2,343.3Z" style="fill:rgb(255,239,206);fill-rule:nonzero;"/>
+                    </g>
+                    <g id="people-26" transform="matrix(0.892625,0,0,0.892625,26.1565,52.678)">
+                        <path d="M389,199.9L391.1,210.5L388.4,224.1L383.5,221.2L384.9,209.5L384.6,213L380,212L384,203.3L389,199.9Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M374.1,142.7L364.8,139.1L344.7,138.3L348.5,122.1L373.1,121.6L374.1,142.7Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                        <path d="M347.6,323L346,335L357.7,334.7L358.7,321.9L347.6,323Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                        <path d="M366.5,339L368.9,354.8L367.6,358.6L358.4,358.6L356,341.2L366.5,339Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                        <path d="M372.4,138.9L367.5,135.6L363.9,125.5L355.7,127.9L353,134.4L347.3,137.3L350.9,149.2L367.8,149.7L372.4,138.9Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M364,132.8L356.6,132.8L348.5,122.5L349.9,100.3L364.2,97.9L373.1,101.4L372.8,122.3L364,132.8Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M375.4,154.5L383.6,204.2L389.5,202L382.2,145.9L375.4,154.5Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M361.7,91.4L345.1,96.6L335.9,141.4L345.2,151.4L345,140.6L345.6,137.4L348.5,122.8L352.1,104.4L361.9,100.4L361.7,91.4Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                        <path d="M362.1,100.4L371.8,104L372.9,146.9L381.1,145.5L379.5,99.2L361.4,91L362.1,100.4Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                        <path d="M358.3,250.6L356.6,341.2L366.6,339.1L375.5,250.2" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M358.6,218.5L358.3,256.8L356.9,322.2L347.7,323L343.3,256.5L358.6,218.5Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M336.1,141.6L347.2,137L351.6,147.8L367.1,148.3L372.3,138.6L382.3,145.4L375.5,154.3L374.7,182.2L388.6,275.2L330.9,275.7L344.2,183.2L341.7,149.6L336.1,141.6Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+                        <path d="M341.6,149.7L339.2,202.4L332.9,201.9L335.9,141.7L341.6,149.7Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M332.9,201.7L332.3,210.1L338,222L342.6,219.3L338.5,208.7L339.1,212.2L343.1,209L339.1,202.5L332.9,201.7Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M294.3,194.1L299.5,189.2L293.8,185.1L288.7,194.3L294.3,194.1Z" style="fill:rgb(174,32,37);fill-rule:nonzero;"/>
+                        <path d="M281.9,200.1L289,194.1L301.2,194.1L310.1,202.8L307.9,231.2L302,230.4L301.2,229L297.2,227.4L290.1,228.4L286.3,230.5L281.4,230.2L281.9,200.1Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                        <path d="M303,224L299.7,221.8L297.3,215.1L291.8,216.7L290,221L286.2,222.9L285.2,244L294.4,259L303,224Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M297.4,220L292.5,220L287.3,213.2L289.5,199.1L297.6,199.1L303.5,205.4L303.3,213.3L297.4,220Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M288.9,204.7L285.4,204.7L285.1,210.4L288.4,210.2L288.9,204.7Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M303.1,205.5L306.3,205.5L306.1,211.2L303.2,211.2L303.1,205.5Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M301.9,334.6L303,343L294.8,342.8L294.2,333.8L301.9,334.6Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                        <path d="M288.7,345.8L287.1,356.9L288.1,359.6L294.6,359.6L296.2,347.4L288.7,345.8Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                        <path d="M272.7,268L271.3,275.6L273.2,285.3L276.7,283.4L275.7,275.2L275.9,277.7L279.2,276.9L276.5,270.7L272.7,268Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M282.5,235.9L276.6,271.1L272.5,269.5L277.7,229.7L282.5,235.9Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M315.6,265.3L317,272.9L315.1,282.6L311.6,280.7L312.6,272.5L312.4,275L309.1,274.2L311.8,268L315.6,265.3Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M306,233.2L311.9,268.4L316,266.8L310.9,227L306,233.2Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M294.4,284L295.7,347.4L288.7,346L282.5,283.9" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                        <path d="M294.3,261.5L294.5,288.3L295.5,334.1L302,334.6L305,288L294.3,261.5Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                        <path d="M310.6,227L302.8,223.8L299.6,231.6L288.8,231.6L286.6,223L277.7,230L282.5,236.3L285,256.1L279,318.2L310.4,318.5L303,256.9L306.8,233L310.6,227Z" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                        <path d="M284.9,197.5L277.6,197L279.2,190.2L289,194" style="fill:rgb(174,32,37);fill-rule:nonzero;"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/assets/images/illustrations/transit/brt-station-left.svg
+++ b/assets/images/illustrations/transit/brt-station-left.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 312 288" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="brt-station-left" transform="matrix(0.675667,0,0,0.675667,9.68207,9.3)">
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <path d="M166.3,245L196.3,952.5L785.2,952.5L815.4,245L166.3,245ZM225.2,922.5L223.2,872.2L758.6,872.2L756.6,922.5L225.2,922.5ZM759.8,842L221.9,842L197.7,275L784.1,275L759.8,842Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <path d="M192.9,872L196.5,952.5L785.2,952.5L788.8,872L192.9,872Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <path d="M220.3,842L220.3,872.7L132.5,872.7L121.8,842L220.3,842Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <path d="M196.5,275L221.9,842L759.8,842L785.1,275L196.5,275Z" style="fill:rgb(228,226,220);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <path d="M218.6,245L218.6,275L132.3,275L121.9,245L218.6,245Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <path d="M763.1,245L763.1,275L849.4,275L859.6,245L763.1,245Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+        </g>
+        <g transform="matrix(0.583012,0,0,0.583012,-71.0609,-142.838)">
+            <rect x="159.2" y="245" width="687.9" height="30.2" style="fill:rgb(248,187,30);"/>
+        </g>
+        <g id="person-large-light-left" transform="matrix(0.518573,0,0,0.518573,-55.9499,-111.263)">
+            <g id="Layer-1">
+                <path d="M263.9,548.8L292.6,568.3L285.5,573.9L261.6,557.1L263.9,548.8Z" style="fill:rgb(255,238,205);fill-opacity:0.7;fill-rule:nonzero;"/>
+                <path d="M265.7,541.5L299.5,562.8L292.4,568.4L263.7,548.9L265.7,541.5Z" style="fill:rgb(255,238,205);fill-opacity:0.3;fill-rule:nonzero;"/>
+                <path d="M261.6,557.2L287.2,575.2L282.9,579.8L257.3,563.8L261.6,557.2Z" style="fill:rgb(1,1,1);fill-rule:nonzero;"/>
+                <path d="M380.7,864.9L383,748.9L394.4,675.3L355.1,667.9L356.6,745.6L359.1,866.4L380.7,864.9Z" style="fill:rgb(207,175,129);fill-rule:nonzero;"/>
+                <path d="M373.6,517.6L373.1,501.1L388.6,496.5L394.9,514L373.6,517.6Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                <path d="M398.7,639.2L394.4,675.5L343.4,744.5L337.6,868.6L314.8,871.9L315.8,741.9L339.9,646.2L398.7,639.2Z" style="fill:rgb(224,206,168);fill-rule:nonzero;"/>
+                <path d="M394.9,513.8L399,639.2L339.3,646.6L347.7,543.8L372.6,517.7L394.9,513.8Z" style="fill:rgb(136,187,106);fill-rule:nonzero;"/>
+                <path d="M349.2,592L296.1,579.8L288.7,587.9L353.9,608.5L389.2,550.1L375,540.5L349.2,592Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M395.4,523.7L388.3,555.2L369.5,549.1L372.3,528.3" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                <path d="M373.6,535.1L347.7,543.7L362.2,517.6L394.9,513.8L395.4,523.4L373.6,535.1Z" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                <path d="M373.8,503.7L358.8,508.5L353.7,493L348.1,493.3L349.6,468.9L392.5,471.7L388.9,499.1" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M301,580.8L273.6,572.9L263.2,579.8L276.1,592.7L293.6,588.9L301,580.8Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M297.4,580.3L281.9,575.5L286,570.4L297.4,580.3Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M375.8,479.3L382.7,477L382.2,490.5L376.9,490.8L375.8,479.3Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M389.6,499.3L392.9,472.6L374.6,471.8L374.3,479.2L382.7,477.2L381.7,490.4L373.8,491.2L373,505.2L389.6,499.3Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                <path d="M359.6,513.8L357.3,503.1L375.6,496L382.2,499L359.6,513.8Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M359.1,863.6L324.6,871L329.4,883.9L376.1,882.6L380.7,864.8L359.1,863.6Z" style="fill:rgb(103,91,76);fill-rule:nonzero;"/>
+                <path d="M314.7,866.9L337.5,868.2L332.9,886L285.9,887.3L281.1,874.4L314.7,866.9Z" style="fill:rgb(152,138,116);fill-rule:nonzero;"/>
+                <path d="M352.2,460L325.5,467.1L332.9,475.7L360.1,469.6L352.2,460Z" style="fill:rgb(104,154,66);fill-rule:nonzero;"/>
+                <path d="M387.3,451.1L393.1,472.4L352.2,470.6L347.4,461.7L358.3,450.8L387.3,451.1Z" style="fill:rgb(104,154,66);fill-rule:nonzero;"/>
+                <path d="M387.3,451.1L393.1,472.4L374.8,471.6L387.3,451.1Z" style="fill:rgb(59,132,63);fill-rule:nonzero;"/>
+            </g>
+        </g>
+        <g transform="matrix(0.510561,0,0,0.510561,-48.0866,-107.38)">
+            <path d="M654.9,585.2L629.3,569.2L633.6,562.9L659,580.9L654.9,585.2Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+            <path d="M737.9,871.5L735.4,750.9L733.9,673.5L760.6,680.9L761.9,754.3L759.5,870L737.9,871.5Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+            <path d="M766.6,519.7L760.3,502.2L744.8,506.8L745.3,523.3L766.6,519.7Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+            <path d="M732,655.7L698.7,737.2L686.3,877.3L709.1,874L725.1,740.7L766.2,681L755.5,649.3L732,655.7Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M686.9,766.1L781.1,765.3L761.3,636.3L766.6,519.3L744.3,523.1L712.5,559L715,644L686.9,766.1Z" style="fill:rgb(253,209,88);fill-rule:nonzero;"/>
+            <path d="M747,545.8L761.2,555.4L726,613.8L660.8,593.5L668.2,585.4L721.3,597.6L747,545.8Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M744.2,533.9L741.4,554.7L759.9,560.8L767,529.3" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+            <path d="M767.1,529.3L766.6,519.7L733.9,523.5L712.3,559.3L745.3,540.8L767.1,529.3Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+            <path d="M761,504.9L764.6,477.5L721.7,474.7L720.2,499.1L725.8,498.8L730.9,514.3L745.9,509.5" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M665.8,594.5L648.3,598.3L635.4,585.4L645.8,578.5L673,586.4L665.8,594.5Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M748.8,496.6L754.1,496.3L754.6,482.8L747.7,484.8L748.8,496.6Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M745,510.8L745.8,497.1L753.7,496.3L754.7,483.1L746.6,485.1L746.9,477.7L765.2,478.5L761.9,505.2L745,510.8Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+            <path d="M759.5,869.7L754.9,887.2L708.2,888.5L703.4,875.6L737.9,868.2L759.5,869.7Z" style="fill:rgb(207,175,129);fill-rule:nonzero;"/>
+            <path d="M721.6,474.7L720.6,461L767.1,456.7L785.6,509.8L784.1,562.1L767.9,565.7L751.7,523.8L752.7,483.9L746.4,485.4L737.8,476.5L721.6,474.7Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+            <path d="M709.2,873L704.6,890.5L657.9,891.8L653.1,878.9L686.4,871.5L709.2,873Z" style="fill:rgb(255,239,206);fill-rule:nonzero;"/>
+        </g>
+        <g id="people-26" transform="matrix(0.520411,0,0,0.520411,-55.8113,-112.126)">
+            <path d="M611.8,631.6L615.1,648.6L610.8,670.4L602.9,665.8L605.2,647L604.7,652.6L597.3,650.8L603.6,636.8L611.8,631.6Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M587.9,539.9L572.9,534.1L540.7,532.8L546.8,506.9L586.1,506.1L587.9,539.9Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+            <path d="M545.5,828.8L543,848.1L561.8,847.6L563.3,827L545.5,828.8Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+            <path d="M575.7,854.4L579.5,879.8L577.5,885.9L562.8,885.9L559,858L575.7,854.4Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+            <path d="M585.1,533.8L577.2,528.5L571.4,512.3L558.2,516.1L553.9,526.5L544.8,531.1L550.6,550.1L577.8,550.9L585.1,533.8Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M571.7,523.9L559.8,523.9L546.9,507.4L549.2,471.9L572,468.1L586.2,473.7L585.7,507.2L571.7,523.9Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M589.9,558.7L603.1,638.4L612.5,634.8L600.8,545L589.9,558.7Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M568.1,457.7L541.4,466.1L526.7,537.9L541.7,553.9L541.4,536.6L542.4,531.5L547,508.1L552.8,478.7L568.5,472.4L568.1,457.7Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+            <path d="M568.6,472.2L584.1,478L585.9,546.8L599.1,544.5L596.6,470.4L567.7,457.2L568.6,472.2Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+            <path d="M562.5,712.8L559.7,858L575.7,854.7L589.9,712.3" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M563,661.3L562.5,722.7L560.2,827.5L545.5,828.8L538.4,722.2L563,661.3Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M527,538.2L544.8,530.8L551.9,548.1L576.8,548.9L585.2,533.4L601.2,544.3L590.3,558.5L589,603.2L611.3,752.2L518.9,753L540.2,604.8L536.1,551L527,538.2Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+            <path d="M535.9,551.1L532.1,635.6L521.9,634.8L526.7,538.3L535.9,551.1Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M521.9,634.4L520.9,647.9L530,666.9L537.4,662.6L530.8,645.6L531.8,651.2L538.1,646.1L531.8,635.7L521.9,634.4Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M460,622.2L468.4,614.3L459.3,607.7L451.2,622.4L460,622.2Z" style="fill:rgb(174,32,37);fill-rule:nonzero;"/>
+            <path d="M440.2,631.8L451.6,622.2L471.1,622.2L485.3,636.2L481.7,681.6L472.3,680.3L471,678L464.7,675.5L453.3,677L447.2,680.3L439.3,679.8L440.2,631.8Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+            <path d="M473.9,670.2L468.6,666.6L464.8,655.9L455.9,658.4L453.1,665.3L447,668.3L445.5,702.1L460.2,726.2L473.9,670.2Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M465,663.8L457.1,663.8L448.7,652.9L452.3,630.3L465.2,630.3L474.6,640.5L474.3,653.2L465,663.8Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M451.3,639.2L445.7,639.2L445.2,648.3L450.5,648L451.3,639.2Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M474.2,640.5L479.3,640.5L479,649.6L474.4,649.6L474.2,640.5Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M472.1,847.3L473.9,860.8L460.7,860.5L459.7,846L472.1,847.3Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+            <path d="M451.1,865.4L448.6,883.2L450.1,887.5L460.5,887.5L463,868L451.1,865.4Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+            <path d="M425.4,740.7L423.1,752.9L426.1,768.4L431.7,765.4L430.2,752.2L430.5,756.3L435.8,755L431.5,745.1L425.4,740.7Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M441.2,689.2L431.8,745.6L425.2,743.1L433.6,679.4L441.2,689.2Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M494.2,736.4L496.5,748.6L493.5,764.1L487.9,761.1L489.4,747.9L489.1,752L483.8,750.7L488.1,740.8L494.2,736.4Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M478.7,684.9L488.1,741.3L494.7,738.8L486.6,675.1L478.7,684.9Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M460.2,766.4L462.2,867.9L451,865.6L441.1,766.1" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+            <path d="M460,730.3L460.3,773.2L461.8,846.6L472.2,847.4L477.3,772.8L460,730.3Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+            <path d="M486.1,675L473.7,669.9L468.6,682.3L451.3,682.3L447.7,668.6L433.5,679.8L441.1,690L445.2,721.7L435.6,821.2L485.9,821.7L473.9,723L480,684.7L486.1,675Z" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+            <path d="M445,627.8L433.3,627L435.8,616.1L451.5,622.2" style="fill:rgb(174,32,37);fill-rule:nonzero;"/>
+        </g>
+    </g>
+</svg>

--- a/assets/images/illustrations/transit/brt-station-right.svg
+++ b/assets/images/illustrations/transit/brt-station-right.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 312 288" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g id="brt-station-right" transform="matrix(0.702015,0,0,0.702015,9.69589,9.3)">
+        <path d="M359.8,335L359.8,351.8L408.2,351.8L413.9,335L359.8,335Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        <path d="M372.2,16.8L358,335L56.1,335L41.9,16.8L372.2,16.8Z" style="fill:rgb(228,226,220);fill-rule:nonzero;"/>
+        <path d="M24.9,0L41.7,397L372.2,397L389.2,0L24.9,0ZM58,380.2L56.8,352L357.2,352L356.1,380.2L58,380.2ZM42.6,16.8L371.7,16.8L358.1,335L56.1,335L42.6,16.8Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+        <path d="M374.2,351.8L372.2,397L41.9,397L39.9,351.8L374.2,351.8Z" style="fill:rgb(29,29,27);fill-rule:nonzero;"/>
+        <g transform="matrix(-1,0,0,1,555.856,-1.1)">
+            <g id="person-large-light-left" transform="matrix(0.889472,0,0,0.889472,25.9188,54.1587)">
+                <g id="Layer-1">
+                    <path d="M217.6,126.2L233.7,137.2L229.7,140.3L216.3,130.9L217.6,126.2Z" style="fill:rgb(255,238,205);fill-opacity:0.7;fill-rule:nonzero;"/>
+                    <path d="M218.6,122L237.5,134L233.5,137.1L217.4,126.1L218.6,122Z" style="fill:rgb(255,238,205);fill-opacity:0.3;fill-rule:nonzero;"/>
+                    <path d="M216.3,130.9L230.7,141L228.3,143.6L213.9,134.6L216.3,130.9Z" style="fill:rgb(1,1,1);fill-rule:nonzero;"/>
+                    <path d="M283.1,303.5L284.4,238.4L290.8,197.1L268.7,193L269.6,236.6L271,304.4L283.1,303.5Z" style="fill:rgb(207,175,129);fill-rule:nonzero;"/>
+                    <path d="M279.1,108.7L278.8,99.4L287.5,96.8L291.1,106.6L279.1,108.7Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                    <path d="M293.2,176.9L290.8,197.3L262.1,236L258.8,305.7L246,307.6L246.6,234.7L260.1,181L293.2,176.9Z" style="fill:rgb(224,206,168);fill-rule:nonzero;"/>
+                    <path d="M291.1,106.5L293.4,176.9L259.9,181L264.6,123.3L278.6,108.6L291.1,106.5Z" style="fill:rgb(136,187,106);fill-rule:nonzero;"/>
+                    <path d="M265.4,150.4L235.6,143.6L231.5,148.2L268.1,159.7L287.9,126.9L279.9,121.5L265.4,150.4Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                    <path d="M291.3,112.1L287.3,129.8L276.8,126.4L278.4,114.7" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                    <path d="M279.1,118.5L264.6,123.3L272.7,108.6L291.1,106.5L291.4,111.9L279.1,118.5Z" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                    <path d="M279.2,100.8L270.8,103.5L268,94.8L264.9,94.9L265.8,81.2L289.9,82.8L287.9,98.2" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                    <path d="M238.4,144.1L223,139.7L217.2,143.5L224.5,150.8L234.3,148.7L238.4,144.1Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                    <path d="M236.4,143.8L227.7,141.1L230,138.3L236.4,143.8Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                    <path d="M280.4,87.1L284.2,85.8L283.9,93.3L280.9,93.4L280.4,87.1Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                    <path d="M288.1,98.4L290,83.4L279.7,83L279.6,87.1L284.3,86L283.7,93.4L279.3,93.8L278.9,101.6L288.1,98.4Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                    <path d="M271.3,106.5L270,100.5L280.3,96.5L284,98.2L271.3,106.5Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                    <path d="M271,302.8L251.6,306.9L254.3,314.2L280.5,313.5L283.1,303.5L271,302.8Z" style="fill:rgb(103,91,76);fill-rule:nonzero;"/>
+                    <path d="M246,304.7L258.8,305.4L256.2,315.4L229.8,316.1L227.1,308.8L246,304.7Z" style="fill:rgb(152,138,116);fill-rule:nonzero;"/>
+                    <path d="M267.1,76.3L252.1,80.3L256.2,85.1L271.4,81.7L267.1,76.3Z" style="fill:rgb(104,154,66);fill-rule:nonzero;"/>
+                    <path d="M286.8,71.3L290.1,83.3L267.2,82.3L264.5,77.3L270.6,71.2L286.8,71.3Z" style="fill:rgb(104,154,66);fill-rule:nonzero;"/>
+                    <path d="M286.8,71.3L290.1,83.3L279.8,82.9L286.8,71.3Z" style="fill:rgb(59,132,63);fill-rule:nonzero;"/>
+                </g>
+            </g>
+            <g transform="matrix(0.875729,0,0,0.875729,39.4062,60.8181)">
+                <path d="M431.3,140.4L416.9,131.4L419.3,127.8L433.5,137.9L431.3,140.4Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+                <path d="M477.9,301L476.5,233.3L475.6,189.9L490.6,194L491.3,235.2L490,300.2L477.9,301Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M494,103.6L490.4,93.8L481.7,96.4L482,105.7L494,103.6Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M474.6,180L455.9,225.7L448.9,304.3L461.7,302.4L470.7,227.6L493.8,194.1L487.8,176.3L474.6,180Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M449.2,241.9L502,241.5L491,169.1L494,103.4L481.5,105.5L463.7,125.6L465.1,173.3L449.2,241.9Z" style="fill:rgb(253,209,88);fill-rule:nonzero;"/>
+                <path d="M483,118.3L491,123.7L471.2,156.5L434.6,145.1L438.7,140.5L468.5,147.3L483,118.3Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M481.4,111.6L479.8,123.3L490.2,126.7L494.2,109" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+                <path d="M494.2,109L493.9,103.6L475.5,105.7L463.4,125.8L481.9,115.4L494.2,109Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+                <path d="M490.8,95.3L492.8,79.9L468.7,78.3L467.8,92L470.9,91.9L473.7,100.6L482.1,97.9" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M437.4,145.6L427.6,147.7L420.3,140.4L426.1,136.6L441.3,141L437.4,145.6Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M484,90.6L487,90.5L487.3,83L483.5,84.1L484,90.6Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M481.9,98.6L482.3,90.9L486.7,90.5L487.3,83.1L482.7,84.2L482.8,80.1L493.1,80.5L491.2,95.5L481.9,98.6Z" style="fill:rgb(115,90,76);fill-rule:nonzero;"/>
+                <path d="M490,300L487.4,309.8L461.2,310.5L458.5,303.2L477.9,299.1L490,300Z" style="fill:rgb(207,175,129);fill-rule:nonzero;"/>
+                <path d="M468.8,78.4L468.2,70.7L494.3,68.3L504.7,98.1L503.8,127.4L494.7,129.4L485.6,105.9L486.2,83.5L482.6,84.4L477.8,79.4L468.8,78.4Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M461.8,301.9L459.2,311.7L433,312.4L430.3,305.1L449,301L461.8,301.9Z" style="fill:rgb(255,239,206);fill-rule:nonzero;"/>
+            </g>
+            <g id="people-26" transform="matrix(0.892625,0,0,0.892625,26.1565,52.678)">
+                <path d="M412.4,174L414.3,183.5L411.9,195.8L407.5,193.2L408.8,182.7L408.5,185.8L404.4,184.8L408,177L412.4,174Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M399,122.5L390.6,119.2L372.5,118.5L375.9,104L398,103.6L399,122.5Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                <path d="M375.2,284.6L373.8,295.4L384.3,295.1L385.2,283.6L375.2,284.6Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M392.2,299L394.3,313.2L393.2,316.6L384.9,316.6L382.8,300.9L392.2,299Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M397.4,119.1L393,116.1L389.7,107L382.3,109.1L379.9,114.9L374.8,117.5L378.1,128.2L393.3,128.6L397.4,119.1Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M389.9,113.6L383.2,113.6L375.9,104.3L377.2,84.4L390,82.3L398,85.4L397.7,104.2L389.9,113.6Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M400.1,133.1L407.5,177.8L412.8,175.8L406.2,125.4L400.1,133.1Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M387.9,76.4L372.9,81.1L364.6,121.4L373,130.4L372.9,120.7L373.5,117.9L376.1,104.8L379.4,88.3L388.2,84.7L387.9,76.4Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                <path d="M388.2,84.5L396.9,87.8L397.9,126.4L405.3,125.1L403.9,83.5L387.7,76.1L388.2,84.5Z" style="fill:rgb(85,63,55);fill-rule:nonzero;"/>
+                <path d="M384.8,219.5L383.2,301L392.2,299.1L400.2,219.2" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M385,190.6L384.7,225.1L383.4,283.9L375.1,284.6L371.1,224.8L385,190.6Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M364.8,121.5L374.8,117.4L378.8,127.1L392.8,127.5L397.5,118.8L406.5,124.9L400.4,132.9L399.7,158L412.2,241.6L360.3,242L372.3,158.8L370,128.6L364.8,121.5Z" style="fill:rgb(42,43,42);fill-rule:nonzero;"/>
+                <path d="M369.8,128.8L367.7,176.2L362,175.8L364.7,121.7L369.8,128.8Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M362,175.5L361.4,183L366.5,193.7L370.6,191.3L366.9,181.8L367.5,184.9L371.1,182.1L367.5,176.3L362,175.5Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M327.2,168.7L331.9,164.3L326.8,160.6L322.2,168.9L327.2,168.7Z" style="fill:rgb(174,32,37);fill-rule:nonzero;"/>
+                <path d="M316.1,174.1L322.5,168.7L333.5,168.7L341.5,176.5L339.5,202L334.2,201.3L333.5,200L329.9,198.6L323.5,199.5L320.1,201.4L315.7,201.1L316.1,174.1Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M335.1,195.6L332.1,193.6L330,187.6L325,189L323.4,192.8L320,194.5L319.1,213.4L327.4,226.9L335.1,195.6Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M330.1,192.1L325.7,192.1L321,186L323,173.3L330.3,173.3L335.6,179L335.5,186.1L330.1,192.1Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M322.4,178.2L319.3,178.2L319,183.3L322,183.2L322.4,178.2Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M335.2,179L338,179L337.9,184.1L335.3,184.1L335.2,179Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M334.1,295L335.1,302.5L327.7,302.4L327.1,294.3L334.1,295Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M322.2,305.2L320.8,315.2L321.7,317.6L327.5,317.6L328.9,306.6L322.2,305.2Z" style="fill:rgb(42,43,43);fill-rule:nonzero;"/>
+                <path d="M307.8,235.2L306.5,242L308.2,250.7L311.3,249L310.4,241.6L310.5,243.9L313.5,243.2L311.1,237.6L307.8,235.2Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M316.7,206.3L311.4,237.9L307.7,236.5L312.4,200.7L316.7,206.3Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M346.4,232.8L347.7,239.6L346,248.3L342.9,246.6L343.8,239.2L343.7,241.5L340.7,240.8L343.1,235.2L346.4,232.8Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M337.8,203.9L343.1,235.5L346.8,234.1L342.2,198.3L337.8,203.9Z" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M327.4,249.6L328.5,306.6L322.2,305.3L316.6,249.5" style="fill:rgb(206,172,152);fill-rule:nonzero;"/>
+                <path d="M327.2,229.4L327.3,253.5L328.2,294.7L334,295.1L336.8,253.2L327.2,229.4Z" style="fill:rgb(169,138,126);fill-rule:nonzero;"/>
+                <path d="M341.9,198.3L334.9,195.5L332.1,202.5L322.4,202.5L320.4,194.8L312.4,201.1L316.7,206.8L319,224.6L313.6,280.4L341.8,280.7L335.1,225.3L338.5,203.8L341.9,198.3Z" style="fill:rgb(103,154,68);fill-rule:nonzero;"/>
+                <path d="M318.8,171.8L312.2,171.4L313.6,165.3L322.4,168.7" style="fill:rgb(174,32,37);fill-rule:nonzero;"/>
+            </g>
+        </g>
+        <path d="M359.8,0L359.8,16.8L408.2,16.8L413.9,0L359.8,0Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+        <path d="M54.3,0L54.3,16.8L5.8,16.8L0,0L54.3,0Z" style="fill:rgb(248,187,30);fill-rule:nonzero;"/>
+        <rect x="7.3" y="0" width="386" height="17" style="fill:rgb(248,187,30);"/>
+    </g>
+</svg>

--- a/assets/locales/en/segment-info.json
+++ b/assets/locales/en/segment-info.json
@@ -39,6 +39,8 @@
     "streetcar": "Streetcar",
     "light-rail": "Light rail",
     "transit-shelter": "Transit shelter",
+    "brt-station": "Bus rapid transit (BRT) station",
+    "brt-bus-lane": "Rapid bus lane",
     "temporary-barrier": "Temporary barrier",
     "inception-train": "“Inception” train",
     "magic-carpet": "Magic carpet"
@@ -177,6 +179,9 @@
     "bus-asphalt|regular": "Asphalt",
     "bus-asphalt|colored": "Red lane",
     "bus-asphalt|shared": "Shared bus/bike lane",
+    "brt-station-orientation|left": "Left",
+    "brt-station-orientation|right": "Right",
+    "brt-station-orientation|center": "Center",
     "bike-asphalt|regular": "Asphalt",
     "bike-asphalt|green": "Green lane",
     "bike-asphalt|red": "Red lane",

--- a/assets/scripts/segments/components.json
+++ b/assets/scripts/segments/components.json
@@ -670,6 +670,31 @@
         }
       }
     },
+    "brt-station": {
+      "name": "Bus rapid transit (BRT) station",
+      "nameKey": "brt-station",
+      "owner": "TRANSIT",
+      "zIndex": 20,
+      "variants": {
+        "orientation": {
+          "left": {
+            "graphics": {
+              "left": "transit--brt-station-left"
+            }
+          },
+          "right": {
+            "graphics": {
+              "right": "transit--brt-station-right"
+            }
+          },
+          "center": {
+            "graphics": {
+              "center": "transit--brt-station-center"
+            }
+          }
+        }
+      }
+    },
     "traffic-cone": {
       "name": "Traffic cone",
       "nameKey": "traffic-cone",
@@ -1185,6 +1210,26 @@
           "outbound": {
             "graphics": {
               "center": "transit--bus-outbound"
+            }
+          }
+        }
+      }
+    },
+    "brt-bus": {
+      "name": "Rapid bus",
+      "nameKey": "brt-bus",
+      "owner": "TRANSIT",
+      "zIndex": 15,
+      "variants": {
+        "direction": {
+          "inbound": {
+            "graphics": {
+              "center": "transit--brt-bus-inbound"
+            }
+          },
+          "outbound": {
+            "graphics": {
+              "center": "transit--brt-bus-outbound"
             }
           }
         }

--- a/assets/scripts/segments/segment-lookup.json
+++ b/assets/scripts/segments/segment-lookup.json
@@ -4342,6 +4342,196 @@
       }
     }
   },
+  "brt-station": {
+    "name": "Bus rapid transit (BRT) station",
+    "nameKey": "brt-station",
+    "owner": "TRANSIT",
+    "zIndex": 20,
+    "defaultWidth": 12,
+    "enableWithFlag": "SEGMENT_BRT",
+    "paletteIcon": "center",
+    "rules": {
+      "minWidth": 12
+    },
+    "variants": ["brt-station-orientation"],
+    "details": {
+      "left": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "brt-station",
+              "variants": {
+                "orientation": ["left"]
+              }
+            }
+          ]
+        }
+      },
+      "right": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "brt-station",
+              "variants": {
+                "orientation": ["right"]
+              }
+            }
+          ]
+        }
+      },
+      "center": {
+        "components": {
+          "lanes": [
+            {
+              "id": "sidewalk",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "objects": [
+            {
+              "id": "brt-station",
+              "variants": {
+                "orientation": ["center"]
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "brt-bus-lane": {
+    "name": "Rapid bus lane",
+    "nameKey": "brt-bus-lane",
+    "owner": "TRANSIT",
+    "zIndex": 15,
+    "defaultWidth": 12,
+    "enableWithFlag": "SEGMENT_BRT",
+    "rules": {
+      "minWidth": 10,
+      "maxWidth": 13
+    },
+    "variants": ["direction", "brt-asphalt"],
+    "details": {
+      "inbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "brt-bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|regular": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "regular"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "brt-bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      },
+      "inbound|red": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-inbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "brt-bus",
+              "variants": {
+                "direction": "inbound"
+              }
+            }
+          ]
+        }
+      },
+      "outbound|red": {
+        "components": {
+          "lanes": [
+            {
+              "id": "asphalt",
+              "variants": {
+                "color": "red"
+              }
+            }
+          ],
+          "markings": [
+            {
+              "id": "markings--straight-outbound-light"
+            }
+          ],
+          "vehicles": [
+            {
+              "id": "brt-bus",
+              "variants": {
+                "direction": "outbound"
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
   "train": {
     "name": "“Inception” train",
     "nameKey": "inception-train",

--- a/assets/scripts/segments/variant_icons.json
+++ b/assets/scripts/segments/variant_icons.json
@@ -243,6 +243,32 @@
       "title": "Shared bus/bike lane"
     }
   },
+  "brt-asphalt": {
+    "regular": {
+      "id": "asphalt",
+      "color": "#292a29",
+      "title": "Asphalt"
+    },
+    "red": {
+      "id": "asphalt",
+      "color": "#9b1f22",
+      "title": "Red lane"
+    }
+  },
+  "brt-station-orientation": {
+    "left": {
+      "id": "orientation-left",
+      "title": "Left"
+    },
+    "right": {
+      "id": "orientation-right",
+      "title": "Right"
+    },
+    "center": {
+      "id": "orientation-center",
+      "title": "Center"
+    }
+  },
   "bike-asphalt": {
     "regular": {
       "id": "asphalt",
@@ -451,5 +477,6 @@
       "color": "#ef9c74",
       "title": "Jersey barrier (plastic)"
     }
-  }
+  },
+  "brt-bus": {}
 }


### PR DESCRIPTION
Adds new BRT station and bus segments for preview:

![image](https://user-images.githubusercontent.com/2553268/94203911-44204c80-fe8e-11ea-8e21-5f9dbe1c220a.png)

This will be merged immediately and deployed so that various stakeholders are able to preview. The segments are NOT public and will only be activated for users with the SEGMENT_BRT flag turned on. Please be aware that details related to BRTs may change, and streets created with preview BRT data may not work in the future if this data format is changed.