### PR TITLE
refactor(i18n): remove use_local configuration

### DIFF
--- a/app/resources/v1/translate.js
+++ b/app/resources/v1/translate.js
@@ -9,7 +9,8 @@ const getFromTransifex = require('../../../lib/transifex.js')
 const readFile = util.promisify(fs.readFile)
 
 async function getLocalTranslation (res, locale, resource) {
-  const translationFile = process.cwd() + '/assets/locales/' + locale + '/' + resource + '.json'
+  const translationFile =
+    process.cwd() + '/assets/locales/' + locale + '/' + resource + '.json'
 
   try {
     return await readFile(translationFile, 'utf8')
@@ -17,9 +18,19 @@ async function getLocalTranslation (res, locale, resource) {
     logger.error(err)
 
     if (err.code === 'ENOENT') {
-      res.status(404).json({ status: 404, msg: 'No translation found with locale code: ' + locale })
+      res
+        .status(404)
+        .json({
+          status: 404,
+          msg: 'No translation found with locale code: ' + locale
+        })
     } else {
-      res.status(500).json({ status: 500, msg: 'Could not retrieve translation for locale: ' + locale })
+      res
+        .status(500)
+        .json({
+          status: 500,
+          msg: 'Could not retrieve translation for locale: ' + locale
+        })
     }
   }
 }
@@ -27,7 +38,8 @@ async function getLocalTranslation (res, locale, resource) {
 function sendSuccessResponse (res, locale, resource, translation) {
   res.set({
     'Content-Type': 'application/json; charset=utf-8',
-    Location: config.restapi.baseuri + '/v1/translate/' + locale + '/' + resource,
+    Location:
+      config.restapi.baseuri + '/v1/translate/' + locale + '/' + resource,
     'Cache-Control': 'max-age=86400'
   })
 
@@ -45,20 +57,25 @@ exports.get = async (req, res) => {
 
   let translation
 
-  if (config.l10n.use_local === false && typeof config.l10n.transifex.api_token === 'undefined') {
-    logger.warn('Remote translation files were requested but an API token was not provided. Falling back to local translations.')
-  }
-
   try {
-    if (config.l10n.use_local === true || typeof config.l10n.transifex.api_token === 'undefined') {
+    if (typeof process.env.TRANSIFEX_API_TOKEN === 'undefined') {
       translation = await getLocalTranslation(res, locale, resource)
     } else {
-      translation = await getFromTransifex(locale, resource, config.l10n.transifex.api_token)
+      translation = await getFromTransifex(
+        locale,
+        resource,
+        process.env.TRANSIFEX_API_TOKEN
+      )
     }
   } catch (err) {
     logger.error(err)
 
-    res.status(500).json({ status: 500, msg: 'Could not retrieve translation for locale: ' + locale })
+    res
+      .status(500)
+      .json({
+        status: 500,
+        msg: 'Could not retrieve translation for locale: ' + locale
+      })
   }
 
   if (translation) {

--- a/config/default.js
+++ b/config/default.js
@@ -56,12 +56,6 @@ module.exports = {
   },
   log_level: 'debug',
   no_internet_mode: false,
-  l10n: {
-    transifex: {
-      api_token: process.env.TRANSIFEX_API_TOKEN
-    },
-    use_local: false
-  },
   geocode: {
     pelias: {
       host: 'api.geocode.earth',

--- a/config/demo.js
+++ b/config/demo.js
@@ -1,6 +1,3 @@
 module.exports = {
-  no_internet_mode: true,
-  l10n: {
-    use_local: true
-  }
+  no_internet_mode: true
 }

--- a/config/production.js
+++ b/config/production.js
@@ -35,9 +35,6 @@ module.exports = {
       }
     }
   },
-  l10n: {
-    use_local: true
-  },
   stripe: {
     tier1_plan_id: process.env.TIER1_PLAN_ID || 'plan_Fc2wCyqj2Azpbm'
   }

--- a/config/staging.js
+++ b/config/staging.js
@@ -17,8 +17,5 @@ module.exports = {
         idle: 10000
       }
     }
-  },
-  l10n: {
-    use_local: false
   }
 }

--- a/config/test.js
+++ b/config/test.js
@@ -14,8 +14,5 @@ module.exports = {
       host: process.env.PGHOST || '127.0.0.1',
       port: process.env.PGPORT || 5432
     }
-  },
-  l10n: {
-    use_local: true
   }
 }

--- a/docs/contributing/translations/technical-guide.rst
+++ b/docs/contributing/translations/technical-guide.rst
@@ -22,9 +22,9 @@ When strings are deleted, Transifex deletes that string from all locales, *inclu
 Previewing translations 
 -----------------------
 
-In development and other testing environments, the strings for each language code are retrieved directly from the Transifex platform via its API. This means a translator can attempt different translations in real time and preview how it appears in Streetmix.
+Translators can preview translations from Transifex in instances of Streetmix where the `TRANSIFEX_API_TOKEN` environment variable is defined. When present, the strings for each language code are retrieved directly via the Transifex API. In this way, a translator can try different version of a translation in real time to see how it appears in Streetmix.
 
-To change this behavior, set the `l10n.use_local` configuration property in the desired environment in the :file:`config` folder.
+If you are an in instance where you do not want live translations from Transifex, unset the `TRANSIFEX_API_TOKEN` environment variable.
 
 
 Updating locale files


### PR DESCRIPTION
This is driven by the eventual goal to remove the staging environment
configuration. (Staging should be as close to Production as possible,
just on a different instance.)

To reach that goal, any staging-specific setting in `config` must be
achieved through some other means, since `config/staging.js` will
no longer be read. For internationalization (i18n) this means that
the `l10n.use_local` configuration setting needs to be applied
in another way.

The simplest way to achieve this is to change the decision making of
whether or not to use local translation files based on the presence
of the `TRANSIFEX_API_TOKEN` alone. If present, it uses the Transifex
API. If not present, it reads local translation files.

Our production server, which reads local translation files, will never
need the Transifex API, so we can remove the token from its env vars.
In staging, we add the Transifex token to allow live translations.
However, we can also unset the variable to achieve the same behavior
as production (and this can be done without pushing configuration
changes to the repository.)

This will also be true for all local instances. By default, without
a Transifex API token, local instances will always read from local
translation files. Only local instances with tokens will read from
the API. Again, to go back to reading local files, just remove the
API token (no need for a second setting to toggle.)