### PR TITLE
Switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        # Codecov reportgin needs fetch-depth > 1
+        fetch-depth: 2
     # Use the current LTS version of Node.js
     - name: Use Node.js 14
       uses: actions/setup-node@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
       run: npm run db:migrate
     - name: Run tests
       run: npm run jest
+    - name: Report code coverage
+      uses: codecov/codecov-action@v1
 
   cypress:
     name: End-to-end (E2E) tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: Continuous integration (CI) testing
+
+on: [push, pull_request]
+
+jobs:
+  # Separate linting as a parallel test from unit/integration testing because it does not
+  # need to be run in multiple environments.
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      CYPRESS_INSTALL_BINARY: "0"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    # Use the current LTS version of Node.js
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - run: npm ci
+    - run: npm run lint
+
+  test:
+    name: Unit and integration tests
+    runs-on: ubuntu-latest
+    container: node:lts-buster
+    strategy:
+      # Use current LTS, previous LTS and latest versions of Node.js
+      # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+      matrix:
+        node-version: [12.x, 14.x, 15.x]
+    env:
+      NODE_ENV: test
+      CYPRESS_INSTALL_BINARY: "0"
+      PGHOST: postgres
+      PGUSER: postgres
+      PGPASSWORD: postgres
+    services:
+      postgres:
+        image: postgis/postgis
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: streetmix_test
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - name: Seed test database
+      run: npm run db:migrate
+    - name: Run tests
+      run: npm run jest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,29 @@ jobs:
       run: npm run db:migrate
     - name: Run tests
       run: npm run jest
+
+  cypress:
+    name: End-to-end (E2E) tests
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node14.15.0-chrome86-ff82
+      # To run Firefox, use non-root user (Firefox security restriction)
+      # https://github.com/cypress-io/github-action#firefox
+      options: --user 1001
+    env:
+      # We need placeholder API keys to mock some third party integrations
+      PELIAS_API_KEY: ge-iampelias
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Install NPM dependencies, cache them correctly
+      # and run all Cypress tests
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          start: npm start
+          wait-on: 'http://localhost:8000'
+          # Specify browser since container image is compiled with Firefox
+          # We can (and should) also test in Chrome since it's a popular
+          # browser, so a future improvement is to test on multiple browsers
+          browser: firefox

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,12 @@
+name: Lint commit messages
+
+on: [pull_request]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v2

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   commitlint:
+    name: Conventional commits
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/app/db/models/__tests__/user.test.js
+++ b/app/db/models/__tests__/user.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import userFactory from '../../factories/user.js'
-const { User } = require('../../models')
+const { User } = require('..')
 
 describe('creates a user', () => {
   let user
@@ -14,13 +14,16 @@ describe('creates a user', () => {
   beforeEach(async () => {
     user = await userFactory()
   })
+
   it('created user to match', async () => {
     user = await userFactory({ id: 'thefirstuser' })
     expect(user.id).toBe('thefirstuser')
   })
+
   it('has a default role of USER', async () => {
     expect(user.roles[0]).toBe('USER')
   })
+
   it('adds admin to roles', async () => {
     // fyi: sequelize dosen't actually pass this to the table until user.save() or update
     // so...this isn't commiting to the database and isn't testing that the role actually exists
@@ -30,10 +33,12 @@ describe('creates a user', () => {
     user.addRole('ADMIN')
     expect(user.roles[2]).not.toBe('ADMIN')
   })
+
   it('removes admin from roles', async () => {
     user.removeRole('ADMIN')
     expect(user.roles[1]).not.toBe('ADMIN')
   })
+
   it('throws an error when role is invalid', async () => {
     // see https://jestjs.io/docs/en/expect#expectassertionsnumber
     expect.assertions(1)

--- a/config/default.js
+++ b/config/default.js
@@ -39,7 +39,7 @@ module.exports = {
   },
   db: {
     sequelize: {
-      logging: true,
+      logging: false,
       database: 'streetmix_dev',
       host: process.env.PGHOST || '127.0.0.1',
       port: process.env.PGPORT || 5432,

--- a/cypress.json
+++ b/cypress.json
@@ -1,7 +1,6 @@
 {
-  "viewportWidth": 1280,
-  "video": false,
   "baseUrl": "http://localhost:8000",
+  "viewportWidth": 1280,
   "viewportHeight": 720,
-  "experimentalFetchPolyfill": true
+  "video": false
 }


### PR DESCRIPTION
Closes #2256 (the issue that was being used to track progress here).

The rationale is that Travis (after migrating to travis-ci.com) has turned off the tap on free CI infrastructure for open source projects. (Even though they're claiming that's not the case, there hasn't been a resolution on how to get it back, and we continue to have open pull requests and progress without test coverage.) This migrates our CI infrastructure to GitHub Actions as an alternative.

This PR will not remove `travis.yml` right now, but as of today Travis will no longer be a required check, while GitHub Actions will.