### PR TITLE
2056 fix: most incremental fix for survey popup bug

### DIFF
--- a/assets/scripts/sentiment/SentimentSurveyContainer.jsx
+++ b/assets/scripts/sentiment/SentimentSurveyContainer.jsx
@@ -36,7 +36,9 @@ function SentimentSurveyContainer (props) {
         setVisible(true)
       }, SURVEY_DELAY_BEFORE_APPEAR)
     }
-  })
+    // only re-run the effect if the value of isDismissed has changed
+    // previously, the useEffect hook was getting called several times
+  }, [isDismissed])
 
   useEffect(() => {
     if (isEnabled) {


### PR DESCRIPTION
I considered a couple things here, but this seemed to be the smallest change that also got us what we wanted.

Left implementation comments in my own review

Note: this is kind of a tricky thing to test locally. The quickest/easiest way I found of replicating the situation was setting line 74 to `if (!isEnabled)`

Obviously this isn't preferable. However, the survey dialog didn't seem to trigger locally and it was hard to tell why. It's possible `SENTIMENT_SURVEY` is somehow set to false, even though the default flag value is true. There are also several other conditionals being checked in 'isEnabled', perhaps it was one of those. Ideally we'd commit a test for this bug to make sure it doesn't happen again. I could see that using cypress, but its probably doable as a unit test as long as we can explicitly set `isEnabled` to true in that context. Which I'm sure we can, I just didn't feel comfortable enough with our unit test setup to quickly write something up, but this is something I would like to get more familiar with. 