### PR TITLE
chore(deps): remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@sentry/browser": "5.15.5",
     "@streetmix/illustrations": "1.0.1",
     "@tippyjs/react": "4.2.0",
-    "async": "3.1.0",
     "auth0": "2.28.0",
     "auth0-js": "9.13.2",
     "autoprefixer": "9.8.6",


### PR DESCRIPTION
https://github.com/streetmix/streetmix/pull/2048 bumps this dependency. 

However, I'm not convinced we use it anywhere. I went back 4-6ish years and found where we used to. 
Here's an example: 
https://github.com/streetmix/streetmix/blob/eb0ec3ac382231a675218ea2ed925ae3cc00cf06/app/models/street.js#L2

However, I can't find any current instances where we require this in the current codebase. My hunch is that at some point we stopped using this library once node introduced it's own async methods but just never removed the dependency. 

This PR is an imperfect way to prove that hypothesis. Does removing this dependency break anything?