### PR TITLE
fix: remove duplicate csp header

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@ app.locals.config = config
 // off-by-default headers for better security as recommended by https://securityheaders.io/
 const helmetConfig = {
   frameguard: false, // Allow Streetmix to be iframed in 3rd party sites
+  contentSecurityPolicy: false, // These are set explicitly later
   hsts: {
     maxAge: 5184000, // 60 days
     includeSubDomains: false // we don't have a wildcard ssl cert


### PR DESCRIPTION
Using the helmet() middleware is the same as including all of
helmet's middlewares individually. We want to customize the
configuration of the contentSecurityPolicy middleware, so we call it
separately.

But if you both call helmet(), and helmet.contentSecurityPolicy(), and
one of them has `reportOnly` set to true, then you get two CSP records -
one as report only, and the other as the main CSP. So any rules that you
were trying to relax by calling the middleware independently aren't
relaxed, because they're only set on the report-only header, and not in
the main CSP header.

The effect of this for this site is that the CSP, in development, would
block a connection to the WebSocket required for Parcel's hot-reloading.