### PR TITLE
fix: dragged segments should preserve randomness

### DIFF
--- a/assets/scripts/segments/SegmentDragLayer.jsx
+++ b/assets/scripts/segments/SegmentDragLayer.jsx
@@ -71,7 +71,7 @@ class SegmentDragLayer extends React.PureComponent {
         {isDragging &&
           (type === Types.SEGMENT || type === Types.PALETTE_SEGMENT) && (
             <div className="floating segment" ref={this.floatingEl}>
-              <SegmentCanvas {...item} />
+              <SegmentCanvas {...item} randSeed={item.id} />
             </div>
           )}
         {/* eslint-enable */}

--- a/assets/scripts/segments/drag_and_drop.js
+++ b/assets/scripts/segments/drag_and_drop.js
@@ -35,6 +35,7 @@ import {
   setActiveSegment,
   setDraggingType
 } from '../store/slices/ui'
+import { generateRandSeed } from '../util/random'
 
 export var draggingResize = {
   segmentEl: null,
@@ -489,6 +490,7 @@ export const paletteSegmentSource = {
     const segmentInfo = getSegmentInfo(props.type)
 
     return {
+      id: generateRandSeed(),
       variantString: Object.keys(segmentInfo.details).shift(),
       type: props.type,
       actualWidth: segmentInfo.defaultWidth

--- a/assets/scripts/segments/scatter.js
+++ b/assets/scripts/segments/scatter.js
@@ -87,7 +87,7 @@ function pickRandomEntityFromPool (pool, randomGenerator) {
 export function getRandomObjects (
   pool,
   maxWidth,
-  randSeed,
+  randSeed = 9123984, // self defined randSeed if one is not provided
   minSpacing,
   maxSpacing,
   maxSpriteWidth,

--- a/assets/scripts/segments/view.js
+++ b/assets/scripts/segments/view.js
@@ -616,7 +616,7 @@ export function drawSegmentContents (
         actualWidth,
         offsetLeft - left * TILE_SIZE * multiplier,
         groundLevel,
-        randSeed ?? 9123984, // self defined randSeed if one is not provided.
+        randSeed,
         graphics.scatter.minSpacing,
         graphics.scatter.maxSpacing,
         0,


### PR DESCRIPTION
Fixes some visual inconsistencies when dragging segments with random seeds (e.g. sidewalk, BRT):

- While dragging a segment from one position in the street to another, the "preview" segment will display with a different id (which also doubles as the random seed) from the original segment. (It will correctly drop with the original id.) This fix preseves the random seed throughout the lifespan of the drag action, so that the preview image is the same as the original (and will not change during the drag, which can happen under certain circumstances which update the preview image).
- While dragging a segment from the palette to the street, the dropped item will adopt a new id (and new random seed) from the original preview segment. This can create a visual confusion as it would appear that the new segment did not drop what was expected. With this fix we now pre-generate the ID (or random seed) as soon as it is dragged out of the palette, so that the dropped item preserves the previewed look.
