### PR TITLE
fix(patreon): handle missing credentials in environment

### DIFF
--- a/app/service_routes.js
+++ b/app/service_routes.js
@@ -116,7 +116,6 @@ routes.get(
   '/services/integrations/patreon/callback',
   resources.services.integrations.patreon.callback,
   resources.services.integrations.patreon.connectUser
-
 )
 
 /******************************************************************************


### PR DESCRIPTION
This is a pretty quick fix, but necessary after merging #2214. This enables Streetmix to run without a hard dependency on Patreon credentials to be present in the environment variables.

Let me know if you're aware of any error handling process that would be preferred by Passport, otherwise, this is the strategy:

1. on app init, do not initialize the Passport Patreon strategy if credentials are unavailable. The `passport.use()` setup is placed inside a function so that we can control when initialization happens. (You can see that we use this pattern in [many other server side scripts](https://github.com/streetmix/streetmix/blob/main/lib/svg-sprite.js) -- we try to avoid running code while scripts are being loaded as it could result in side effects we did not want.)
2. if any of the Patreon service routes are hit when credentials are unavailable, return a server error code.