### PR TITLE
refactor(sequelize): simplify db setup code

### DIFF
--- a/app/db/models/index.js
+++ b/app/db/models/index.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const fs = require('fs')
-const path = require('path')
 const Sequelize = require('sequelize')
-const basename = path.basename(__filename)
 const config = require('config')
+const models = require('requireindex')(__dirname)
 const db = {}
 
 const configDb = config.get('db.sequelize')
@@ -28,31 +26,22 @@ if (config.has('db.sequelize.url')) {
   })
 }
 
-// reads in files where we define other models
-fs.readdirSync(__dirname)
-  .filter((file) => {
-    return (
-      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
-    )
-  })
-  .forEach((file) => {
-    const model = require(path.join(__dirname, file))(
-      sequelize,
-      Sequelize.DataTypes
-    )
-    if (!model) {
-      throw new Error(`missing model for file: ${file}`)
-    }
-    db[model.name] = model
-  })
+// Set up each model
+Object.values(models).forEach((modelDefiner) => {
+  const model = modelDefiner(sequelize, Sequelize.DataTypes)
 
+  if (!model) {
+    throw new Error(`missing model for file: ${modelDefiner}`)
+  }
+
+  db[model.name] = model
+})
+
+// Set up associations
 Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db)
   }
 })
-
-db.sequelize = sequelize
-db.Sequelize = Sequelize
 
 module.exports = db


### PR DESCRIPTION
- uses `requireindex` to retrieve model files in the directory
- refactor the way models are defined
  (see: https://github.com/sequelize/express-example/blob/master/express-main-example/sequelize/index.js)
  It's not being done in exactly the same way, but this is the reference example
- remove exporting sequelize objects on the db (doesn't seem to be used anywhere)