### PR TITLE
chore: upgrade node to version 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "BSD-3-Clause",
   "engines": {
-    "node": "12.x",
+    "node": "14.x",
     "npm": "6.x"
   },
   "scripts": {


### PR DESCRIPTION
this should upgrade to node-14

I've been using streetmix with node 14 for awhile and haven't seen anything break. All tests pass. We'll probably want CI to pass and make sure it and the heroku preview app are running the newer version of node. 

https://openjsf.org/blog/2020/04/21/project-update-node-js-version-14-available-now/ <--I didn't see anything here too remarkable for us. 