### PR TITLE
feat: make auth0 domain fully configurable #2330

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@
 NODE_ENV=development
 
 # Required secrets.
+AUTH0_DOMAIN=
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
 

--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ const csp = {
       "'self'",
       'platform.twitter.com',
       'cdn.mxpnl.com',
-      'streetmix.auth0.com',
+      process.env.AUTH0_DOMAIN,
       '*.basemaps.cartocdn.com',
       'api.geocode.earth',
       'downloads.mailchimp.com.s3.amazonaws.com',
@@ -117,7 +117,7 @@ const csp = {
       'api.geocode.earth',
       'syndication.twitter.com',
       'sentry.io',
-      'streetmix.auth0.com',
+      process.env.AUTH0_DOMAIN,
       'checkout.stripe.com',
       'plausible.io'
     ],

--- a/app.json
+++ b/app.json
@@ -9,6 +9,9 @@
       "description": "A secret key for verifying the integrity of signed cookies.",
       "generator": "secret"
     },
+    "AUTH0_DOMAIN": {
+      "required": true
+    },
     "AUTH0_CLIENT_ID": {
       "required": true
     },

--- a/app/authentication.js
+++ b/app/authentication.js
@@ -7,13 +7,13 @@ const secret = jwksRsa.expressJwtSecret({
   cache: true,
   rateLimit: true,
   jwksRequestsPerMinute: 5,
-  jwksUri: 'http://streetmix.auth0.com/.well-known/jwks.json'
+  jwksUri: `https://${process.env.AUTH0_DOMAIN}/.well-known/jwks.json`
 })
 
 const jwtCheck = jwt({
   algorithms: ['RS256'],
   secret,
-  issuer: 'https://streetmix.auth0.com/',
+  issuer: `https://${process.env.AUTH0_DOMAIN}/`,
   audience: config.auth0.client_id,
   credentialsRequired: false,
   getToken: function fromCookies (req) {

--- a/config/default.js
+++ b/config/default.js
@@ -7,11 +7,11 @@ module.exports = {
   app_host_port: 'localhost:' + port,
   header_host_port: 'localhost:' + port,
   auth0: {
-    domain: 'streetmix.auth0.com',
+    domain: process.env.AUTH0_DOMAIN || null,
     client_id: process.env.AUTH0_CLIENT_ID || null,
     client_secret: process.env.AUTH0_CLIENT_SECRET,
-    token_api_url: 'https://streetmix.auth0.com/oauth/token',
-    audience: 'https://streetmix.auth0.com/api/v2/',
+    token_api_url: `https://${process.env.AUTH0_DOMAIN}/oauth/token`,
+    audience: `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
     screen_name_custom_claim: 'https://twitter.com/screen_name',
     management_scope: 'read:users write:users',
     callback_path: '/services/auth/sign-in-callback'

--- a/docs/technical/installing-streetmix.rst
+++ b/docs/technical/installing-streetmix.rst
@@ -269,6 +269,8 @@ The only required environment variables are the keys used for the Auth0 authenti
 +-----------------------------------+----------------------------------------------+-----------+
 | Variable name                     | Description                                  | Required  |
 +===================================+==============================================+===========+
+| ``AUTH0_DOMAIN``                  | Authentication service (Auth0) domain        | Yes       |
++-----------------------------------+----------------------------------------------+-----------+
 | ``AUTH0_CLIENT_ID``               | Authentication service (Auth0) client ID     | Yes       |
 +-----------------------------------+----------------------------------------------+-----------+
 | ``AUTH0_CLIENT_SECRET``           | Authentication service (Auth0) client secret | Yes       |


### PR DESCRIPTION
Previously, we allowed for an `AUTH0_DOMAIN` env configuration setting, but weren’t fully committed to it: parts of the codebase still hard-referenced `streetmix.auth0.com`.

Now, we properly dribble the `AUTH0_DOMAIN` env var through the full stack, setting the app up for alternate Auth0 tenants.

This also includes a very minor fix to the URL for our `jwksUri` JSON Web Key Set, which was set to the HTTP version of the URL instead of HTTPS. I updated that while adding the string concatenation.

Closes #2330