### PR TITLE
docs: add install instructions for PostGIS, resolves #1949 [skip ci]

### DIFF
--- a/docs/technical/installing-streetmix.rst
+++ b/docs/technical/installing-streetmix.rst
@@ -40,6 +40,11 @@ You may already have some of these prerequisites installed. Skip or update the p
 
       brew install postgres
 
+5. Install PostGIS. You can `download MacOSX packages here <https://postgis.net/install/>`_ but just like above the easiest method would be to use Homebrew:
+
+   .. prompt:: bash $
+
+      brew install postgis
 
 Clone and install Streetmix
 +++++++++++++++++++++++++++
@@ -102,6 +107,8 @@ You may already have some of these prerequisites installed. Skip or update the p
 
 4. Install PostgreSQL. You can `download Windows packages here <https://www.postgresql.org/download/windows/>`_.
 
+5. Install PostGIS. You can `download Windows packages here <https://postgis.net/windows_downloads/>`_.
+
 
 Clone and install Streetmix
 +++++++++++++++++++++++++++
@@ -146,11 +153,13 @@ See :ref:`install-all`, below.
 On Linux
 ----------
 
-The primary requirements for this project are Node.js and PostgreSQL. You will need those installed if you do not have them already.
+The primary requirements for this project are Node.js, PostgreSQL and PostGIS. You will need those installed if you do not have them already.
 
 `Installing Node.js <https://www.ostechnix.com/install-node-js-linux/>`_
 
 `Installing Postgres <http://postgresguide.com/setup/install.html>`_
+
+`Installing PostGIS <https://postgis.net/install/>`_
 
 If you haven't installed Postgres on your machine before, you may need to set up some intial configuration. `Here is an example for ArchLinux <https://wiki.archlinux.org/index.php/PostgreSQL>`_.
 

--- a/docs/technical/project.rst
+++ b/docs/technical/project.rst
@@ -9,6 +9,7 @@ Streetmix is a Node.js and JavaScript project. We use the following frameworks:
 
 - `Express <https://expressjs.com/>`_, a web application framework. This is basically the server side of Streetmix. It handles HTTP requests and serves files and data requested by the front end.
 - `PostgreSQL <https://www.postgresql.org/>`_, a relational database. All the data on the server is stored in PostgreSQL.
+- `PostGIS <https://postgis.net/>`_, PostGIS is a spatial database extender for PostgreSQL, adding support for geographic objects.
 - `Parcel <https://parceljs.org/>`_, a web application bundler. When Streetmix starts, it uses Parcel to bundle all the front end JavaScript and CSS.
 - `Babel <https://babeljs.io/>`_, a compiler which allows us to use modern JavaScript in browsers that do not yet support it.
 - `React <https://reactjs.org/>`_, a front-end user interface framework. Most UI is rendered with React.


### PR DESCRIPTION
I didn't see a way of checking for PostGIS before running the migration scripts, people may have issues when migrating like we did. I've added the requirements to the installation instructions and the project description docs.