### PR TITLE
chore(actions): download translation cron job

### DIFF
--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -1,0 +1,27 @@
+name: Update translations
+
+on:
+  schedule:
+    # Daily at a specific time (7:30 chosen arbitrarily)
+    - cron: "30 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  translations:
+    runs-on: ubuntu-latest
+    env:
+      TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    # Use the current LTS version of Node.js
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install necessary dependencies
+      run: npm install dotenv chalk
+    - name: Download translations
+      run: node ./bin/download_translations.js
+    - name: Check status
+      run: git status


### PR DESCRIPTION
It seems we may need to add this job to the main branch before GitHub will set up a workflow for it. This won't do much, but is a starting point toward completion of #2273.