### PR TITLE
chore(package): keep node at v18 or v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": ">=18.x",
+    "node": "^18.x || ^20.x",
     "npm": ">=9.x"
   },
   "scripts": {


### PR DESCRIPTION
keep heroku from trying to install node v21, which breaks with sass right now