### PR TITLE
Replace lodash with smaller alternatives

### DIFF
--- a/assets/scripts/app/StreetEditable.jsx
+++ b/assets/scripts/app/StreetEditable.jsx
@@ -2,8 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { DropTarget } from 'react-dnd'
-import flow from 'lodash/flow'
 import { CSSTransition, TransitionGroup } from 'react-transition-group'
+import { flow } from '../util/flow'
 import Segment from '../segments/Segment'
 import {
   TILE_SIZE,
@@ -220,11 +220,11 @@ function mapStateToProps (state) {
   }
 }
 
-export default flow(
+export default flow([
   DropTarget(
     [Types.SEGMENT, Types.PALETTE_SEGMENT],
     canvasTarget,
     collectDropTarget
   ),
   connect(mapStateToProps)
-)(StreetEditable)
+])(StreetEditable)

--- a/assets/scripts/app/keyboard_commands.js
+++ b/assets/scripts/app/keyboard_commands.js
@@ -1,5 +1,3 @@
-import { noop } from 'lodash'
-
 import USER_ROLES from '../../../app/data/user_roles'
 import { DRAGGING_TYPE_RESIZE, DRAGGING_TYPE_MOVE } from '../segments/constants'
 import { handleSegmentResizeCancel } from '../segments/resizing'
@@ -56,7 +54,7 @@ export function registerKeypresses () {
       preventDefault: true,
       requireFocusOnBody: false
     },
-    noop
+    () => {} // noop
   )
 
   // Catch-all for the backspace or delete buttons to prevent
@@ -67,7 +65,7 @@ export function registerKeypresses () {
       preventDefault: true,
       requireFocusOnBody: true
     },
-    noop
+    () => {} // noop
   )
 
   // Secret menu to toggle feature flags

--- a/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
+++ b/assets/scripts/dialogs/__tests__/GeotagDialog.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import React from 'react'
-import { cloneDeep } from 'lodash'
+import clone from 'just-clone'
 import { screen } from '@testing-library/react'
 import { render } from '../../../../test/helpers/render'
 import GeotagDialog from '../GeotagDialog'
@@ -159,7 +159,7 @@ describe('GeotagDialog', () => {
     })
 
     it('shows geocoding is unavailable if offline mode is on', () => {
-      const newInitialState = cloneDeep(initialState)
+      const newInitialState = clone(initialState)
       newInitialState.system.offline = true
 
       render(<GeotagDialog />, {

--- a/assets/scripts/info_bubble/InfoBubble.jsx
+++ b/assets/scripts/info_bubble/InfoBubble.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { IntlProvider, FormattedMessage } from 'react-intl'
-import { debounce } from 'lodash'
+import debounce from 'just-debounce-it'
 import { registerKeypress } from '../app/keypress'
 import { BUILDINGS } from '../segments/buildings'
 import {

--- a/assets/scripts/info_bubble/UpDownInput.jsx
+++ b/assets/scripts/info_bubble/UpDownInput.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { debounce } from 'lodash'
+import debounce from 'just-debounce-it'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import Button from '../ui/Button'
 import { ICON_MINUS, ICON_PLUS } from '../ui/icons'

--- a/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
+++ b/assets/scripts/info_bubble/__tests__/UpDownInput.test.js
@@ -4,12 +4,10 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import UpDownInput from '../UpDownInput'
 
-// Mock out lodash's `debounce` method so that the debounced
-// `onUpdatedValue` callback will be executed immediately when
-// called (we are not implementing the debounce in this test)
-jest.mock('lodash', () => ({
-  debounce: (fn) => fn
-}))
+// Mock the `debounce` method so that the debounced `onUpdatedValue` callback
+// will be executed immediately when called (we are not implementing the
+// debounce in this test)
+jest.mock('just-debounce-it', () => jest.fn((fn) => fn))
 
 const handleUp = jest.fn()
 const handleDown = jest.fn()

--- a/assets/scripts/segments/Segment.jsx
+++ b/assets/scripts/segments/Segment.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { DragSource, DropTarget } from 'react-dnd'
 import { getEmptyImage } from 'react-dnd-html5-backend'
-import flow from 'lodash/flow'
 import { CSSTransition } from 'react-transition-group'
+import { flow } from '../util/flow'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { INFO_BUBBLE_TYPE_SEGMENT } from '../info_bubble/constants'
 import { formatMessage } from '../locales/locale'
@@ -416,7 +416,7 @@ const mapDispatchToProps = {
   addToast
 }
 
-export default flow(
+export default flow([
   DragSource(Types.SEGMENT, segmentSource, collectDragSource),
   DropTarget(
     [Types.SEGMENT, Types.PALETTE_SEGMENT],
@@ -424,4 +424,4 @@ export default flow(
     collectDropTarget
   ),
   connect(mapStateToProps, mapDispatchToProps)
-)(Segment)
+])(Segment)

--- a/assets/scripts/segments/__tests__/info.test.js
+++ b/assets/scripts/segments/__tests__/info.test.js
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import { differenceWith, isEqual, isEqualWith } from 'lodash'
 import SEGMENT_INFO from '../info.json'
 import SPRITE_DEFS from '../sprite-defs.json'
 import {
@@ -100,15 +99,10 @@ describe('segment info', () => {
       expect(variant.unknown).toBeFalsy()
 
       const original = SEGMENT_INFO['turn-lane'].details['inbound|straight']
+      // Sort original array to pass equality check
+      original.graphics.center.sort()
 
-      const checkArrayEquality = (origValue, testValue) => {
-        if (Array.isArray(origValue) && Array.isArray(testValue)) {
-          return !differenceWith(origValue, testValue, isEqual).length
-        }
-      }
-
-      const correct = isEqualWith(original, variant, checkArrayEquality)
-      expect(correct).toEqual(true)
+      expect(variant).toEqual(original)
     })
   })
 })

--- a/assets/scripts/segments/scatter.js
+++ b/assets/scripts/segments/scatter.js
@@ -1,6 +1,6 @@
 import seedrandom from 'seedrandom'
-import maxBy from 'lodash/maxBy'
 import { images } from '../app/load_resources'
+import { maxBy } from '../util/maxBy'
 import { drawSegmentImage } from './view'
 import { getSpriteDef } from './info'
 import { TILE_SIZE, TILE_SIZE_ACTUAL } from './constants'
@@ -17,7 +17,7 @@ const DEFAULT_SCATTER_SPACING_MAX = 3 // in feet
  * @returns {Number} - maximum street width in feet
  */
 function getSpriteMaxWidth (pool) {
-  return maxBy(pool, 'width').width
+  return maxBy(pool, (s) => s.width).width
 }
 
 /**

--- a/assets/scripts/segments/segment-dict.js
+++ b/assets/scripts/segments/segment-dict.js
@@ -1,4 +1,4 @@
-import { uniq } from 'lodash'
+import { unique } from '../util/unique'
 import SEGMENT_COMPONENTS from './components.json'
 import SEGMENT_LOOKUP from './segment-lookup.json'
 import { SEGMENT_UNKNOWN, SEGMENT_UNKNOWN_VARIANT } from './info'
@@ -136,7 +136,7 @@ function appendVariantSprites (target, source) {
   const sourceArray = Array.isArray(source) ? source : [source]
 
   const graphicsInfo = targetArray.concat(sourceArray)
-  return uniq(graphicsInfo)
+  return unique(graphicsInfo)
 }
 
 /**

--- a/assets/scripts/sentiment/scores.js
+++ b/assets/scripts/sentiment/scores.js
@@ -1,4 +1,3 @@
-import find from 'lodash/find'
 import IMG_SENTIMENT_1 from '../../images/openmoji/color/1F620.svg'
 import IMG_SENTIMENT_2 from '../../images/openmoji/color/1F641.svg'
 import IMG_SENTIMENT_3 from '../../images/openmoji/color/1F610.svg'
@@ -54,7 +53,7 @@ const SCORE_DATA = [
 ]
 
 export function getDataForScore (score) {
-  return find(SCORE_DATA, { score })
+  return SCORE_DATA.find((d) => d.score === score)
 }
 
 export function getAllScoreData () {

--- a/assets/scripts/store/actions/street.js
+++ b/assets/scripts/store/actions/street.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import clone from 'just-clone'
 import {
   RESIZE_TYPE_INCREMENT,
   RESIZE_TYPE_PRECISE_DRAGGING,
@@ -119,7 +119,7 @@ export const incrementSegmentWidth = (
 }
 
 const createStreetFromResponse = (response) => {
-  const street = cloneDeep(response.data.street)
+  const street = clone(response.data.street)
   street.creatorId = (response.creator && response.creator.id) || null
   street.originalStreetId = response.originalStreetId || null
   street.updatedAt = response.updatedAt || null

--- a/assets/scripts/streets/data_model.js
+++ b/assets/scripts/streets/data_model.js
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid'
-import cloneDeep from 'lodash/cloneDeep'
+import clone from 'just-clone'
 import { DEFAULT_SEGMENTS } from '../segments/default'
 import {
   normalizeSegmentWidth,
@@ -462,7 +462,7 @@ function fillDefaultSegments (units) {
   const leftHandTraffic = getLeftHandTraffic()
 
   for (const i in DEFAULT_SEGMENTS[leftHandTraffic]) {
-    const segment = cloneDeep(DEFAULT_SEGMENTS[leftHandTraffic][i])
+    const segment = clone(DEFAULT_SEGMENTS[leftHandTraffic][i])
 
     segment.variantString = getVariantString(segment.variant)
 

--- a/assets/scripts/streets/undo_stack.js
+++ b/assets/scripts/streets/undo_stack.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import clone from 'just-clone'
 import { infoBubble } from '../info_bubble/info_bubble'
 import { cancelSegmentResizeTransitions } from '../segments/resizing'
 import store from '../store'
@@ -7,7 +7,7 @@ import { createNewUndo, unifyStack } from '../store/slices/undo'
 import { setUpdateTimeToNow, updateEverything } from './data_model'
 
 export function getUndoStack () {
-  return cloneDeep(store.getState().undo.stack)
+  return clone(store.getState().undo.stack)
 }
 
 export function getUndoPosition () {
@@ -17,7 +17,7 @@ export function getUndoPosition () {
 export function finishUndoOrRedo () {
   // set current street to the thing we just updated
   const { position, stack } = store.getState().undo
-  store.dispatch(updateStreetData(cloneDeep(stack[position])))
+  store.dispatch(updateStreetData(clone(stack[position])))
   cancelSegmentResizeTransitions()
 
   setUpdateTimeToNow()
@@ -35,7 +35,7 @@ export function createNewUndoIfNecessary (lastStreet = {}, currentStreet) {
     return
   }
 
-  store.dispatch(createNewUndo(cloneDeep(lastStreet)))
+  store.dispatch(createNewUndo(clone(lastStreet)))
 }
 
 export function unifyUndoStack () {

--- a/assets/scripts/streets/xhr.js
+++ b/assets/scripts/streets/xhr.js
@@ -1,4 +1,4 @@
-import { cloneDeep } from 'lodash'
+import clone from 'just-clone'
 import { showError, ERRORS } from '../app/errors'
 import {
   checkIfEverythingIsLoaded,
@@ -264,7 +264,7 @@ function unpackStreetDataFromServerTransmission (transmission) {
     return
   }
 
-  const street = cloneDeep(transmission.data.street)
+  const street = clone(transmission.data.street)
   street.creatorId = (transmission.creator && transmission.creator.id) || null
   street.originalStreetId = transmission.originalStreetId || null
   street.updatedAt = transmission.updatedAt || null
@@ -304,7 +304,7 @@ export function unpackServerStreetData (
   if (transmission.data.undoStack) {
     store.dispatch(
       replaceUndoStack({
-        stack: cloneDeep(transmission.data.undoStack),
+        stack: clone(transmission.data.undoStack),
         position: transmission.data.undoPosition
       })
     )
@@ -345,7 +345,7 @@ export function packServerStreetDataRaw () {
   delete data.street.creatorId
 
   if (store.getState().flags.SAVE_UNDO.value === true) {
-    data.undoStack = cloneDeep(store.getState().undo.stack)
+    data.undoStack = clone(store.getState().undo.stack)
     data.undoPosition = store.getState().undo.position
   }
 

--- a/assets/scripts/users/localization.js
+++ b/assets/scripts/users/localization.js
@@ -1,5 +1,4 @@
-import { cloneDeep } from 'lodash'
-
+import clone from 'just-clone'
 import { debug } from '../preinit/debug_settings'
 import { normalizeAllSegmentWidths } from '../segments/resizing'
 import { segmentsChanged } from '../segments/view'
@@ -172,7 +171,7 @@ export function updateUnits (newUnits) {
       )
     }
   } else {
-    store.dispatch(updateStreetData(cloneDeep(undoStack[undoPosition - 1])))
+    store.dispatch(updateStreetData(clone(undoStack[undoPosition - 1])))
   }
   segmentsChanged()
 

--- a/assets/scripts/users/settings.js
+++ b/assets/scripts/users/settings.js
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce'
+import debounce from 'just-debounce-it'
 import { MODES, getMode } from '../app/mode'
 import store, { observeStore } from '../store'
 import { updateSettings } from '../store/slices/settings'

--- a/assets/scripts/util/__tests__/maxBy.test.js
+++ b/assets/scripts/util/__tests__/maxBy.test.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+import { maxBy } from '../maxBy'
+
+describe('maxBy()', () => {
+  it('returns the object with the highest value property', () => {
+    const objs = [
+      { a: 1 },
+      { a: 3 },
+      { a: 4 },
+      { a: 5 },
+      { a: null },
+      { a: 9 },
+      { a: 1 }
+    ]
+    expect(maxBy(objs, (o) => o.a)).toEqual({ a: 9 })
+  })
+})

--- a/assets/scripts/util/__tests__/unique.test.js
+++ b/assets/scripts/util/__tests__/unique.test.js
@@ -1,0 +1,9 @@
+/* eslint-env jest */
+import { unique } from '../unique'
+
+describe('unique()', () => {
+  it('returns an array of unique values', () => {
+    const array = [1, 'a', '1', 'a', 'b', 1, 1, { x: 1 }, 'a', { x: 1 }]
+    expect(unique(array)).toEqual([1, 'a', '1', 'b', { x: 1 }, { x: 1 }])
+  })
+})

--- a/assets/scripts/util/flow.js
+++ b/assets/scripts/util/flow.js
@@ -1,0 +1,19 @@
+/**
+ * Replacement for lodash's flow().
+ *
+ * Creates a function that returns the result of invoking the given functions
+ * with the `this` binding of the created function, where each successive
+ * invocation is supplied the return value of the previous.
+ *
+ * This is the vanilla JS implementation via
+ * https://youmightnotneed.com/lodash/#flow
+ *
+ * WARNING: This is not a drop in replacement solution and it might not work
+ * for some edge cases.
+ *
+ * @param {Array} funcs - array of functions
+ * @returns Function
+ */
+export function flow (funcs) {
+  return (...args) => funcs.reduce((prev, fnc) => [fnc(...prev)], args)[0]
+}

--- a/assets/scripts/util/maxBy.js
+++ b/assets/scripts/util/maxBy.js
@@ -1,0 +1,24 @@
+/**
+ * Replacement for lodash's maxBy().
+ *
+ * This method is like _.max except that it accepts iteratee which is
+ * invoked for each element in array to generate the criterion by which
+ * the value is ranked. The iteratee is invoked with one argument: (value).
+ *
+ * This is the vanilla JS implementation via
+ * https://youmightnotneed.com/lodash/#maxBy
+ *
+ * WARNING: This is not a drop in replacement solution and it might not work
+ * for some edge cases.
+ *
+ * For instance: if not all objects in the array have the same properties,
+ * this will fail to find the correct object.
+ *
+ * @param {Array} arr - array of items to find the max value
+ * @param {Function} func - selector function
+ * @returns *
+ */
+export function maxBy (arr, func) {
+  const max = Math.max(...arr.map(func))
+  return arr.find((item) => func(item) === max)
+}

--- a/assets/scripts/util/unique.js
+++ b/assets/scripts/util/unique.js
@@ -1,0 +1,20 @@
+/**
+ * Replacement for lodash's uniq().
+ *
+ * Creates a duplicate-free version of an array, in which only the first
+ * occurrence of each element is kept. The order of result values is
+ * determined by the order they occur in the array.
+ *
+ * This is the vanilla JS implementation via
+ * https://youmightnotneed.com/lodash/#uniq
+ * (Using Array.from() instead of the spread operator)
+ *
+ * WARNING: This is not a drop in replacement solution and it might not work
+ * for some edge cases.
+ *
+ * @param {Array} arr - array of items to convert to unique values
+ * @returns Array
+ */
+export function unique (arr) {
+  return Array.from(new Set(arr))
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "js-cookie": "3.0.1",
         "json2csv": "5.0.6",
         "just-clone": "6.2.0",
+        "just-debounce-it": "3.2.0",
         "jwks-rsa": "3.0.1",
         "jwt-decode": "3.1.2",
         "leaflet": "1.9.3",
@@ -18092,6 +18093,11 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
       "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA=="
+    },
+    "node_modules/just-debounce-it": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-3.2.0.tgz",
+      "integrity": "sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ=="
     },
     "node_modules/jwa": {
       "version": "1.4.1",
@@ -38513,6 +38519,11 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
       "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA=="
+    },
+    "just-debounce-it": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/just-debounce-it/-/just-debounce-it-3.2.0.tgz",
+      "integrity": "sha512-WXzwLL0745uNuedrCsCs3rpmfD6DBaf7uuVwaq98/8dafURfgQaBsSpjiPp5+CW6Vjltwy9cOGI6qE71b3T8iQ=="
     },
     "jwa": {
       "version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "jwks-rsa": "3.0.1",
         "jwt-decode": "3.1.2",
         "leaflet": "1.9.3",
-        "lodash": "4.17.21",
         "nanoid": "3.1.31",
         "newrelic": "9.10.2",
         "nodemon": "2.0.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "intl-messageformat": "10.3.1",
         "js-cookie": "3.0.1",
         "json2csv": "5.0.6",
+        "just-clone": "6.2.0",
         "jwks-rsa": "3.0.1",
         "jwt-decode": "3.1.2",
         "leaflet": "1.9.3",
@@ -18086,6 +18087,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/just-clone": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA=="
     },
     "node_modules/jwa": {
       "version": "1.4.1",
@@ -38502,6 +38508,11 @@
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.1"
       }
+    },
+    "just-clone": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-6.2.0.tgz",
+      "integrity": "sha512-1IynUYEc/HAwxhi3WDpIpxJbZpMCvvrrmZVqvj9EhpvbH8lls7HhdhiByjL7DkAaWlLIzpC0Xc/VPvy/UxLNjA=="
     },
     "jwa": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "js-cookie": "3.0.1",
     "json2csv": "5.0.6",
     "just-clone": "6.2.0",
+    "just-debounce-it": "3.2.0",
     "jwks-rsa": "3.0.1",
     "jwt-decode": "3.1.2",
     "leaflet": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "jwks-rsa": "3.0.1",
     "jwt-decode": "3.1.2",
     "leaflet": "1.9.3",
-    "lodash": "4.17.21",
     "nanoid": "3.1.31",
     "newrelic": "9.10.2",
     "nodemon": "2.0.21",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "intl-messageformat": "10.3.1",
     "js-cookie": "3.0.1",
     "json2csv": "5.0.6",
+    "just-clone": "6.2.0",
     "jwks-rsa": "3.0.1",
     "jwt-decode": "3.1.2",
     "leaflet": "1.9.3",


### PR DESCRIPTION
See:
- https://github.com/angus-c/just
- https://youmightnotneed.com/lodash

Reasons for us to not use lodash:
- Some features have become normal JavaScript functionality (e.g. `Array.find()`), we should update our code
- Streetmix has always had a pretty lightweight JS bundle and thankfully doesn't add bloat too quickly, but squeezing some more bytes out is always a decent idea, which makes Streetmix more usable on slower Internet connections.