### PR TITLE
When connecting to third party providers, store connection data in a table

### DIFF
--- a/app/db/migrations/20210506212658-create-user-connections.js
+++ b/app/db/migrations/20210506212658-create-user-connections.js
@@ -1,0 +1,45 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('UserConnections', {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: Sequelize.INTEGER
+      },
+      user_id: {
+        type: Sequelize.STRING
+      },
+      provider: {
+        type: Sequelize.STRING
+      },
+      provider_user_id: {
+        type: Sequelize.STRING
+      },
+      deleted: {
+        type: Sequelize.BOOLEAN,
+        defaultValue: false
+      },
+      monetized: {
+        type: Sequelize.BOOLEAN
+      },
+      metadata: {
+        type: Sequelize.JSON
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('UserConnections')
+  }
+}

--- a/app/db/models/index.js
+++ b/app/db/models/index.js
@@ -44,4 +44,6 @@ Object.keys(db).forEach((modelName) => {
   }
 })
 
+db.sequelize = sequelize
+
 module.exports = db

--- a/app/db/models/userconnections.js
+++ b/app/db/models/userconnections.js
@@ -1,0 +1,53 @@
+'use strict'
+const { Model } = require('sequelize')
+
+module.exports = (sequelize, DataTypes) => {
+  class UserConnections extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate (models) {
+      // define association here
+    }
+  }
+
+  UserConnections.init(
+    {
+      id: {
+        allowNull: false,
+        autoIncrement: true,
+        primaryKey: true,
+        type: DataTypes.INTEGER
+      },
+      user_id: {
+        allowNull: false,
+        type: DataTypes.STRING
+      },
+      provider: {
+        allowNull: false,
+        type: DataTypes.STRING
+      },
+      provider_user_id: DataTypes.STRING,
+      deleted: {
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
+      },
+      monetized: DataTypes.BOOLEAN,
+      metadata: DataTypes.JSON
+    },
+    {
+      sequelize,
+      modelName: 'UserConnections',
+      indexes: [
+        {
+          unique: true,
+          fields: ['user_id', 'provider']
+        }
+      ]
+    }
+  )
+
+  return UserConnections
+}

--- a/app/resources/services/integrations/patreon.js
+++ b/app/resources/services/integrations/patreon.js
@@ -6,7 +6,7 @@ const logger = require('../../../../lib/logger.js')()
 
 const { User } = require('../../../db/models')
 
-const { findUser } = require('./helpers')
+const { findUser, addUserConnection } = require('./helpers')
 
 /*
 our use case makes this a little complicated,
@@ -111,21 +111,13 @@ exports.callback = (req, res, next) => {
 exports.connectUser = async (req, res) => {
   // in passport, using 'authorize' attaches user data to 'account'
   // instead of overriding the user session data
-  const databaseUser = req.account
-  const identity = {
-    provider: req.profile.provider,
-    user_id: req.profile.id
-  }
+  const account = req.account
+  const profile = req.profile
+
   try {
-    await User.update(
-      {
-        identities: [identity]
-      },
-      { where: { auth0Id: databaseUser.auth0Id }, returning: true }
-    )
+    await addUserConnection(account, profile)
     res.redirect('/')
   } catch (err) {
-    // what would we want to do here?
     logger.error(err)
     res.redirect('/error')
   }


### PR DESCRIPTION
This revises the first attempt at storing third-party connections, which placed provider IDs inside of a JSON document on the User model. As users can have multiple third-party connections, and we may be in a situation where we will need to do a lookup when we _only_ have a third-party account ID (e.g. responding to Patreon webhooks), a table structure (in the standard relational database format) will be more efficient to parse and work with.

To migrate and test:

- Clone this branch
- Run `db:migrate`
- Note that migration does not transfer existing data from the User model, as this feature is not yet live.
- Access the `/services/integrations/coil` and `/services/integrations/patreon` endpoints to recreate connection data.
- Note that right now the `identities` field on the User model is also being saved concurrently, so that we can be confident that the table structure is performing to our expectations.

Notes on table structure:
- Although Streetmix tables did not usually use a self-incrementing `id` field as a primary key (this is a relic of former tables being ported from MongoDB), this one does.
- Additionally, the combination of "user id" and "provider" create a unique index, as we assume that users have only one connection to any third party provider at a time. Ideally, this makes it more efficient to look up any user's provider data.
- Unclear if another unique index should be provided on the combination of "provider" and "provider id".
- A "deleted" field is added to make it more efficient for a connection to be cleared, and then re-added later, if needed.
- A "monetized" field is added so that it can be separately toggled on/off depending on incoming connection data. Ideally, this makes it easier to query whether a user is monetized (is true for any rows resulting where user ID and monetized=true and deleted=false)
- The "metadata" field is our JSON raw data, which we can store and inspect payloads later.

Currently, this branch only stores user data on completion of a successful connection. Next steps are:
- Update the `monetized` field depending on user data, either during OAuth, or webhook activity (Patreon), or streaming payments activity (Coil).
- Enable Patreon webhooks to update user connections.
- Update user role sync status with the user's `monetized=true` query.
- Remove identity column from User model.
