### PR TITLE
Renames "no-internet mode" to "offline mode"

### DIFF
--- a/app/bundle.js
+++ b/app/bundle.js
@@ -15,14 +15,17 @@ process.env.AUTH0_CLIENT_ID = config.get('auth0.client_id')
 process.env.STRIPE_API_KEY = config.get('stripe.api_key')
 process.env.USE_AUTH0 = config.get('auth0.use_auth0')
 process.env.ENV = config.get('env')
-process.env.NO_INTERNET_MODE = config.get('no_internet_mode')
+process.env.OFFLINE_MODE = config.get('no_internet_mode')
 
 async function runBundle (app) {
-  const bundler = new Bundler(path.join(process.cwd(), '/assets/scripts/main.js'), {
-    outDir: './build',
-    publicUrl: '/assets'
-    // scopeHoist: true // Turns on experimental tree-shaking (broken)
-  })
+  const bundler = new Bundler(
+    path.join(process.cwd(), '/assets/scripts/main.js'),
+    {
+      outDir: './build',
+      publicUrl: '/assets'
+      // scopeHoist: true // Turns on experimental tree-shaking (broken)
+    }
+  )
 
   if (config.env === 'production') {
     await bundler.bundle()

--- a/assets/scripts/app/config.js
+++ b/assets/scripts/app/config.js
@@ -24,13 +24,17 @@ function parse (value) {
 
 export const API_URL = process.env.API_URL + '/'
 export const FACEBOOK_APP_ID = parse(process.env.FACEBOOK_APP_ID)
-export const TWITTER_SIGN_IN_CALLBACK_PATH = parse(process.env.TWITTER_CALLBACK_PATH)
+export const TWITTER_SIGN_IN_CALLBACK_PATH = parse(
+  process.env.TWITTER_CALLBACK_PATH
+)
 export const ENV = process.env.ENV
-export const NO_INTERNET_MODE = parse(process.env.NO_INTERNET_MODE)
+export const OFFLINE_MODE = parse(process.env.OFFLINE_MODE)
 export const PELIAS_HOST_NAME = process.env.PELIAS_HOST_NAME
 export const PELIAS_API_KEY = parse(process.env.PELIAS_API_KEY)
 export const AUTH0_CLIENT_ID = parse(process.env.AUTH0_CLIENT_ID)
 export const AUTH0_DOMAIN = parse(process.env.AUTH0_DOMAIN)
-export const AUTH0_SIGN_IN_CALLBACK_PATH = parse(process.env.AUTH0_CALLBACK_PATH)
+export const AUTH0_SIGN_IN_CALLBACK_PATH = parse(
+  process.env.AUTH0_CALLBACK_PATH
+)
 export const USE_AUTH0 = parse(process.env.USE_AUTH0)
 export const STRIPE_API_KEY = parse(process.env.STRIPE_API_KEY)

--- a/assets/scripts/app/page_url.js
+++ b/assets/scripts/app/page_url.js
@@ -157,8 +157,8 @@ export function updatePageUrl (forceGalleryUrl, userId = null) {
   if (debug.forceLiveUpdate) {
     url += '&debug-force-live-update'
   }
-  if (debug.forceNoInternet) {
-    url += '&debug-force-no-internet'
+  if (debug.forceOfflineMode) {
+    url += '&debug-force-offline'
   }
 
   url = url.replace(/&/, '?')

--- a/assets/scripts/dialogs/AboutDialog.jsx
+++ b/assets/scripts/dialogs/AboutDialog.jsx
@@ -17,7 +17,7 @@ import mozlogo from '../../images/sponsors/mozilla.svg'
 import './AboutDialog.scss'
 
 function AboutDialog (props) {
-  const noInternet = useSelector((state) => state.system.noInternet)
+  const offline = useSelector((state) => state.system.offline)
 
   return (
     <Dialog>
@@ -76,7 +76,7 @@ function AboutDialog (props) {
                     </ExternalLink>
                   </li>
                 </ul>
-                {!noInternet && (
+                {!offline && (
                   <>
                     <p>
                       <ExternalLink href="https://opencollective.com/streetmix/">

--- a/assets/scripts/info_bubble/Description.jsx
+++ b/assets/scripts/info_bubble/Description.jsx
@@ -37,7 +37,7 @@ function Description (props) {
   const descriptionVisible = useSelector(
     (state) => state.infoBubble.descriptionVisible
   )
-  const noInternet = useSelector((state) => state.system.noInternet)
+  const offline = useSelector((state) => state.system.offline)
   const dispatch = useDispatch()
 
   function handleClickShow () {
@@ -104,7 +104,7 @@ function Description (props) {
         image={description.image}
         content={content}
         caption={imageCaption}
-        noInternet={noInternet}
+        offline={offline}
         bubbleY={Number.parseInt(props.infoBubbleEl.style.top)}
       />
     </>

--- a/assets/scripts/info_bubble/DescriptionPanel.jsx
+++ b/assets/scripts/info_bubble/DescriptionPanel.jsx
@@ -32,7 +32,7 @@ DescriptionPanel.propTypes = {
   caption: PropTypes.string,
   onClickHide: PropTypes.func,
   bubbleY: PropTypes.number,
-  noInternet: PropTypes.bool
+  offline: PropTypes.bool
 }
 
 function DescriptionPanel ({
@@ -42,7 +42,7 @@ function DescriptionPanel ({
   caption,
   onClickHide = () => {},
   bubbleY,
-  noInternet = false
+  offline = false
 }) {
   const [highlightTriangle, setHighlightTriangle] = useState(false)
 
@@ -96,7 +96,7 @@ function DescriptionPanel ({
                     'listItem',
                     'blockquote',
                     'heading',
-                    !noInternet && 'link'
+                    !offline && 'link'
                   ]}
                   unwrapDisallowed={true}
                   linkTarget="_blank"

--- a/assets/scripts/menus/IdentityMenu.jsx
+++ b/assets/scripts/menus/IdentityMenu.jsx
@@ -8,7 +8,7 @@ import './IdentityMenu.scss'
 
 function IdentityMenu (props) {
   const userId = useSelector((state) => state.user.signInData?.userId)
-  const noInternet = useSelector((state) => state.system.noInternet)
+  const offline = useSelector((state) => state.system.offline)
   const dispatch = useDispatch()
   const handleClickMyStreets = useCallback(
     (event) => {
@@ -22,7 +22,7 @@ function IdentityMenu (props) {
 
   return (
     <Menu {...props} className="identity-menu">
-      {!noInternet && (
+      {!offline && (
         <a href={myStreetsLink} onClick={handleClickMyStreets}>
           <FormattedMessage
             id="menu.item.my-streets"

--- a/assets/scripts/menus/MenuBar.jsx
+++ b/assets/scripts/menus/MenuBar.jsx
@@ -16,7 +16,7 @@ MenuBar.propTypes = {
 
 function MenuBar (props) {
   const user = useSelector((state) => state.user.signInData?.details || null)
-  const offline = useSelector((state) => state.system.noInternet)
+  const offline = useSelector((state) => state.system.offline)
   const upgradeFunnel = useSelector(
     (state) => state.flags.BUSINESS_PLAN.value || false
   )

--- a/assets/scripts/menus/ShareMenu.jsx
+++ b/assets/scripts/menus/ShareMenu.jsx
@@ -13,7 +13,7 @@ import { startPrinting } from '../store/slices/app'
 import './ShareMenu.scss'
 
 function ShareMenu (props) {
-  const noInternet = useSelector((state) => state.system.noInternet)
+  const offline = useSelector((state) => state.system.offline)
   const signedIn = useSelector((state) => state.user.signedIn || false)
   const userId = useSelector((state) => state.user.signInData?.userId || '')
   const street = useSelector((state) => state.street)
@@ -168,7 +168,7 @@ function ShareMenu (props) {
 
   return (
     <Menu onShow={handleShow} className="share-menu" {...props}>
-      {!noInternet && (
+      {!offline && (
         <>
           {signInPromo}
           <div className="share-via-link-container">

--- a/assets/scripts/menus/__tests__/MenuBar.test.js
+++ b/assets/scripts/menus/__tests__/MenuBar.test.js
@@ -23,7 +23,7 @@ describe('MenuBar', () => {
       {
         initialState: {
           system: {
-            noInternet: true
+            offline: true
           }
         }
       }

--- a/assets/scripts/menus/__tests__/ShareMenu.test.js
+++ b/assets/scripts/menus/__tests__/ShareMenu.test.js
@@ -208,9 +208,9 @@ describe('ShareMenu', () => {
     expect(copy).toBeCalledTimes(1)
   })
 
-  it('does not render external share links in no internet mode', () => {
+  it('does not render external share links in offline mode', () => {
     const { asFragment } = renderWithReduxAndIntl(<ShareMenu />, {
-      initialState: { system: { noInternet: true } }
+      initialState: { system: { offline: true } }
     })
 
     expect(asFragment()).toMatchSnapshot()

--- a/assets/scripts/menus/__tests__/__snapshots__/ShareMenu.test.js.snap
+++ b/assets/scripts/menus/__tests__/__snapshots__/ShareMenu.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ShareMenu does not render external share links in no internet mode 1`] = `
+exports[`ShareMenu does not render external share links in offline mode 1`] = `
 <DocumentFragment>
   <div
     class="menu share-menu"

--- a/assets/scripts/preinit/debug_settings.js
+++ b/assets/scripts/preinit/debug_settings.js
@@ -15,7 +15,7 @@ export const debug = {
   forceLeftHandTraffic: false,
   forceUnsupportedBrowser: false,
   forceNonRetina: false,
-  forceNoInternet: false,
+  forceOfflineMode: false,
   forceReadOnly: false,
   forceLiveUpdate: false
 }
@@ -34,8 +34,8 @@ if (url.match(/[?&]debug-force-non-retina&?/)) {
   debug.forceNonRetina = true
 }
 
-if (url.match(/[?&]debug-force-no-internet&?/)) {
-  debug.forceNoInternet = true
+if (url.match(/[?&]debug-force-offline&?/)) {
+  debug.forceOfflineMode = true
 }
 
 if (url.match(/[?&]debug-force-read-only&?/)) {

--- a/assets/scripts/preinit/system_capabilities.js
+++ b/assets/scripts/preinit/system_capabilities.js
@@ -5,7 +5,7 @@
  * browser, connection, etc).
  *
  */
-import { NO_INTERNET_MODE } from '../app/config'
+import { OFFLINE_MODE } from '../app/config'
 import { debug } from './debug_settings'
 import store from '../store'
 import { setSystemFlags } from '../store/slices/system'
@@ -16,8 +16,8 @@ import { setSystemFlags } from '../store/slices/system'
 export function initSystemCapabilities () {
   const system = {}
 
-  if (debug.forceNoInternet || NO_INTERNET_MODE === true) {
-    system.noInternet = true
+  if (debug.forceOfflineMode || OFFLINE_MODE === true) {
+    system.offline = true
   }
 
   if (debug.forceNonRetina) {

--- a/assets/scripts/store/slices/debug.js
+++ b/assets/scripts/store/slices/debug.js
@@ -6,7 +6,7 @@ const debugSlice = createSlice({
     forceLeftHandTraffic: false,
     forceUnsupportedBrowser: false,
     forceNonRetina: false,
-    forceNoInternet: false,
+    forceOfflineMode: false,
     forceReadOnly: false,
     forceLiveUpdate: false
   },

--- a/assets/scripts/store/slices/debug.test.js
+++ b/assets/scripts/store/slices/debug.test.js
@@ -6,7 +6,7 @@ describe('debug reducer', () => {
     forceLeftHandTraffic: false,
     forceUnsupportedBrowser: false,
     forceNonRetina: false,
-    forceNoInternet: false,
+    forceOfflineMode: false,
     forceReadOnly: false,
     forceLiveUpdate: false
   }
@@ -28,7 +28,7 @@ describe('debug reducer', () => {
         forceLeftHandTraffic: false,
         forceUnsupportedBrowser: false,
         forceNonRetina: true,
-        forceNoInternet: false,
+        forceOfflineMode: false,
         forceReadOnly: false,
         forceLiveUpdate: false
       }
@@ -50,7 +50,7 @@ describe('debug reducer', () => {
         forceLeftHandTraffic: true,
         forceUnsupportedBrowser: false,
         forceNonRetina: true,
-        forceNoInternet: false,
+        forceOfflineMode: false,
         forceReadOnly: false,
         forceLiveUpdate: false
       }

--- a/assets/scripts/store/slices/system.js
+++ b/assets/scripts/store/slices/system.js
@@ -16,7 +16,7 @@ const systemSlice = createSlice({
         navigator.userAgent.indexOf('Chrome') === -1) ||
       false,
     windows: navigator.userAgent.indexOf('Windows') !== -1 || false,
-    noInternet: false,
+    offline: false,
     devicePixelRatio: window.devicePixelRatio || 1.0
   },
 

--- a/assets/scripts/store/slices/system.test.js
+++ b/assets/scripts/store/slices/system.test.js
@@ -6,7 +6,7 @@ describe('system reducer', () => {
     phone: false,
     safari: false,
     windows: false,
-    noInternet: false,
+    offline: false,
     devicePixelRatio: 1
   }
 
@@ -19,7 +19,7 @@ describe('system reducer', () => {
       system(
         initialState,
         setSystemFlags({
-          noInternet: true,
+          offline: true,
           devicePixelRatio: 2
         })
       )
@@ -27,7 +27,7 @@ describe('system reducer', () => {
       phone: false,
       safari: false,
       windows: false,
-      noInternet: true,
+      offline: true,
       devicePixelRatio: 2
     })
   })

--- a/assets/scripts/ui/ExternalLink.jsx
+++ b/assets/scripts/ui/ExternalLink.jsx
@@ -10,13 +10,13 @@ ExternalLink.propTypes = {
 }
 
 function ExternalLink ({ children, href, ...restProps }) {
-  const noInternet = useSelector((state) => state.system.noInternet)
+  const offline = useSelector((state) => state.system.offline)
 
   if (!href.startsWith('mailto:') && !isExternalUrl(href)) {
     throw new Error(ERRORS.INVALID_EXTERNAL_LINK)
   }
 
-  if (noInternet) {
+  if (offline) {
     return children
   }
 

--- a/assets/scripts/ui/__tests__/ExternalLink.test.js
+++ b/assets/scripts/ui/__tests__/ExternalLink.test.js
@@ -6,13 +6,13 @@ import { ERRORS } from '../../../../lib/util'
 
 const initialStateForOnline = {
   system: {
-    noInternet: false
+    offline: false
   }
 }
 
 const initialStateForOffline = {
   system: {
-    noInternet: true
+    offline: true
   }
 }
 
@@ -47,7 +47,7 @@ describe('ExternalLink', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('renders string child without an <a> element in "no-internet" mode', () => {
+  it('renders string child without an <a> element in "offline" mode', () => {
     const {
       asFragment
     } = renderWithReduxAndIntl(
@@ -57,7 +57,7 @@ describe('ExternalLink', () => {
     expect(asFragment()).toMatchSnapshot()
   })
 
-  it('renders element child without an <a> element in "no-internet" mode', () => {
+  it('renders element child without an <a> element in "offline" mode', () => {
     const { asFragment } = renderWithReduxAndIntl(
       <ExternalLink href="https://example.com">
         <div>foo</div>

--- a/assets/scripts/ui/__tests__/__snapshots__/ExternalLink.test.js.snap
+++ b/assets/scripts/ui/__tests__/__snapshots__/ExternalLink.test.js.snap
@@ -38,7 +38,7 @@ exports[`ExternalLink renders an <a> element with string child 1`] = `
 </DocumentFragment>
 `;
 
-exports[`ExternalLink renders element child without an <a> element in "no-internet" mode 1`] = `
+exports[`ExternalLink renders element child without an <a> element in "offline" mode 1`] = `
 <DocumentFragment>
   <div>
     foo
@@ -46,7 +46,7 @@ exports[`ExternalLink renders element child without an <a> element in "no-intern
 </DocumentFragment>
 `;
 
-exports[`ExternalLink renders string child without an <a> element in "no-internet" mode 1`] = `
+exports[`ExternalLink renders string child without an <a> element in "offline" mode 1`] = `
 <DocumentFragment>
   foo
 </DocumentFragment>

--- a/docs/technical/installing-streetmix.rst
+++ b/docs/technical/installing-streetmix.rst
@@ -316,10 +316,10 @@ Every so often, you will need to update the project.
    Debug a migration on a Heroku application instance like so: ``heroku run 'DEBUG=sequelize* npx sequelize db:migrate' --app <heroku app id>`` (Note the quotation marks surrounding the command.)
 
 
-Setup in a no-internet environment
-----------------------------------
+Setup in an offline environment
+-------------------------------
 
-This is for a special case where you may need to deploy Streetmix onto machines that are going to be running in an environment without Internet access, such as a public space without Wi-Fi, or a conference center with very limited Wi-Fi. To put Streetmix into "no Internet mode", set your :envvar:`NODE_ENV` environment variable to ``demo``.
+This is for a special case where you may need to deploy Streetmix onto machines that are going to be running in an environment without Internet access, such as a public space without Wi-Fi, or a conference center with very limited Wi-Fi. To put Streetmix into "offline mode", set your :envvar:`NODE_ENV` environment variable to ``demo``.
 
 You may do this by editing the :file:`.env` file (see :ref:`install-env-vars` for more information about this file).
 
@@ -332,7 +332,7 @@ You can also do it one time by starting the server like this:
 
 .. caution::
 
-   "No Internet mode" is not a well-supported feature of Streetmix. Use it with care.
+   "Offline mode" is not a well-supported feature of Streetmix. Use it with care.
 
 
 .. tip::


### PR DESCRIPTION
"Offline mode" seems like better terminology. But, note that "offline" does not mean "Streetmix is currently not connected to the Internet." It means "Streetmix is not depending on external resources not hosted on the current server because it may not be able to reach those external resources." This is slightly different than some interpretations of "offline" which means "the entire app runs client side only and makes no calls to the backend whatsoever."

Maybe there's a better term to be used here?