### PR TITLE
Update cypress images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,12 +72,7 @@ jobs:
     name: End-to-end (E2E) tests
     runs-on: ubuntu-latest
     container:
-      # make is not included in newer cypress/browsers images, and some
-      # npm packages require it during install. This the latest cypress
-      # image that works, if a little outdated. Can't update unless we
-      # figure out how to add `make` or remove the package `deasync`
-      # (a sub-depedency of parcel-bundler, which is also outdated.)
-      image: cypress/browsers:node16.5.0-chrome97-ff96
+      image: cypress/browsers:node18.12.0-chrome103-ff107
       # To run Firefox, use non-root user (Firefox security restriction)
       # https://github.com/cypress-io/github-action#firefox
       options: --user 1001

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
+      HUSKY: "0"
       CYPRESS_INSTALL_BINARY: "0"
     steps:
     - name: Checkout
@@ -32,6 +33,7 @@ jobs:
         node-version: [16.x, 18.x]
     env:
       NODE_ENV: test
+      HUSKY: "0"
       CYPRESS_INSTALL_BINARY: "0"
       PGHOST: postgres
       PGUSER: postgres
@@ -59,8 +61,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-      # Ignore scripts to prevent husky installation, which can break
-    - run: npm ci --ignore-scripts
+    - run: npm ci
     - name: Seed test database
       run: npm run db:migrate
     - name: Run tests
@@ -77,6 +78,7 @@ jobs:
       # https://github.com/cypress-io/github-action#firefox
       options: --user 1001
     env:
+      HUSKY: "0"
       # We need placeholder API keys to mock some third party integrations
       PELIAS_API_KEY: ge-iampelias
       PELIAS_HOST_NAME: dummy.pelias.com

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
+      HUSKY: "0"
       CYPRESS_INSTALL_BINARY: "0"
     steps:
     - name: Checkout


### PR DESCRIPTION
- Now that we're on Parcel v2 we no longer need to lock the cypress/browser image to an older version for compatibility issues
- Disables husky install in CI via environment variable, rather than `--ignore-scripts` flag which can clobber other packages' postinstall scripts.