### PR TITLE
refactor(SegmentForPalette): combine the palette item code paths

### DIFF
--- a/assets/scripts/segments/SegmentForPalette.jsx
+++ b/assets/scripts/segments/SegmentForPalette.jsx
@@ -63,53 +63,34 @@ function SegmentForPalette (props) {
   }
   actualWidth += PALETTE_SEGMENT_EXTRA_PADDING
 
+  const classNames = ['segment', 'segment-in-palette']
+  let sublabel = null
+
   if (props.disabled) {
-    return (
-      <li
-        style={{
-          width: actualWidth * TILE_SIZE * PALETTE_SEGMENT_MULTIPLIER + 'px'
-        }}
-        className="segment segment-in-palette segment-disabled"
-      >
-        <Tooltip
-          target={props.tooltipTarget}
-          label={getLabel(props)}
-          sublabel={intl.formatMessage({
-            id: 'plus.locked.user',
-            // Default message ends with a Unicode-only left-right order mark
-            // to allow for proper punctuation in `rtl` text direction
-            // This character is hidden from editors by default!
-            defaultMessage: 'Sign in to use!‎'
-          })}
-        >
-          {/* Wrapper element necessary for <Tooltip /> (alternate solution is
-              to forward ref) */}
-          <div style={{ height: '80px' }} tabIndex="0">
-            <SegmentCanvas
-              actualWidth={actualWidth}
-              type={props.type}
-              variantString={props.variantString}
-              randSeed={props.randSeed}
-              multiplier={PALETTE_SEGMENT_MULTIPLIER}
-              groundBaseline={PALETTE_GROUND_BASELINE}
-            />
-          </div>
-        </Tooltip>
-        <FontAwesomeIcon icon={ICON_LOCK} />
-      </li>
-    )
+    classNames.push('segment-disabled')
+    sublabel = intl.formatMessage({
+      id: 'plus.locked.user',
+      // Default message ends with a Unicode-only left-right order mark
+      // to allow for proper punctuation in `rtl` text direction
+      // This character is hidden from editors by default!
+      defaultMessage: 'Sign in to use!‎'
+    })
   }
 
-  return props.connectDragSource(
+  const node = (
     <li
       style={{
         width: actualWidth * TILE_SIZE * PALETTE_SEGMENT_MULTIPLIER + 'px'
       }}
-      className="segment segment-in-palette"
+      className={classNames.join(' ')}
     >
-      <Tooltip target={props.tooltipTarget} label={getLabel(props)}>
-        {/* Wrapper element necessary for <Tooltip /> (alternate solution is
-            to forward ref)
+      <Tooltip
+        target={props.tooltipTarget}
+        label={getLabel(props)}
+        sublabel={sublabel}
+      >
+        {/* Wrapper element necessary for <Tooltip />
+            (alternate solution is to forward ref)
             This wrapper element is also the target for hover / focus
             in order the activate the tooltip. */}
         <div style={{ height: '80px' }} tabIndex="0">
@@ -123,8 +104,17 @@ function SegmentForPalette (props) {
           />
         </div>
       </Tooltip>
+      {props.disabled && <FontAwesomeIcon icon={ICON_LOCK} />}
     </li>
   )
+
+  // If disabled, return node only
+  if (props.disabled) {
+    return node
+  }
+
+  // Otherwise, return node wrapped with react-dnd abilities.
+  return props.connectDragSource(node)
 }
 
 export default DragSource(


### PR DESCRIPTION
Previously, disabled and enabled palette items ran through separate code paths that were mostly the same (essentially, duplicate code) with minor differences. This combines the two code paths into one.

This was initially part of a larger refactor involving the Tippy instance, which I aborted (low priority). But this is still a worthy refactor to retain.