### PR TITLE
Enable streaming payments from coil integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,8 +93,7 @@ const csp = {
       'downloads.mailchimp.com.s3.amazonaws.com',
       'checkout.stripe.com',
       'plausible.io',
-      'cdn.coil.com',
-      "'unsafe-inline'"
+      'cdn.coil.com'
     ],
     workerSrc: ["'self'"],
     childSrc: ['platform.twitter.com'],
@@ -245,6 +244,5 @@ app.get(
 
 // Catch-all, also passes a btpToken for coil integration of streaming payments
 app.use(function (req, res) {
-  res.locals.btpToken = req.session.btpToken
   res.render('main')
 })

--- a/app.js
+++ b/app.js
@@ -93,7 +93,8 @@ const csp = {
       'downloads.mailchimp.com.s3.amazonaws.com',
       'checkout.stripe.com',
       'plausible.io',
-      'cdn.coil.com'
+      'cdn.coil.com',
+      "'unsafe-inline'"
     ],
     workerSrc: ["'self'"],
     childSrc: ['platform.twitter.com'],

--- a/app/api_routes.js
+++ b/app/api_routes.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser')
 const cors = require('cors')
 const resources = require('./resources')
 const jwtCheck = require('./authentication')
+const { BTPTokenCheck } = require('./resources/services/integrations/coil')
 /**
  * @swagger
  *
@@ -388,7 +389,13 @@ routes.get('/api/v1/users', cors(), jwtCheck, resources.v1.users.get)
  *           $ref: '#/definitions/User'
  *
  */
-routes.get('/api/v1/users/:user_id', cors(), jwtCheck, resources.v1.users.get)
+routes.get(
+  '/api/v1/users/:user_id',
+  cors(),
+  jwtCheck,
+  BTPTokenCheck,
+  resources.v1.users.get
+)
 routes.put('/api/v1/users/:user_id', cors(), jwtCheck, resources.v1.users.put)
 routes.delete(
   '/api/v1/users/:user_id',

--- a/app/resources/services/integrations/coil.js
+++ b/app/resources/services/integrations/coil.js
@@ -1,3 +1,4 @@
+const querystring = require('querystring')
 const config = require('config')
 const btoa = require('btoa')
 const passport = require('passport')
@@ -113,27 +114,29 @@ exports.callback = (req, res, next) => {
   })(req, res, next)
 }
 
+// passportjs dosen't handle refresh tokens as a strategy so we have to handle that ourself
 const refreshAccessToken = async (refreshToken) => {
   try {
     const encodedAuth = btoa(
-      `${process.env.COIL_CLIENT_ID}:${encodeURIComponent(
-        process.env.COIL_CLIENT_SECRET
-      )}`
+      process.env.COIL_CLIENT_ID +
+        ':' +
+        encodeURIComponent(process.env.COIL_CLIENT_SECRET)
     )
+    const data = querystring.stringify({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken
+    })
     const requestConfig = {
       method: 'post',
-      url: 'https://api.coil.com/user/btp',
+      url: 'https://coil.com/oauth/token',
       headers: {
         Authorization: `Basic ${encodedAuth}`,
         'content-type': 'application/x-www-form-urlencoded'
       },
-      data: {
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken
-      }
+      data: data
     }
     const response = await axios(requestConfig)
-    return response.data
+    return response.data.access_token
   } catch (error) {
     logger.error(error)
   }

--- a/app/resources/services/integrations/coil.js
+++ b/app/resources/services/integrations/coil.js
@@ -8,7 +8,12 @@ const axios = require('axios')
 const { User } = require('../../../db/models')
 const logger = require('../../../../lib/logger.js')()
 
-const { findUser, addUserConnection, syncAccountStatus } = require('./helpers')
+const {
+  findUser,
+  addUserConnection,
+  syncAccountStatus,
+  addOrUpdateByProviderName
+} = require('./helpers')
 
 const initCoil = () => {
   const authToken = btoa(

--- a/app/resources/services/integrations/coil.js
+++ b/app/resources/services/integrations/coil.js
@@ -131,6 +131,8 @@ const getBTPToken = async (accessToken) => {
   }
 }
 
+exports.getBTPToken = getBTPToken
+
 /**
  * connects the third party profile with the database user record
  * pass third party profile data here, construct an object to save to user DB

--- a/app/resources/services/integrations/coil.js
+++ b/app/resources/services/integrations/coil.js
@@ -113,6 +113,34 @@ exports.callback = (req, res, next) => {
   })(req, res, next)
 }
 
+const refreshAccessToken = async (refreshToken) => {
+  try {
+    const encodedAuth = btoa(
+      `${process.env.COIL_CLIENT_ID}:${encodeURIComponent(
+        process.env.COIL_CLIENT_SECRET
+      )}`
+    )
+    const requestConfig = {
+      method: 'post',
+      url: 'https://api.coil.com/user/btp',
+      headers: {
+        Authorization: `Basic ${encodedAuth}`,
+        'content-type': 'application/x-www-form-urlencoded'
+      },
+      data: {
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken
+      }
+    }
+    const response = await axios(requestConfig)
+    return response.data
+  } catch (error) {
+    logger.error(error)
+  }
+}
+
+exports.refreshAccessToken = refreshAccessToken
+
 const getBTPToken = async (accessToken) => {
   try {
     const requestConfig = {
@@ -148,6 +176,7 @@ exports.connectUser = async (req, res, next) => {
   try {
     // we pass the token to the request session, so it should persist as long as the user has their browser open
     const btpToken = await getBTPToken(req.profile.access_token)
+    // if 401, refresh
     req.session.btpToken = btpToken
 
     await addUserConnection(account, profile)

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -251,7 +251,10 @@ exports.get = async function (req, res) {
     if (coilData !== undefined) {
       // fetch and return btpToken
       const btpToken = await getBTPToken(coilData.access_token)
+      // express-seesion seems to indicate this line is all that would be needed to add to cookies
       req.session.btpToken = btpToken
+      // ..but it dosen't work unless we do this:
+      res.cookie('btpToken', btpToken)
     }
   }
 

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -3,7 +3,10 @@ const cloudinary = require('cloudinary')
 const { ERRORS, asUserJson } = require('../../../lib/util')
 const logger = require('../../../lib/logger.js')()
 const { User } = require('../../db/models')
-const { getBTPToken } = require('../services/integrations/coil')
+const {
+  refreshAccessToken,
+  getBTPToken
+} = require('../services/integrations/coil')
 
 exports.post = async function (req, res) {
   const handleCreateUser = function (user) {
@@ -250,16 +253,24 @@ exports.get = async function (req, res) {
     )
     if (coilData !== undefined) {
       // fetch and return btpToken
-      const btpToken = await getBTPToken(coilData.access_token)
-      // express-seesion seems to indicate this line is all that would be needed to add to cookies
-      req.session.btpToken = btpToken
-      // ..but it dosen't work unless we do this:
-      res.cookie('btpToken', btpToken)
+      try {
+        const btpToken = await getBTPToken(coilData.access_token)
+        // express-sesion seems to indicate this line is all that would be needed to add to cookies
+        req.session.btpToken = btpToken
+        // ..but it dosen't work unless we do this:
+        res.cookie('btpToken', btpToken)
+      } catch (error) {
+        if (error.response.status === 401) {
+          await refreshAccessToken(coilData.access_token)
+          const btpToken = await getBTPToken(coilData.access_token)
+          res.cookie('btpToken', btpToken)
+        }
+        logger.error(error)
+      }
     }
   }
 
-  // TODO this function seems like it could be replaced by
-  // sequelize findByPK
+  // this function seems like it could be replaced by sequelize findByPK
   const findUserById = async function (userId) {
     let user
     try {
@@ -307,8 +318,6 @@ exports.get = async function (req, res) {
   }
 
   try {
-    // seems odd to have these two functions chained together, when we
-    // have an ORM that can retrive the user details. is this code still used?
     const result = await findUserById(userId)
     await BTPTokenCheck(result)
     res.status(200).send(asUserJson(result))

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -3,6 +3,7 @@ const cloudinary = require('cloudinary')
 const { ERRORS, asUserJson } = require('../../../lib/util')
 const logger = require('../../../lib/logger.js')()
 const { User } = require('../../db/models')
+const { getBTPToken } = require('../services/integrations/coil')
 
 exports.post = async function (req, res) {
   const handleCreateUser = function (user) {
@@ -242,6 +243,18 @@ exports.get = async function (req, res) {
     }
   }
 
+  const BTPTokenCheck = async function (userData) {
+    // check for coil provider to set access token to stream payments
+    const coilData = userData.identities.find(
+      (item) => item.provider === 'coil'
+    )
+    if (coilData !== undefined) {
+      // fetch and return btpToken
+      const btpToken = await getBTPToken(coilData.access_token)
+      req.session.btpToken = btpToken
+    }
+  }
+
   // TODO this function seems like it could be replaced by
   // sequelize findByPK
   const findUserById = async function (userId) {
@@ -294,6 +307,7 @@ exports.get = async function (req, res) {
     // seems odd to have these two functions chained together, when we
     // have an ORM that can retrive the user details. is this code still used?
     const result = await findUserById(userId)
+    await BTPTokenCheck(result)
     res.status(200).send(asUserJson(result))
   } catch (err) {
     handleError(err)

--- a/app/resources/v1/users.js
+++ b/app/resources/v1/users.js
@@ -3,13 +3,7 @@ const cloudinary = require('cloudinary')
 const { ERRORS, asUserJson } = require('../../../lib/util')
 const logger = require('../../../lib/logger.js')()
 const { User } = require('../../db/models')
-const {
-  refreshAccessToken,
-  getBTPToken
-} = require('../services/integrations/coil')
-const {
-  addOrUpdateByProviderName
-} = require('../services/integrations/helpers')
+
 exports.post = async function (req, res) {
   const handleCreateUser = function (user) {
     if (!user) {
@@ -248,38 +242,6 @@ exports.get = async function (req, res) {
     }
   }
 
-  const BTPTokenCheck = async function (userData) {
-    // check for coil provider to set access token to stream payments
-    const coilData = userData.identities.find(
-      (item) => item.provider === 'coil'
-    )
-    if (coilData !== undefined) {
-      // fetch and return btpToken
-      let btpToken = await getBTPToken(coilData.access_token)
-      if (typeof btpToken === 'undefined') {
-        // token may be expired, so lets refresh and try
-        const newAccessToken = await refreshAccessToken(coilData.refresh_token)
-
-        const identities = userData.identities
-        coilData.access_token = newAccessToken
-        addOrUpdateByProviderName(identities, coilData)
-        await User.update(
-          {
-            identities: identities
-          },
-          { where: { auth0Id: userData.auth0Id }, returning: true }
-        )
-        // return btp token after updating access token
-        btpToken = await getBTPToken(newAccessToken)
-      }
-
-      // express-sesion seems to indicate this line is all that would be needed to add to cookies
-      req.session.btpToken = btpToken
-      // ..but it dosen't work unless we do this:
-      res.cookie('btpToken', btpToken)
-    }
-  }
-
   // this function seems like it could be replaced by sequelize findByPK
   const findUserById = async function (userId) {
     let user
@@ -329,7 +291,6 @@ exports.get = async function (req, res) {
 
   try {
     const result = await findUserById(userId)
-    await BTPTokenCheck(result)
     res.status(200).send(asUserJson(result))
   } catch (err) {
     handleError(err)

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -59,8 +59,7 @@
         document.monetization.state = 'stopped'
       }
     </script>
-    <script src="https://cdn.coil.com/coil-oauth-wm.v7.beta.js" defer>
-    </script>
+
 
 
 
@@ -119,10 +118,8 @@
     <div id="react-app" class="app"></div>
     <script src="https://platform.twitter.com/widgets.js" async></script>
     <script src="/assets/main.{{cacheTimestamp}}.js"></script>
-    <script defer>
-      document.addEventListener("load", document.coilMonetizationPolyfill.init({ btpToken: '{{btpToken}}' }));
-      
-    </script>
+    <script src="https://cdn.coil.com/coil-oauth-wm.v7.beta.js">
+    </script> 
   </body>
 
 </html>

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -59,8 +59,8 @@
         document.monetization.state = 'stopped'
       }
     </script>
-
-
+    <script src="https://cdn.coil.com/coil-oauth-wm.v7.beta.js" defer>
+    </script>
 
 
 
@@ -118,7 +118,6 @@
     <div id="react-app" class="app"></div>
     <script src="https://platform.twitter.com/widgets.js" async></script>
     <script src="/assets/main.{{cacheTimestamp}}.js"></script>
-    <script src="https://cdn.coil.com/coil-oauth-wm.v7.beta.js">
     </script> 
   </body>
 

--- a/app/views/main.hbs
+++ b/app/views/main.hbs
@@ -51,6 +51,18 @@
       <meta name="monetization" content="{{.}}">
     {{/config.monetization}}
 
+    <script>
+      if (document.monetization) {
+        document.monetizationExtensionInstalled = true
+      } else {
+        document.monetization = document.createElement('div')
+        document.monetization.state = 'stopped'
+      }
+    </script>
+    <script src="https://cdn.coil.com/coil-oauth-wm.v7.beta.js" defer>
+    </script>
+
+
 
 
 
@@ -105,9 +117,12 @@
 
     {{! Mount point for React }}
     <div id="react-app" class="app"></div>
-
     <script src="https://platform.twitter.com/widgets.js" async></script>
     <script src="/assets/main.{{cacheTimestamp}}.js"></script>
+    <script defer>
+      document.addEventListener("load", document.coilMonetizationPolyfill.init({ btpToken: '{{btpToken}}' }));
+      
+    </script>
   </body>
 
 </html>

--- a/assets/scripts/integrations/coil.js
+++ b/assets/scripts/integrations/coil.js
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie'
+
 if (document.monetization) {
   document.monetizationExtensionInstalled = true
 } else {
@@ -7,5 +9,15 @@ if (document.monetization) {
 
 document.addEventListener(
   'load',
-  document.coilMonetizationPolyfill.init({ btpToken: '{{btpToken}}' })
+  document.coilMonetizationPolyfill.init({ btpToken: passToken() })
 )
+
+function passToken () {
+  const cookies = Cookies.get()
+  if (cookies.btpToken !== undefined) {
+    const btpToken = cookies.btpToken
+    return btpToken
+  } else {
+    return null
+  }
+}

--- a/assets/scripts/integrations/coil.js
+++ b/assets/scripts/integrations/coil.js
@@ -1,16 +1,11 @@
 import Cookies from 'js-cookie'
 
 if (document.monetization) {
-  document.monetizationExtensionInstalled = true
-} else {
-  document.monetization = document.createElement('div')
-  document.monetization.state = 'stopped'
+  document.addEventListener(
+    'load',
+    document.coilMonetizationPolyfill.init({ btpToken: passToken() })
+  )
 }
-
-document.addEventListener(
-  'load',
-  document.coilMonetizationPolyfill.init({ btpToken: passToken() })
-)
 
 function passToken () {
   const cookies = Cookies.get()

--- a/assets/scripts/integrations/coil.js
+++ b/assets/scripts/integrations/coil.js
@@ -1,0 +1,11 @@
+if (document.monetization) {
+  document.monetizationExtensionInstalled = true
+} else {
+  document.monetization = document.createElement('div')
+  document.monetization.state = 'stopped'
+}
+
+document.addEventListener(
+  'load',
+  document.coilMonetizationPolyfill.init({ btpToken: '{{btpToken}}' })
+)

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -29,6 +29,9 @@ import store from './store'
 import { initialize } from './app/initialization'
 import App from './app/App'
 
+// third party integrations
+import './integrations/coil'
+
 // Error tracking
 // Load this before all other modules. Only load when run in production.
 if (


### PR DESCRIPTION
ATM we get a BTP token when a user connects an account

We'll also need to get a new token whenever they establish a new session (aka visit the site and are logged in)

TODO: 

* ~~implement refresh token functionality since the user access_token is only good for an hour~~
* ~~better handle the existence of a token so that we don't issue too many new tokens in an inefficient way~~
* make sure this is passed to the client, and that the client also refreshes the btp token if its 30 mins or more on a page (update: not super clear how to initiate this from coil, but the backend code should mostly be there now)