### PR TITLE
Fix manual width input (#1766)

### DIFF
--- a/assets/scripts/dialogs/SignInDialog.scss
+++ b/assets/scripts/dialogs/SignInDialog.scss
@@ -27,10 +27,10 @@
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s;
 
   &:focus {
-    border-color: darken($button-border-colour, 5%);
+    border-color: $colour-turquoise-425;
     outline: 0;
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.07),
-      0 0 8px opacify(darken($button-border-colour, 10%), 0.15);
+      0 0 8px opacify($colour-turquoise-450, 0.1);
   }
 
   &.sign-in-input-error {

--- a/assets/scripts/info_bubble/BuildingHeightControl.jsx
+++ b/assets/scripts/info_bubble/BuildingHeightControl.jsx
@@ -98,6 +98,7 @@ function BuildingHeightControl ({ position }) {
           id: 'tooltip.remove-floor',
           defaultMessage: 'Remove floor'
         })}
+        allowAutoUpdate={true}
       />
     </div>
   )

--- a/assets/scripts/info_bubble/BuildingHeightControl.scss
+++ b/assets/scripts/info_bubble/BuildingHeightControl.scss
@@ -1,4 +1,6 @@
-.building-height {
+@import "../../styles/variables.scss";
+
+.building-height .up-down-input {
   /* Re-organizes the up/down input so that elements are stacked
   veritcally, and flips the icons so that up above the element */
   display: flex;
@@ -7,16 +9,17 @@
 
   .up-down-input-element {
     width: 100px;
-    margin-top: 4px;
-    margin-bottom: 2px;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    border-left: 1px solid $form-element-border;
+    border-right: 1px solid $form-element-border;
   }
 
   .up-down-input-decrement {
-    margin-top: 3px;
-    margin-bottom: 5px;
+    border-radius: $border-radius-medium;
   }
 
   .up-down-input-increment {
-    margin-bottom: 2px;
+    border-radius: $border-radius-medium;
   }
 }

--- a/assets/scripts/info_bubble/UpDownInput.jsx
+++ b/assets/scripts/info_bubble/UpDownInput.jsx
@@ -67,7 +67,10 @@ function UpDownInput (props) {
 
   const [isEditing, setIsEditing] = useState(false)
   const [isHovered, setIsHovered] = useState(false)
-  const [displayValue, setDisplayValue] = useState(value)
+  // If the initial `value` prop is `null` or undefined, the displayValue must
+  // be initiated as an empty string, otherwise React throws a warning about
+  // uncontrolled inputs when the value is changed later
+  const [displayValue, setDisplayValue] = useState(value ?? '')
   const [userInputValue, setUserInputValue] = useState(null)
 
   const debounceUpdateValue = debounce(onUpdatedValue, EDIT_INPUT_DELAY)
@@ -76,6 +79,12 @@ function UpDownInput (props) {
   useEffect(() => {
     // If component is disabled, display nothing
     if (disabled) {
+      setDisplayValue('')
+      return
+    }
+
+    // If the `value` prop is `null` or undefined, display nothing
+    if (value === null || typeof value === 'undefined') {
       setDisplayValue('')
       return
     }

--- a/assets/scripts/info_bubble/UpDownInput.jsx
+++ b/assets/scripts/info_bubble/UpDownInput.jsx
@@ -230,7 +230,7 @@ function UpDownInput (props) {
   }
 
   return (
-    <>
+    <div className="up-down-input">
       <button
         className="up-down-input-decrement"
         title={downTooltip}
@@ -265,7 +265,7 @@ function UpDownInput (props) {
       >
         <FontAwesomeIcon icon={ICON_PLUS} />
       </button>
-    </>
+    </div>
   )
 }
 

--- a/assets/scripts/info_bubble/UpDownInput.jsx
+++ b/assets/scripts/info_bubble/UpDownInput.jsx
@@ -1,195 +1,189 @@
-import React from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { debounce } from 'lodash'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { ICON_MINUS, ICON_PLUS } from '../ui/icons'
 import './UpDownInput.scss'
 
-const EDIT_INPUT_DELAY = 200
+const EDIT_INPUT_DELAY = 800
 
-export default class UpDownInput extends React.Component {
-  static propTypes = {
-    // Raw input value must always be a number type which can be
-    // compared with the minValue and maxValue.
-    value: PropTypes.number,
-    minValue: PropTypes.number,
-    maxValue: PropTypes.number,
+UpDownInput.propTypes = {
+  // Raw input value must always be a number type which can be
+  // compared with the minValue and maxValue.
+  value: PropTypes.number,
+  minValue: PropTypes.number,
+  maxValue: PropTypes.number,
 
-    // Formatter functions are used to optionally format raw values
-    // for display. These functions should return a number or a string.
+  // Formatter functions are used to optionally format raw values
+  // for display. These functions should return a number or a string.
 
-    // `inputValueFormatter` formats a value that is displayed when
-    // a user has focused or hovered over the <input> element. If this
-    // function is unspecified, the display value remains the raw
-    // `value` prop.
-    inputValueFormatter: PropTypes.func,
+  // `inputValueFormatter` formats a value that is displayed when
+  // a user has focused or hovered over the <input> element. If this
+  // function is unspecified, the display value remains the raw
+  // `value` prop.
+  inputValueFormatter: PropTypes.func,
 
-    // `displayValueFormatter` formats a value that is displayed inside
-    // the <input> element when it is not being edited. If this
-    // function is unspecified, the display value remains the raw
-    // `value` prop.
-    displayValueFormatter: PropTypes.func,
+  // `displayValueFormatter` formats a value that is displayed inside
+  // the <input> element when it is not being edited. If this
+  // function is unspecified, the display value remains the raw
+  // `value` prop.
+  displayValueFormatter: PropTypes.func,
 
-    // Handler functions are specified by the parent component. These
-    // handlers should be responsible for validating raw inputs and
-    // updating street data.
-    onClickUp: PropTypes.func,
-    onClickDown: PropTypes.func,
-    onUpdatedValue: PropTypes.func,
+  // Handler functions are specified by the parent component. These
+  // handlers should be responsible for validating raw inputs and
+  // updating street data.
+  onClickUp: PropTypes.func,
+  onClickDown: PropTypes.func,
+  onUpdatedValue: PropTypes.func,
 
-    // When `true`, the input box and buttons are disabled
-    disabled: PropTypes.bool,
+  // When `true`, the input box and buttons are disabled
+  disabled: PropTypes.bool,
 
-    // Tooltip text
-    inputTooltip: PropTypes.string,
-    upTooltip: PropTypes.string,
-    downTooltip: PropTypes.string
-  }
+  // Tooltip text
+  inputTooltip: PropTypes.string,
+  upTooltip: PropTypes.string,
+  downTooltip: PropTypes.string
+}
 
-  static defaultProps = {
-    inputValueFormatter: (value) => value,
-    displayValueFormatter: (value) => value,
-    onClickUp: () => {},
-    onClickDown: () => {},
-    onUpdatedValue: () => {},
-    disabled: false,
-    inputTooltip: 'Change value',
-    upTooltip: 'Increment',
-    downTooltip: 'Decrement'
-  }
+function UpDownInput (props) {
+  // Destructure props with default values
+  const {
+    value,
+    minValue,
+    maxValue,
+    inputValueFormatter = (value) => value,
+    displayValueFormatter = (value) => value,
+    onClickUp = () => {},
+    onClickDown = () => {},
+    onUpdatedValue = () => {},
+    disabled = false,
+    inputTooltip = 'Change value',
+    upTooltip = 'Increment',
+    downTooltip = 'Decrement'
+  } = props
 
-  constructor (props) {
-    super(props)
+  const oldValue = useRef(null)
+  const inputEl = useRef()
 
-    this.oldValue = null
-    this.inputEl = React.createRef()
+  const [isEditing, setIsEditing] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
+  const [displayValue, setDisplayValue] = useState(value)
+  const [userInputValue, setUserInputValue] = useState(null)
 
-    this.state = {
-      isEditing: false,
-      isHovered: false,
-      displayValue: null
+  const debounceUpdateValue = debounce(onUpdatedValue, EDIT_INPUT_DELAY)
+
+  // Depending on what happens, set the display value of the <input> element.
+  useEffect(() => {
+    // If component is disabled, display nothing
+    if (disabled) {
+      setDisplayValue('')
+      return
     }
 
-    // Debounce `props.onUpdatedValue` to prevent rapid input changes from thrashing data
-    this.debounceUpdateValue = debounce(props.onUpdatedValue, EDIT_INPUT_DELAY)
-  }
-
-  /**
-   * If UI is not in user-editing mode, update the display
-   * when the value in store changes
-   *
-   * @param {Object} nextProps
-   */
-  static getDerivedStateFromProps (nextProps, prevState) {
-    if (!prevState.isEditing && !prevState.isHovered) {
-      return {
-        displayValue: nextProps.displayValueFormatter(nextProps.value)
+    // If input is being edited (or hovered, which displays its "raw" value),
+    // display the value without units. The `inputValueFormatter` function is
+    // run, which takes into account the user's preferred units.
+    if (isEditing || isHovered) {
+      if (userInputValue) {
+        // If there is user input, always display that
+        setDisplayValue(userInputValue)
+      } else {
+        // Otherwise, display the value from props
+        setDisplayValue(inputValueFormatter(value))
       }
+      return
     }
 
-    return {
-      value: nextProps.value
-    }
-  }
+    // In all other cases, display the "prettified" value inside the input,
+    // which is the "raw" value formatted using the correct unit conversion
+    // and unit label.
+    setDisplayValue(displayValueFormatter(value))
+  }, [
+    value,
+    userInputValue,
+    disabled,
+    isEditing,
+    isHovered,
+    inputValueFormatter,
+    displayValueFormatter
+  ])
 
   /**
    * If UI is going to enter user-editing mode, immediately
    * save the previous value in case editing is cancelled
-   *
-   * @param {Object} prevProps
-   * @param {Object} prevState
    */
-  componentDidUpdate (prevProps, prevState) {
-    if (!prevState.isEditing && this.state.isEditing) {
-      this.oldValue = prevProps.value
+  useEffect(() => {
+    if (isEditing === true) {
+      oldValue.current = value
+    } else {
+      // reset `userInputValue`
+      setUserInputValue(null)
     }
+    // We only want to save the old value once, not every time it changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEditing])
+
+  function handleClickIncrement (event) {
+    onClickUp(event)
   }
 
-  handleClickIncrement = (event) => {
-    this.props.onClickUp(event)
+  function handleClickDecrement (event) {
+    onClickDown(event)
   }
 
-  handleClickDecrement = (event) => {
-    this.props.onClickDown(event)
+  function handleInputClick (event) {
+    setIsEditing(true)
   }
 
-  handleInputChange = (event) => {
+  function handleInputChange (event) {
     const value = event.target.value
 
     // Update the input element to display user input
-    this.setState({
-      isEditing: true,
-      displayValue: value
-    })
+    setUserInputValue(value)
 
     // Send the value to the parent's handler function
-    // using the debounced version of `props.onUpdatedValue`
-    this.debounceUpdateValue(value)
+    // using the debounced version of `onUpdatedValue`
+    debounceUpdateValue(value)
   }
 
-  handleInputClick = (event) => {
-    const el = event.target
-
-    this.setState({
-      isEditing: true,
-      displayValue: this.props.inputValueFormatter(this.props.value)
-    })
-
-    if (document.activeElement !== el) {
-      el.select()
+  function handleInputFocus (event) {
+    // Automatically select the value on focus so that it's easy to start
+    // typing new values. In React, this only works if the .select() is called
+    // at the end of the execution stack, so we put it inside a setTimeout()
+    // with a timeout of zero. We also must store the reference to the event
+    // target because the React synthetic event will not persist into the
+    // `setTimeout` function.
+    const target = event.target
+    if (document.activeElement !== target) {
+      window.setTimeout(() => {
+        target.select()
+      }, 0)
     }
   }
 
-  handleInputDoubleClick = (event) => {
-    const el = event.target
-    el.select()
+  function handleInputBlur (event) {
+    setIsEditing(false)
   }
 
-  handleInputFocus = (event) => {
-    const el = event.target
+  function handleInputMouseDown (event) {
+    // Bail if already in editing mode.
+    if (isEditing) return
 
-    if (document.activeElement !== el) {
-      el.select()
-    }
-  }
-
-  /**
-   * On blur, input shows prettified value.
-   */
-  handleInputBlur = (event) => {
-    this.setState({
-      isEditing: false,
-      displayValue: this.props.displayValueFormatter(this.props.value)
-    })
-  }
-
-  /**
-   * Prevent mousedown event from resetting the input view.
-   */
-  handleInputMouseDown = (event) => {
-    this.setState({
-      isEditing: true,
-      displayValue: this.props.inputValueFormatter(this.props.value)
-    })
+    setIsEditing(true)
   }
 
   /**
    * On mouse over, UI assumes user is ready to edit.
    */
-  handleInputMouseOver = (event) => {
+  function handleInputMouseOver (event) {
     // Bail if already in editing mode.
-    if (this.state.isEditing) return
+    if (isEditing) return
 
-    this.setState({
-      isHovered: true,
-      displayValue: this.props.inputValueFormatter(this.props.value)
-    })
+    setIsHovered(true)
 
-    // Automatically select the value on hover so that it's easy to start typing new values.
-    // In React, this only works if the .select() is called at the end of the execution
-    // stack, so we put it inside a setTimeout() with a timeout of zero. We also must
-    // store the reference to the event target because the React synthetic event will
-    // not persist into the setTimeout function.
+    // Automatically select the value on hover so that it's easy to start
+    // typing new values. See comment in `handleInputFocus` about why we use
+    // a `setTimeout` with a 0 time value here.
     const target = event.target
     window.setTimeout(() => {
       target.focus()
@@ -200,100 +194,79 @@ export default class UpDownInput extends React.Component {
   /**
    * On mouse out, if user is not editing, UI returns to default view.
    */
-  handleInputMouseOut = (event) => {
+  function handleInputMouseOut (event) {
     // Bail if already in editing mode.
-    if (this.state.isEditing) return
+    if (isEditing) return
 
-    this.setState({
-      isHovered: false,
-      displayValue: this.props.displayValueFormatter(this.props.value)
-    })
+    setIsHovered(false)
 
     event.target.blur()
   }
 
-  handleInputKeyDown = (event) => {
+  function handleInputKeyDown (event) {
     switch (event.key) {
       case 'Enter':
-        this.props.onUpdatedValue(event.target.value)
+        onUpdatedValue(event.target.value)
 
-        this.setState({
-          isEditing: false
-        })
+        setIsEditing(false)
 
-        this.inputEl.current.focus()
-        this.inputEl.current.select()
+        inputEl.current.focus()
+        inputEl.current.select()
 
         break
       case 'Esc': // IE/Edge specific value
       case 'Escape':
         // Lose focus from input but place focus on body
-        this.inputEl.current.blur()
+        inputEl.current.blur()
         document.body.focus()
 
         // Reset editing or hover state
-        this.setState({
-          isEditing: false,
-          isHovered: false
-        })
+        setIsEditing(false)
+        setIsHovered(false)
 
-        this.props.onUpdatedValue(this.oldValue)
+        onUpdatedValue(oldValue.current)
         break
     }
   }
 
-  renderInputEl = () => (
-    <input
-      type="text"
-      className="up-down-input-element"
-      title={this.props.inputTooltip}
-      disabled={this.props.disabled}
-      value={this.props.disabled ? '' : this.state.displayValue}
-      onChange={this.handleInputChange}
-      onClick={this.handleInputClick}
-      onDoubleClick={this.handleInputDoubleClick}
-      onFocus={this.handleInputFocus}
-      onBlur={this.handleInputBlur}
-      onMouseDown={this.handleInputMouseDown}
-      onMouseOver={this.handleInputMouseOver}
-      onMouseOut={this.handleInputMouseOut}
-      onKeyDown={this.handleInputKeyDown}
-      ref={this.inputEl}
-    />
+  return (
+    <>
+      <button
+        className="up-down-input-decrement"
+        title={downTooltip}
+        tabIndex={-1}
+        onClick={handleClickDecrement}
+        disabled={disabled || (minValue ? value <= minValue : false)}
+      >
+        <FontAwesomeIcon icon={ICON_MINUS} />
+      </button>
+      <input
+        type="text"
+        className="up-down-input-element"
+        title={inputTooltip}
+        disabled={disabled}
+        value={displayValue}
+        onChange={handleInputChange}
+        onClick={handleInputClick}
+        onFocus={handleInputFocus}
+        onBlur={handleInputBlur}
+        onMouseDown={handleInputMouseDown}
+        onMouseOver={handleInputMouseOver}
+        onMouseOut={handleInputMouseOut}
+        onKeyDown={handleInputKeyDown}
+        ref={inputEl}
+      />
+      <button
+        className="up-down-input-increment"
+        title={upTooltip}
+        tabIndex={-1}
+        onClick={handleClickIncrement}
+        disabled={disabled || (maxValue ? value >= maxValue : false)}
+      >
+        <FontAwesomeIcon icon={ICON_PLUS} />
+      </button>
+    </>
   )
-
-  /**
-   * @todo make minValue and maxValue optional
-   */
-  render () {
-    return (
-      <>
-        <button
-          className="up-down-input-decrement"
-          title={this.props.downTooltip}
-          tabIndex={-1}
-          onClick={this.handleClickDecrement}
-          disabled={
-            this.props.disabled || this.props.value <= this.props.minValue
-          }
-        >
-          <FontAwesomeIcon icon={ICON_MINUS} />
-        </button>
-
-        {this.renderInputEl()}
-
-        <button
-          className="up-down-input-increment"
-          title={this.props.upTooltip}
-          tabIndex={-1}
-          onClick={this.handleClickIncrement}
-          disabled={
-            this.props.disabled || this.props.value >= this.props.maxValue
-          }
-        >
-          <FontAwesomeIcon icon={ICON_PLUS} />
-        </button>
-      </>
-    )
-  }
 }
+
+export default UpDownInput

--- a/assets/scripts/info_bubble/UpDownInput.scss
+++ b/assets/scripts/info_bubble/UpDownInput.scss
@@ -2,13 +2,28 @@
 
 .up-down-input-element {
   width: 50px;
-  margin: 0 3px;
   font-family: $font-family;
   text-align: center;
   background: $form-element-background;
   border: 1px solid $form-element-border;
+  border-left: 0;
+  border-right: 0;
   vertical-align: bottom;
   height: 30px;
   line-height: 22px;
   outline: none;
+}
+
+.up-down-input-decrement {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.up-down-input-increment {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.up-down-input button svg {
+  color: $colour-midnight-700 !important;
 }

--- a/assets/scripts/info_bubble/__tests__/InfoBubble.test.js
+++ b/assets/scripts/info_bubble/__tests__/InfoBubble.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import React from 'react'
-import { fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithReduxAndIntl } from '../../../../test/helpers/render'
 import InfoBubble from '../InfoBubble'
 import {
@@ -35,7 +35,15 @@ const initialState = {
     activeSegment: 0
   },
   street: {
-    segments: [],
+    segments: [
+      {
+        type: 'streetcar',
+        variantString: 'inbound|regular',
+        segmentType: 'streetcar',
+        id: '1',
+        width: 200
+      }
+    ],
     leftBuildingVariant: 'grass',
     rightBuildingVariant: 'grass'
   },
@@ -47,13 +55,15 @@ const initialState = {
 
 describe('InfoBubble', () => {
   it('renders', () => {
-    const wrapper = renderWithReduxAndIntl(<InfoBubble />, { initialState })
-    expect(wrapper.asFragment()).toMatchSnapshot()
+    const { asFragment } = renderWithReduxAndIntl(<InfoBubble />, {
+      initialState
+    })
+    expect(asFragment()).toMatchSnapshot()
   })
 
   // TODO: this passes, but it doesn't render the <Description /> child component.
   it('shows description', () => {
-    const wrapper = renderWithReduxAndIntl(<InfoBubble />, {
+    const { asFragment } = renderWithReduxAndIntl(<InfoBubble />, {
       initialState: {
         ...initialState,
         infoBubble: {
@@ -64,11 +74,11 @@ describe('InfoBubble', () => {
       }
     })
 
-    expect(wrapper.asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot()
   })
 
   it('is visible', () => {
-    const wrapper = renderWithReduxAndIntl(<InfoBubble />, {
+    const { asFragment } = renderWithReduxAndIntl(<InfoBubble />, {
       initialState: {
         ...initialState,
         infoBubble: {
@@ -79,11 +89,11 @@ describe('InfoBubble', () => {
       }
     })
 
-    expect(wrapper.asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot()
   })
 
   it('shows building left info bubble', () => {
-    const wrapper = renderWithReduxAndIntl(<InfoBubble />, {
+    const { asFragment } = renderWithReduxAndIntl(<InfoBubble />, {
       initialState: {
         ...initialState,
         ui: {
@@ -92,11 +102,11 @@ describe('InfoBubble', () => {
       }
     })
 
-    expect(wrapper.asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot()
   })
 
   it('shows building right info bubble', () => {
-    const wrapper = renderWithReduxAndIntl(<InfoBubble />, {
+    const { asFragment } = renderWithReduxAndIntl(<InfoBubble />, {
       initialState: {
         ...initialState,
         ui: {
@@ -105,26 +115,18 @@ describe('InfoBubble', () => {
       }
     })
 
-    expect(wrapper.asFragment()).toMatchSnapshot()
+    expect(asFragment()).toMatchSnapshot()
   })
 
-  describe('interactions', () => {
-    it('set info bubble mouse inside', () => {
-      const { container, store } = renderWithReduxAndIntl(<InfoBubble />, {
-        initialState
-      })
-      fireEvent.mouseEnter(container.firstChild)
-
-      expect(store.getState().infoBubble.mouseInside).toEqual(true)
+  it('sets info bubble mouse inside', () => {
+    const { container, store } = renderWithReduxAndIntl(<InfoBubble />, {
+      initialState
     })
 
-    it('does not set info bubble mouse inside', () => {
-      const { container, store } = renderWithReduxAndIntl(<InfoBubble />, {
-        initialState
-      })
-      fireEvent.mouseLeave(container.firstChild)
+    userEvent.hover(container.firstChild)
+    expect(store.getState().infoBubble.mouseInside).toEqual(true)
 
-      expect(store.getState().infoBubble.mouseInside).toEqual(false)
-    })
+    userEvent.unhover(container.firstChild)
+    expect(store.getState().infoBubble.mouseInside).toEqual(false)
   })
 })

--- a/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
+++ b/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
@@ -1,7 +1,15 @@
 /* eslint-env jest */
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import UpDownInput from '../UpDownInput'
+
+// Mock out lodash's `debounce` method so that the debounced
+// `onUpdatedValue` callback will be executed immediately when
+// called (we are not implementing the debounce in this test)
+jest.mock('lodash', () => ({
+  debounce: (fn) => fn
+}))
 
 const inputValueFormatter = jest.fn((value) => value)
 const displayValueFormatter = jest.fn((value) => value)
@@ -18,7 +26,6 @@ const defaultProps = {
   onClickUp: handleUp,
   onClickDown: handleDown,
   onUpdatedValue: handleUpdate,
-  inputTooltip: 'input',
   upTooltip: 'up',
   downTooltip: 'down'
 }
@@ -31,30 +38,29 @@ describe('UpDownInput', () => {
   })
 
   it('behaves', () => {
-    const wrapper = render(<UpDownInput {...defaultProps} />)
+    render(<UpDownInput {...defaultProps} />)
 
-    // const inputEl = wrapper.getByTitle('input')
-    const upButton = wrapper.getByTitle('up')
-    const downButton = wrapper.getByTitle('down')
+    const inputEl = screen.getByRole('textbox')
+    const upButton = screen.getByTitle('up')
+    const downButton = screen.getByTitle('down')
 
     // Ensure handler functions are called
-    fireEvent.click(upButton)
+    userEvent.click(upButton)
     expect(handleUp).toHaveBeenCalled()
 
-    fireEvent.click(downButton)
+    userEvent.click(downButton)
     expect(handleDown).toHaveBeenCalled()
 
-    // TODO: This is not being called
-    // fireEvent.keyDown(inputEl, { key: 'A' })
-    // expect(handleUpdate).toHaveBeenCalled()
+    userEvent.type(inputEl, 'abc')
+    expect(handleUpdate).toHaveBeenCalledTimes(3)
   })
 
   it('renders inputs as disabled', () => {
-    const wrapper = render(<UpDownInput {...defaultProps} disabled={true} />)
+    render(<UpDownInput {...defaultProps} disabled={true} />)
 
-    const inputEl = wrapper.getByTitle('input')
-    const upButton = wrapper.getByTitle('up')
-    const downButton = wrapper.getByTitle('down')
+    const inputEl = screen.getByRole('textbox')
+    const upButton = screen.getByTitle('up')
+    const downButton = screen.getByTitle('down')
 
     expect(inputEl).toBeDisabled()
     expect(upButton).toBeDisabled()
@@ -62,20 +68,20 @@ describe('UpDownInput', () => {
   })
 
   it('disables down button when value is the min value', () => {
-    const wrapper = render(<UpDownInput {...defaultProps} value={1} />)
+    render(<UpDownInput {...defaultProps} value={1} />)
 
-    const upButton = wrapper.getByTitle('up')
-    const downButton = wrapper.getByTitle('down')
+    const upButton = screen.getByTitle('up')
+    const downButton = screen.getByTitle('down')
 
     expect(upButton).not.toBeDisabled()
     expect(downButton).toBeDisabled()
   })
 
   it('disables up button when value is the max value', () => {
-    const wrapper = render(<UpDownInput {...defaultProps} value={10} />)
+    render(<UpDownInput {...defaultProps} value={10} />)
 
-    const upButton = wrapper.getByTitle('up')
-    const downButton = wrapper.getByTitle('down')
+    const upButton = screen.getByTitle('up')
+    const downButton = screen.getByTitle('down')
 
     expect(upButton).toBeDisabled()
     expect(downButton).not.toBeDisabled()

--- a/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
+++ b/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
@@ -34,7 +34,7 @@ describe('UpDownInput', () => {
   })
 
   it('behaves', () => {
-    render(<UpDownInput {...defaultProps} />)
+    render(<UpDownInput {...defaultProps} allowAutoUpdate={true} />)
 
     const inputEl = screen.getByRole('textbox')
     const upButton = screen.getByTitle('up')
@@ -172,5 +172,29 @@ describe('UpDownInput', () => {
 
     expect(upButton).toBeDisabled()
     expect(downButton).not.toBeDisabled()
+  })
+
+  // Fixes a bug where dirty input could be remembered between different
+  // types of UI interactions. This test is currently skipped.
+  // TODO: up/down handlers should affect and re-render component
+  it.skip('resets "dirty" input if user switches to +/- buttons', () => {
+    render(<UpDownInput {...defaultProps} />)
+
+    const inputEl = screen.getByRole('textbox')
+    const upButton = screen.getByTitle('up')
+
+    userEvent.clear(inputEl)
+    userEvent.type(inputEl, '6{enter}')
+    userEvent.click(upButton)
+    expect(inputEl.value).toBe('7')
+
+    // Expect value on hover to reflect new value (7), not previous "dirty"
+    // value (6)
+    userEvent.hover(inputEl)
+    expect(inputEl.value).toBe('7')
+
+    // User unhovers over the input
+    userEvent.unhover(inputEl)
+    expect(inputEl.value).toBe('7')
   })
 })

--- a/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
+++ b/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
@@ -11,8 +11,6 @@ jest.mock('lodash', () => ({
   debounce: (fn) => fn
 }))
 
-const inputValueFormatter = jest.fn((value) => value)
-const displayValueFormatter = jest.fn((value) => value)
 const handleUp = jest.fn()
 const handleDown = jest.fn()
 const handleUpdate = jest.fn()
@@ -21,8 +19,6 @@ const defaultProps = {
   value: 5,
   minValue: 1,
   maxValue: 10,
-  inputValueFormatter: inputValueFormatter,
-  displayValueFormatter: displayValueFormatter,
   onClickUp: handleUp,
   onClickDown: handleDown,
   onUpdatedValue: handleUpdate,
@@ -44,6 +40,9 @@ describe('UpDownInput', () => {
     const upButton = screen.getByTitle('up')
     const downButton = screen.getByTitle('down')
 
+    // Expect input value to be displayed
+    expect(inputEl.value).toBe('5')
+
     // Ensure handler functions are called
     userEvent.click(upButton)
     expect(handleUp).toHaveBeenCalled()
@@ -53,6 +52,94 @@ describe('UpDownInput', () => {
 
     userEvent.type(inputEl, 'abc')
     expect(handleUpdate).toHaveBeenCalledTimes(3)
+  })
+
+  // If we don't handle nullish values, React throws a warning about
+  // uncontrolled components, but that won't fail the test because the <input>
+  // element has, by default, an empty string value when the value isn't
+  // explicitly set. If we don't handle nullish values, we will see warnings
+  // in the console log (rather than failures)
+  it('renders empty string in input if the value prop is null', () => {
+    render(<UpDownInput {...defaultProps} value={null} />)
+    expect(screen.getByRole('textbox').value).toBe('')
+  })
+
+  it('renders empty string in input if the value prop is undefined', () => {
+    render(<UpDownInput {...defaultProps} value={undefined} />)
+    expect(screen.getByRole('textbox').value).toBe('')
+  })
+
+  it('formats values using `inputValueFormatter` and `displayValueFormatter`', () => {
+    render(
+      <UpDownInput
+        {...defaultProps}
+        inputValueFormatter={(value) => value}
+        displayValueFormatter={(value) => `${value} bar`}
+      />
+    )
+
+    // When first rendered, the display formatter is called
+    const inputEl = screen.getByRole('textbox')
+    expect(inputEl.value).toBe('5 bar')
+
+    // User clicks on the input, so the input formatter is called
+    userEvent.click(inputEl)
+    expect(inputEl.value).toBe('5')
+
+    // User clicks outside the input, setting active element elsewhere.
+    // The display formatter should now be called again
+    userEvent.click(inputEl.parentNode)
+    expect(inputEl.value).toBe('5 bar')
+  })
+
+  // Same as above, but with mouse interaction
+  it('formats values when hovering over or out on the input element', () => {
+    render(
+      <UpDownInput
+        {...defaultProps}
+        inputValueFormatter={(value) => value}
+        displayValueFormatter={(value) => `${value} bar`}
+      />
+    )
+
+    // When first rendered, the display formatter is called
+    const inputEl = screen.getByRole('textbox')
+    expect(inputEl.value).toBe('5 bar')
+
+    // User hovers over the input, so the input formatter is called
+    // Note: the input content is also selected, but we are not testing for that
+    userEvent.hover(inputEl)
+    expect(inputEl.value).toBe('5')
+
+    // User unhovers over the input
+    // The display formatter should now be called again
+    userEvent.unhover(inputEl)
+    expect(inputEl.value).toBe('5 bar')
+  })
+
+  it('handles "Enter" key as confirm action', () => {
+    render(<UpDownInput {...defaultProps} />)
+
+    const inputEl = screen.getByRole('textbox')
+
+    userEvent.clear(inputEl)
+    userEvent.type(inputEl, '3{enter}')
+
+    expect(handleUpdate).toHaveBeenLastCalledWith('3')
+  })
+
+  it('handles "Escape" key to revert input', () => {
+    render(<UpDownInput {...defaultProps} />)
+
+    const inputEl = screen.getByRole('textbox')
+
+    userEvent.clear(inputEl)
+    userEvent.type(inputEl, '3{esc}')
+
+    // When this is reverted, the `handleUpdate` callback is called
+    // with the original value, which is a number type, rather than
+    // a string type (which would be the value of the input element)
+    expect(handleUpdate).toHaveBeenLastCalledWith(5)
   })
 
   it('renders inputs as disabled', () => {

--- a/assets/scripts/info_bubble/__tests__/WidthControl.test.js
+++ b/assets/scripts/info_bubble/__tests__/WidthControl.test.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 import React from 'react'
-import { fireEvent } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { renderWithReduxAndIntl } from '../../../../test/helpers/render'
-
 import WidthControl from '../WidthControl'
 
 jest.mock('../../app/routing', () => {})
@@ -22,35 +22,38 @@ describe('WidthControl', () => {
   })
 
   it('renders', () => {
-    const wrapper = renderWithReduxAndIntl(<WidthControl />, {
-      initialState: { street: { segments: [segment] } }
-    })
-    expect(wrapper.asFragment()).toMatchSnapshot()
+    const { asFragment } = renderWithReduxAndIntl(
+      <WidthControl position={activeElement} />,
+      {
+        initialState: { street: { segments: [segment] } }
+      }
+    )
+    expect(asFragment()).toMatchSnapshot()
   })
 
   describe('increase width', () => {
     it('increaeses store width', () => {
-      const wrapper = renderWithReduxAndIntl(
+      const { store } = renderWithReduxAndIntl(
         <WidthControl position={activeElement} />,
         { initialState: { street: { segments: [segment], units: 1 } } }
       )
-      fireEvent.click(wrapper.getByTitle(/Increase width/i))
-      expect(
-        wrapper.store.getState().street.segments[activeElement].width
-      ).toEqual(200.5)
+      userEvent.click(screen.getByTitle(/Increase width/i))
+      expect(store.getState().street.segments[activeElement].width).toEqual(
+        200.5
+      )
     })
   })
 
   describe('decrease width', () => {
     it('decreaeses store width', () => {
-      const wrapper = renderWithReduxAndIntl(
+      const { store } = renderWithReduxAndIntl(
         <WidthControl position={activeElement} />,
         { initialState: { street: { segments: [segment], units: 1 } } }
       )
-      fireEvent.click(wrapper.getByTitle(/Decrease width/i))
-      expect(
-        wrapper.store.getState().street.segments[activeElement].width
-      ).toEqual(199.5)
+      userEvent.click(screen.getByTitle(/Decrease width/i))
+      expect(store.getState().street.segments[activeElement].width).toEqual(
+        199.5
+      )
     })
   })
 })

--- a/assets/scripts/info_bubble/__tests__/__snapshots__/InfoBubble.test.js.snap
+++ b/assets/scripts/info_bubble/__tests__/__snapshots__/InfoBubble.test.js.snap
@@ -37,31 +37,35 @@ exports[`InfoBubble is visible 1`] = `
       <div
         class="non-variant"
       >
-        <button
-          class="up-down-input-decrement"
-          disabled=""
-          tabindex="-1"
-          title="Decrease width (hold Shift for more precision)"
+        <div
+          class="up-down-input"
         >
-          <svg
-            class="svg-inline--fa fa-minus"
+          <button
+            class="up-down-input-decrement"
+            disabled=""
+            tabindex="-1"
+            title="Decrease width (hold Shift for more precision)"
+          >
+            <svg
+              class="svg-inline--fa fa-minus"
+            />
+          </button>
+          <input
+            class="up-down-input-element"
+            title="Change width of the segment"
+            type="text"
+            value="0 m"
           />
-        </button>
-        <input
-          class="up-down-input-element"
-          title="Change width of the segment"
-          type="text"
-          value="0 m"
-        />
-        <button
-          class="up-down-input-increment"
-          tabindex="-1"
-          title="Increase width (hold Shift for more precision)"
-        >
-          <svg
-            class="svg-inline--fa fa-plus"
-          />
-        </button>
+          <button
+            class="up-down-input-increment"
+            tabindex="-1"
+            title="Increase width (hold Shift for more precision)"
+          >
+            <svg
+              class="svg-inline--fa fa-plus"
+            />
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -105,31 +109,35 @@ exports[`InfoBubble renders 1`] = `
       <div
         class="non-variant"
       >
-        <button
-          class="up-down-input-decrement"
-          disabled=""
-          tabindex="-1"
-          title="Decrease width (hold Shift for more precision)"
+        <div
+          class="up-down-input"
         >
-          <svg
-            class="svg-inline--fa fa-minus"
+          <button
+            class="up-down-input-decrement"
+            disabled=""
+            tabindex="-1"
+            title="Decrease width (hold Shift for more precision)"
+          >
+            <svg
+              class="svg-inline--fa fa-minus"
+            />
+          </button>
+          <input
+            class="up-down-input-element"
+            title="Change width of the segment"
+            type="text"
+            value="0 m"
           />
-        </button>
-        <input
-          class="up-down-input-element"
-          title="Change width of the segment"
-          type="text"
-          value="0 m"
-        />
-        <button
-          class="up-down-input-increment"
-          tabindex="-1"
-          title="Increase width (hold Shift for more precision)"
-        >
-          <svg
-            class="svg-inline--fa fa-plus"
-          />
-        </button>
+          <button
+            class="up-down-input-increment"
+            tabindex="-1"
+            title="Increase width (hold Shift for more precision)"
+          >
+            <svg
+              class="svg-inline--fa fa-plus"
+            />
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -267,33 +275,37 @@ exports[`InfoBubble shows building left info bubble 1`] = `
       <div
         class="non-variant building-height"
       >
-        <button
-          class="up-down-input-decrement"
-          disabled=""
-          tabindex="-1"
-          title="Remove floor"
+        <div
+          class="up-down-input"
         >
-          <svg
-            class="svg-inline--fa fa-minus"
+          <button
+            class="up-down-input-decrement"
+            disabled=""
+            tabindex="-1"
+            title="Remove floor"
+          >
+            <svg
+              class="svg-inline--fa fa-minus"
+            />
+          </button>
+          <input
+            class="up-down-input-element"
+            disabled=""
+            title="Change the number of floors"
+            type="text"
+            value=""
           />
-        </button>
-        <input
-          class="up-down-input-element"
-          disabled=""
-          title="Change the number of floors"
-          type="text"
-          value=""
-        />
-        <button
-          class="up-down-input-increment"
-          disabled=""
-          tabindex="-1"
-          title="Add floor"
-        >
-          <svg
-            class="svg-inline--fa fa-plus"
-          />
-        </button>
+          <button
+            class="up-down-input-increment"
+            disabled=""
+            tabindex="-1"
+            title="Add floor"
+          >
+            <svg
+              class="svg-inline--fa fa-plus"
+            />
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -431,33 +443,37 @@ exports[`InfoBubble shows building right info bubble 1`] = `
       <div
         class="non-variant building-height"
       >
-        <button
-          class="up-down-input-decrement"
-          disabled=""
-          tabindex="-1"
-          title="Remove floor"
+        <div
+          class="up-down-input"
         >
-          <svg
-            class="svg-inline--fa fa-minus"
+          <button
+            class="up-down-input-decrement"
+            disabled=""
+            tabindex="-1"
+            title="Remove floor"
+          >
+            <svg
+              class="svg-inline--fa fa-minus"
+            />
+          </button>
+          <input
+            class="up-down-input-element"
+            disabled=""
+            title="Change the number of floors"
+            type="text"
+            value=""
           />
-        </button>
-        <input
-          class="up-down-input-element"
-          disabled=""
-          title="Change the number of floors"
-          type="text"
-          value=""
-        />
-        <button
-          class="up-down-input-increment"
-          disabled=""
-          tabindex="-1"
-          title="Add floor"
-        >
-          <svg
-            class="svg-inline--fa fa-plus"
-          />
-        </button>
+          <button
+            class="up-down-input-increment"
+            disabled=""
+            tabindex="-1"
+            title="Add floor"
+          >
+            <svg
+              class="svg-inline--fa fa-plus"
+            />
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -501,31 +517,35 @@ exports[`InfoBubble shows description 1`] = `
       <div
         class="non-variant"
       >
-        <button
-          class="up-down-input-decrement"
-          disabled=""
-          tabindex="-1"
-          title="Decrease width (hold Shift for more precision)"
+        <div
+          class="up-down-input"
         >
-          <svg
-            class="svg-inline--fa fa-minus"
+          <button
+            class="up-down-input-decrement"
+            disabled=""
+            tabindex="-1"
+            title="Decrease width (hold Shift for more precision)"
+          >
+            <svg
+              class="svg-inline--fa fa-minus"
+            />
+          </button>
+          <input
+            class="up-down-input-element"
+            title="Change width of the segment"
+            type="text"
+            value="0 m"
           />
-        </button>
-        <input
-          class="up-down-input-element"
-          title="Change width of the segment"
-          type="text"
-          value="0 m"
-        />
-        <button
-          class="up-down-input-increment"
-          tabindex="-1"
-          title="Increase width (hold Shift for more precision)"
-        >
-          <svg
-            class="svg-inline--fa fa-plus"
-          />
-        </button>
+          <button
+            class="up-down-input-increment"
+            tabindex="-1"
+            title="Increase width (hold Shift for more precision)"
+          >
+            <svg
+              class="svg-inline--fa fa-plus"
+            />
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/assets/scripts/info_bubble/__tests__/__snapshots__/InfoBubble.test.js.snap
+++ b/assets/scripts/info_bubble/__tests__/__snapshots__/InfoBubble.test.js.snap
@@ -12,6 +12,7 @@ exports[`InfoBubble is visible 1`] = `
       <div
         class="info-bubble-label info-bubble-label-editable"
       >
+        Streetcar
         <span
           class="info-bubble-label-editable-icon"
         >
@@ -35,6 +36,82 @@ exports[`InfoBubble is visible 1`] = `
       class="info-bubble-controls"
     >
       <div
+        class="variants"
+      >
+        <button
+          class="variant-selected"
+          disabled=""
+          title="Inbound"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-direction-inbound"
+            />
+          </svg>
+        </button>
+        <button
+          title="Outbound"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-direction-outbound"
+            />
+          </svg>
+        </button>
+        <hr />
+        <button
+          class="variant-selected"
+          disabled=""
+          title="Asphalt"
+        >
+          <svg
+            class="icon"
+            style="fill: #292a29;"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-asphalt"
+            />
+          </svg>
+        </button>
+        <button
+          title="Red lane"
+        >
+          <svg
+            class="icon"
+            style="fill: #9b1f22;"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-asphalt"
+            />
+          </svg>
+        </button>
+        <button
+          title="Grass"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-grass"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
         class="non-variant"
       >
         <div
@@ -42,7 +119,6 @@ exports[`InfoBubble is visible 1`] = `
         >
           <button
             class="up-down-input-decrement"
-            disabled=""
             tabindex="-1"
             title="Decrease width (hold Shift for more precision)"
           >
@@ -54,7 +130,7 @@ exports[`InfoBubble is visible 1`] = `
             class="up-down-input-element"
             title="Change width of the segment"
             type="text"
-            value="0 m"
+            value="60 m"
           />
           <button
             class="up-down-input-increment"
@@ -84,6 +160,7 @@ exports[`InfoBubble renders 1`] = `
       <div
         class="info-bubble-label info-bubble-label-editable"
       >
+        Streetcar
         <span
           class="info-bubble-label-editable-icon"
         >
@@ -107,6 +184,82 @@ exports[`InfoBubble renders 1`] = `
       class="info-bubble-controls"
     >
       <div
+        class="variants"
+      >
+        <button
+          class="variant-selected"
+          disabled=""
+          title="Inbound"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-direction-inbound"
+            />
+          </svg>
+        </button>
+        <button
+          title="Outbound"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-direction-outbound"
+            />
+          </svg>
+        </button>
+        <hr />
+        <button
+          class="variant-selected"
+          disabled=""
+          title="Asphalt"
+        >
+          <svg
+            class="icon"
+            style="fill: #292a29;"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-asphalt"
+            />
+          </svg>
+        </button>
+        <button
+          title="Red lane"
+        >
+          <svg
+            class="icon"
+            style="fill: #9b1f22;"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-asphalt"
+            />
+          </svg>
+        </button>
+        <button
+          title="Grass"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-grass"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
         class="non-variant"
       >
         <div
@@ -114,7 +267,6 @@ exports[`InfoBubble renders 1`] = `
         >
           <button
             class="up-down-input-decrement"
-            disabled=""
             tabindex="-1"
             title="Decrease width (hold Shift for more precision)"
           >
@@ -126,7 +278,7 @@ exports[`InfoBubble renders 1`] = `
             class="up-down-input-element"
             title="Change width of the segment"
             type="text"
-            value="0 m"
+            value="60 m"
           />
           <button
             class="up-down-input-increment"
@@ -492,6 +644,7 @@ exports[`InfoBubble shows description 1`] = `
       <div
         class="info-bubble-label info-bubble-label-editable"
       >
+        Streetcar
         <span
           class="info-bubble-label-editable-icon"
         >
@@ -515,6 +668,82 @@ exports[`InfoBubble shows description 1`] = `
       class="info-bubble-controls"
     >
       <div
+        class="variants"
+      >
+        <button
+          class="variant-selected"
+          disabled=""
+          title="Inbound"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-direction-inbound"
+            />
+          </svg>
+        </button>
+        <button
+          title="Outbound"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-direction-outbound"
+            />
+          </svg>
+        </button>
+        <hr />
+        <button
+          class="variant-selected"
+          disabled=""
+          title="Asphalt"
+        >
+          <svg
+            class="icon"
+            style="fill: #292a29;"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-asphalt"
+            />
+          </svg>
+        </button>
+        <button
+          title="Red lane"
+        >
+          <svg
+            class="icon"
+            style="fill: #9b1f22;"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-asphalt"
+            />
+          </svg>
+        </button>
+        <button
+          title="Grass"
+        >
+          <svg
+            class="icon"
+            xmlns="http://www.w3.org/1999/svg"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
+          >
+            <use
+              xlink:href="#icon-grass"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
         class="non-variant"
       >
         <div
@@ -522,7 +751,6 @@ exports[`InfoBubble shows description 1`] = `
         >
           <button
             class="up-down-input-decrement"
-            disabled=""
             tabindex="-1"
             title="Decrease width (hold Shift for more precision)"
           >
@@ -534,7 +762,7 @@ exports[`InfoBubble shows description 1`] = `
             class="up-down-input-element"
             title="Change width of the segment"
             type="text"
-            value="0 m"
+            value="60 m"
           />
           <button
             class="up-down-input-increment"

--- a/assets/scripts/info_bubble/__tests__/__snapshots__/WidthControl.test.js.snap
+++ b/assets/scripts/info_bubble/__tests__/__snapshots__/WidthControl.test.js.snap
@@ -5,31 +5,35 @@ exports[`WidthControl renders 1`] = `
   <div
     class="non-variant"
   >
-    <button
-      class="up-down-input-decrement"
-      disabled=""
-      tabindex="-1"
-      title="Decrease width (hold Shift for more precision)"
+    <div
+      class="up-down-input"
     >
-      <svg
-        class="svg-inline--fa fa-minus"
+      <button
+        class="up-down-input-decrement"
+        disabled=""
+        tabindex="-1"
+        title="Decrease width (hold Shift for more precision)"
+      >
+        <svg
+          class="svg-inline--fa fa-minus"
+        />
+      </button>
+      <input
+        class="up-down-input-element"
+        title="Change width of the segment"
+        type="text"
+        value="0 m"
       />
-    </button>
-    <input
-      class="up-down-input-element"
-      title="Change width of the segment"
-      type="text"
-      value="0 m"
-    />
-    <button
-      class="up-down-input-increment"
-      tabindex="-1"
-      title="Increase width (hold Shift for more precision)"
-    >
-      <svg
-        class="svg-inline--fa fa-plus"
-      />
-    </button>
+      <button
+        class="up-down-input-increment"
+        tabindex="-1"
+        title="Increase width (hold Shift for more precision)"
+      >
+        <svg
+          class="svg-inline--fa fa-plus"
+        />
+      </button>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/assets/scripts/info_bubble/__tests__/__snapshots__/WidthControl.test.js.snap
+++ b/assets/scripts/info_bubble/__tests__/__snapshots__/WidthControl.test.js.snap
@@ -10,7 +10,6 @@ exports[`WidthControl renders 1`] = `
     >
       <button
         class="up-down-input-decrement"
-        disabled=""
         tabindex="-1"
         title="Decrease width (hold Shift for more precision)"
       >
@@ -22,7 +21,7 @@ exports[`WidthControl renders 1`] = `
         class="up-down-input-element"
         title="Change width of the segment"
         type="text"
-        value="0 m"
+        value="60 m"
       />
       <button
         class="up-down-input-increment"

--- a/assets/scripts/menus/Menu.scss
+++ b/assets/scripts/menus/Menu.scss
@@ -36,7 +36,7 @@ $menu-box-shadow: $medium-box-shadow;
     display: block;
     position: relative;
     padding: 0.75em 2.5em;
-    border-bottom: 1px solid $ui-colour;
+    border-bottom: 1px solid $colour-turquoise-200;
     text-decoration: none;
     color: black;
 
@@ -45,11 +45,11 @@ $menu-box-shadow: $medium-box-shadow;
     }
 
     &:hover {
-      background: fade-out($ui-colour, 0.5);
+      background-color: $colour-turquoise-100;
     }
 
     &:active {
-      background: fade-out($ui-colour, 0.3);
+      background-color: $colour-turquoise-150;
     }
   }
 
@@ -94,8 +94,8 @@ body.safari .menu {
   list-style: none;
   padding: 0;
   margin: 0;
-  border-top: 1px solid #cde1ea;
-  border-bottom: 1px solid #cde1ea;
+  border-top: 1px solid $colour-turquoise-200;
+  border-bottom: 1px solid $colour-turquoise-200;
 
   // Remove the top border if menu group is the first element in a menu
   &:first-child {
@@ -120,7 +120,7 @@ body.safari .menu {
   cursor: pointer;
 
   &:hover {
-    background: fade-out($ui-colour, 0.5);
+    background-color: $colour-turquoise-100;
   }
 
   .fa-check {

--- a/assets/styles/_base.scss
+++ b/assets/styles/_base.scss
@@ -87,7 +87,7 @@ textarea {
 
 hr {
   border: 0;
-  border-top: 1px solid $hr-colour;
+  border-top: 1px solid $colour-turquoise-400;
   margin-top: 1em;
   margin-bottom: 1em;
 }

--- a/assets/styles/_buttons.scss
+++ b/assets/styles/_buttons.scss
@@ -23,22 +23,22 @@ a.button-like {
   border: 0;
   border-radius: $border-radius-medium;
   padding: 0.75em 2em;
-  background-color: $colour-turquoise-200;
-  color: black;
+  background-color: $colour-turquoise-225;
+  color: $colour-midnight-700;
   font-weight: bold;
   text-align: center;
   text-decoration: none;
 
   &:not([disabled]) .svg-inline--fa {
-    color: #231f20;
+    color: $colour-midnight-700;
   }
 
   &:hover {
-    background-color: $colour-turquoise-210;
+    background-color: $colour-turquoise-250;
   }
 
   &:active {
-    background-color: $colour-turquoise-220;
+    background-color: $colour-turquoise-250;
   }
 
   &[disabled] {

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -17,35 +17,6 @@ $border-radius-medium: 4px;
 $border-radius-large: 6px;
 $menu-side-inset: $left-right-inset - 20px;
 
-// Colours
-$background-dirt-colour: rgb(53, 45, 39);
-$sky-colour: rgb(169, 204, 219);
-$ui-colour: lighten($sky-colour, 10%);
-$form-element-background: lighten($ui-colour, 10%);
-$form-element-border: $ui-colour;
-$button-border-colour: darken($ui-colour, 10%);
-$button-border: 1px solid $button-border-colour;
-$alert-background: #fff0c0;
-$alert-border-colour: #ffd755;
-$alert-border: 5px solid $alert-border-colour;
-$off-white: rgb(247, 247, 247);
-$palette-background: $off-white;
-$menu-bar-background: $off-white;
-$bottom-background: rgb(216, 211, 203);
-$warning-colour: rgb(220, 20, 20);
-$segment-text: rgb(40, 35, 30);
-$segment-hover-text: lighten($segment-text, 30%);
-$segment-warning-text: $warning-colour;
-$empty-segment-text: fade-out($segment-text, 0.5);
-$segment-hover-background: rgba(255, 255, 255, 0.2);
-$light-text-colour: rgb(240, 240, 240);
-$info-bubble-background: white;
-$segment-width-rule: rgb(160, 160, 160);
-$street-name-text: black;
-$street-name-background: white;
-$hr-colour: darken($ui-colour, 10%);
-$control-disabled-colour: gray;
-
 // Brand colours
 $colour-emerald-700: rgb(12, 62, 22);
 $colour-emerald-600: rgb(35, 113, 55);
@@ -76,8 +47,39 @@ $colour-midnight-300: rgb(166, 178, 200);
 $colour-midnight-200: rgb(212, 219, 231);
 $colour-midnight-100: rgb(230, 235, 244);
 
-$colour-turquoise-210: color.scale($colour-turquoise-200, $lightness: -2%);
-$colour-turquoise-220: color.scale($colour-turquoise-200, $lightness: -4%);
+$colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
+$colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 10%);
+$colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
+$colour-turquoise-250: color.scale($colour-turquoise-200, $lightness: -10%);
+$colour-turquoise-425: color.scale($colour-turquoise-400, $lightness: -5%);
+$colour-turquoise-450: color.scale($colour-turquoise-400, $lightness: -10%);
+
+// Colours
+$background-dirt-colour: rgb(53, 45, 39);
+$sky-colour: rgb(169, 204, 219);
+$ui-colour: lighten($sky-colour, 10%);
+$form-element-background: $colour-turquoise-50;
+$form-element-border: $colour-turquoise-200;
+$button-border: 1px solid $colour-turquoise-400;
+$alert-background: #fff0c0;
+$alert-border-colour: #ffd755;
+$alert-border: 5px solid $alert-border-colour;
+$off-white: rgb(247, 247, 247);
+$palette-background: $off-white;
+$menu-bar-background: $off-white;
+$bottom-background: rgb(216, 211, 203);
+$warning-colour: rgb(220, 20, 20);
+$segment-text: rgb(40, 35, 30);
+$segment-hover-text: lighten($segment-text, 30%);
+$segment-warning-text: $warning-colour;
+$empty-segment-text: fade-out($segment-text, 0.5);
+$segment-hover-background: rgba(255, 255, 255, 0.2);
+$light-text-colour: rgb(240, 240, 240);
+$info-bubble-background: white;
+$segment-width-rule: rgb(160, 160, 160);
+$street-name-text: black;
+$street-name-background: white;
+$control-disabled-colour: gray;
 
 // Layered UI box shadows
 $light-box-shadow: 0 0 14px 0 rgba(0, 0, 0, 0.075);


### PR DESCRIPTION
This PR fixes one of the main observed bug reported in #1766: when a manual width input entry incorrectly updates the wrong segment. Furthermore, we attempt one particular UI tweaks suggested in that original issue: instead of auto-updating a segment width as the user types, we now wait for confirmation (with Enter key) or when the user loses focus  on the input element.

In addition:

- Updates the UI so that the width input and buttons are visually grouped together.
- As a consequence of updating to the newer color scheme, some other instances of UI color in other parts of the application (like the menu) have been updated.
- Additional test suite coverage for `<UpDownInput >` component.
- Refactors test suite for above component, and its parent components, in accordance with issues #2043 and #2044.
