### PR TITLE
Increase profile image URL limit (again!)

### DIFF
--- a/app/db/migrations/20240509152241-increase-user-profile-url-length.cjs
+++ b/app/db/migrations/20240509152241-increase-user-profile-url-length.cjs
@@ -1,0 +1,40 @@
+'use strict'
+
+// Following up from 20210506170155-update-user-profile-url
+// we've found that in some rare cases, a googleusercontent.com
+// URL exceeds the 1024 character limit by just a little bit.
+// So let's just go ahead and double the URL length.
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.changeColumn('Users', 'profile_image_url', {
+      type: Sequelize.STRING(2048)
+    })
+  },
+
+  async down (queryInterface, Sequelize) {
+    // See the comment in 20210506170155-update-user-profile-url
+    // for why we use this pattern here when we roll back this step.
+    return queryInterface.sequelize.transaction((t) => {
+      return Promise.all([
+        queryInterface.sequelize.query(
+          `
+          UPDATE "Users"
+          SET profile_image_url = profile_image_url::varchar(1024)
+          WHERE CHAR_LENGTH(profile_image_url) > 1024
+        `,
+          { transaction: t }
+        ),
+        queryInterface.changeColumn(
+          'Users',
+          'profile_image_url',
+          {
+            type: Sequelize.STRING(1024)
+          },
+          { transaction: t }
+        )
+      ])
+    })
+  }
+}

--- a/app/db/models/user.js
+++ b/app/db/models/user.js
@@ -46,7 +46,13 @@ export default (sequelize, DataTypes) => {
         }
       },
       profileImageUrl: {
-        type: DataTypes.STRING(1024),
+        // The maximum URL length should be "under 2000 characters"
+        // https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers
+        // In practice, URLs from various login methods are under 1024
+        // characters, but a rare handful of googleusercontent.com URLs are
+        // just slightly longer. Bumping to 2048 characters should prevent
+        // SQL insert errors that block people from signing in.
+        type: DataTypes.STRING(2048),
         field: 'profile_image_url'
       },
       flags: DataTypes.JSON,

--- a/docs/docs/user-guide/changelog.md
+++ b/docs/docs/user-guide/changelog.md
@@ -5,6 +5,12 @@ sidebar_position: 5
 
 # What's new in Streetmix?
 
+## May 9, 2024
+
+### 🐛 Bug fixes
+
+- Fixed a database issue that can prevent logins from a Google e-mail address, in rare cases.
+
 ## April 26, 2024
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
Sequel (not SQL) to this: https://github.com/streetmix/streetmix/issues/2335

In some rare cases a `googleusercontent.com` URL can exceed the 1024 by a handful of characters (the longest I've seen recently is 1036). This would throw a `SequelizeDatabaseError` for users who had these profile image URLs, preventing them from logging in.