### PR TITLE
feat(metrification): converting API responses to metric (DO NOT MERGE)

### DIFF
--- a/app/resources/v1/streets.js
+++ b/app/resources/v1/streets.js
@@ -1,7 +1,11 @@
 const config = require('config')
 const { v1: uuidv1 } = require('uuid')
 const { isArray } = require('lodash')
-const { ERRORS, asStreetJson } = require('../../../lib/util')
+const {
+  ERRORS,
+  asStreetJson,
+  convertMetricBackToImperialUnits
+} = require('../../../lib/util')
 const logger = require('../../../lib/logger.js')()
 const { User, Street, Sequence } = require('../../db/models')
 
@@ -509,6 +513,11 @@ exports.put = async function (req, res) {
       }
       street.originalStreetId = origStreet.id
     }
+
+    // We're doing stuff in metric on the front-end right now, but the database
+    // is still storing imperial so we convert back
+    street.data.street = convertMetricBackToImperialUnits(street.data.street)
+
     return street.save({ returning: true })
   } // END function - updateStreetData
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,20 @@
+const IMPERIAL_METRIC_MULTIPLIER = 30 / 100
+const METRIC_PRECISION = 3
+const IMPERIAL_PRECISION = 5
+
+function convertImperialMeasurementToMetric (value) {
+  return Number.parseFloat(
+    (value * IMPERIAL_METRIC_MULTIPLIER).toFixed(METRIC_PRECISION)
+  )
+}
+
+function convertMetricMeasurementToImperial (value) {
+  const resolution = 1 / 6 // this is the metric resolution
+  const new1 = value / IMPERIAL_METRIC_MULTIPLIER
+  const new2 = Math.round(new1 / resolution) * resolution
+  return Number.parseFloat(new2.toFixed(IMPERIAL_PRECISION))
+}
+
 exports.asStreetJson = function (street) {
   const json = {
     id: street.id,
@@ -14,7 +31,35 @@ exports.asStreetJson = function (street) {
     json.creator = { id: street.creatorId }
   }
 
+  // A temporary thing where we return width values pre-calculated as metric!
+  // Doing the conversion at this means the API will always have metric values,
+  // while we don't edit the database yet.
+  // The original width is stored as `widthImperial` for reference
+  // Change street width to metric
+  street.data.street.widthImperial = street.data.street.width
+  street.data.street.width = convertImperialMeasurementToMetric(
+    street.data.street.width
+  )
+  // Change all street segments to metric
+  if (street.data.street.segments) {
+    json.data.street.segments = street.data.street.segments.map((segment) => ({
+      ...segment,
+      widthImperial: segment.width,
+      width: convertImperialMeasurementToMetric(segment.width)
+    }))
+  }
+
   return json
+}
+
+exports.convertMetricBackToImperialUnits = function (street) {
+  street.width = convertMetricMeasurementToImperial(street.width)
+  street.segments = street.segments.map((segment) => {
+    segment.width = convertMetricMeasurementToImperial(segment.width)
+    return segment
+  })
+
+  return street
 }
 
 exports.asUserJson = function (user) {


### PR DESCRIPTION
This injects a step in the GET and PUT calls to `/api/v1/streets` respectively, where GETting a street will return data in metric units instead, and PUTting data will convert those values back into imperial for the database. Nothing else is changed. Code on the front end will need to be updated to not assume imperial units.

Note: this does not change the POST call, where a new street is created on the front end in imperial units. That could be a next step to tackle.