### PR TITLE
Port all SCSS variables to CSS custom properties

### DIFF
--- a/client/src/app/BlockingShield.scss
+++ b/client/src/app/BlockingShield.scss
@@ -1,4 +1,3 @@
-@import "../../styles/variables";
 @import "../../styles/mixins";
 
 .blocking-shield {
@@ -20,7 +19,7 @@
 
   &.darken,
   &.darken-immediately {
-    background: fade-out($sky-colour, 0.15);
+    background-color: color-mix(in oklch, var(--sky-color), transparent 15%);
     color: black;
   }
 

--- a/client/src/app/BlockingShield.scss
+++ b/client/src/app/BlockingShield.scss
@@ -4,7 +4,7 @@
 .blocking-shield {
   @include blocking-shield;
 
-  z-index: $z-09-blocking-shield;
+  z-index: var(--z-09-blocking-shield);
   display: none;
   background: transparent;
   color: transparent;

--- a/client/src/app/BlockingShield.scss
+++ b/client/src/app/BlockingShield.scss
@@ -19,7 +19,11 @@
 
   &.darken,
   &.darken-immediately {
-    background-color: color-mix(in oklch, var(--sky-color), transparent 15%);
+    // While the preferred mixing method is in oklch, there is a bug(?) in
+    // Safari where doing so also causes the hue to shift unexpectedly.
+    // Mixing transparency in srgb will only affect alpha channel as expected
+    // in tested browsers (Firefox + Chrome) including Safari.
+    background-color: color-mix(in srgb, var(--sky-color), transparent 15%);
     color: black;
   }
 

--- a/client/src/app/DebugInfo.scss
+++ b/client/src/app/DebugInfo.scss
@@ -1,10 +1,8 @@
-@import "../../styles/variables";
-
 .debug-container {
   position: fixed;
   inset: 0;
   padding: 30px;
-  z-index: $z-09-debug;
+  z-index: var(--z-09-debug);
   background-color: rgb(192 192 192 / 50%);
   backdrop-filter: blur(4px);
 

--- a/client/src/app/NotificationBar/NotificationBar.scss
+++ b/client/src/app/NotificationBar/NotificationBar.scss
@@ -5,8 +5,8 @@
   z-index: $z-08-notification-bar;
   padding: 0.75em calc(36px + 1.5em); /* Makes room for dismiss button */
   text-align: center; /* Since the app is very center-view oriented, this helps message legibility */
-  background-color: $alert-background;
-  border-bottom: $alert-border;
+  background-color: var(--alert-background);
+  border-bottom: var(--alert-border);
 }
 
 /* Close button overrides */

--- a/client/src/app/NotificationBar/NotificationBar.scss
+++ b/client/src/app/NotificationBar/NotificationBar.scss
@@ -1,18 +1,16 @@
-@import "../../../styles/variables";
-
 .notification-bar {
+  /* Close button overrides */
+  // TODO: Make standard for toast, status, etc
+  --close-icon-color: var(--color-copper-500);
+  --close-icon-color-hover: var(--color-copper-600);
+
   position: relative;
-  z-index: $z-08-notification-bar;
+  z-index: var(--z-08-notification-bar);
   padding: 0.75em calc(36px + 1.5em); /* Makes room for dismiss button */
   text-align: center; /* Since the app is very center-view oriented, this helps message legibility */
   background-color: var(--alert-background);
   border-bottom: var(--alert-border);
 }
-
-/* Close button overrides */
-// TODO: Make standard for toast, status, etc
-$close-icon-colour: $colour-copper-500;
-$close-icon-colour-hover: $colour-copper-600;
 
 .notification-bar .close {
   width: 24px;
@@ -33,10 +31,10 @@ $close-icon-colour-hover: $colour-copper-600;
   }
 
   svg {
-    color: $close-icon-colour !important;
+    color: var(--close-icon-color) !important;
   }
 
   &:hover svg {
-    color: $close-icon-colour-hover !important;
+    color: var(--close-icon-color-hover) !important;
   }
 }

--- a/client/src/app/PrintContainer.scss
+++ b/client/src/app/PrintContainer.scss
@@ -10,7 +10,7 @@
   width: 100%;
   height: 100%;
   background-color: white;
-  z-index: $z-10-print;
+  z-index: var(--z-10-print);
 
   img {
     max-width: 100%;

--- a/client/src/app/PrintContainer.scss
+++ b/client/src/app/PrintContainer.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .print-container {
   display: none;
   align-items: center;

--- a/client/src/app/ScrollIndicators.scss
+++ b/client/src/app/ScrollIndicators.scss
@@ -1,4 +1,3 @@
-@import "../../styles/variables";
 @import "../../styles/mixins";
 
 .street-scroll-indicators {
@@ -21,7 +20,7 @@
     letter-spacing: -0.15em;
     cursor: pointer;
     user-select: none;
-    z-index: $z-07-street-scroll;
+    z-index: var(--z-07-street-scroll);
 
     &:hover {
       opacity: 0.45;

--- a/client/src/app/SponsorBanner.scss
+++ b/client/src/app/SponsorBanner.scss
@@ -1,8 +1,6 @@
-@import "../../styles/variables";
-
 .sponsor-banner {
   position: relative;
-  z-index: $z-08-notification-bar;
+  z-index: var(--z-08-notification-bar);
   padding: 0.5em 1em 0.75em;
   background-color: var(--background-dirt-color);
   border-top: 5px solid

--- a/client/src/app/SponsorBanner.scss
+++ b/client/src/app/SponsorBanner.scss
@@ -1,12 +1,12 @@
-@use "sass:color";
 @import "../../styles/variables";
 
 .sponsor-banner {
   position: relative;
   z-index: $z-08-notification-bar;
   padding: 0.5em 1em 0.75em;
-  background-color: $background-dirt-colour;
-  border-top: 5px solid color.scale($background-dirt-colour, $lightness: -10%);
+  background-color: var(--background-dirt-color);
+  border-top: 5px solid
+    color-mix(in oklch, black 10%, var(--background-dirt-color));
   color: white;
 }
 

--- a/client/src/app/StreetView.scss
+++ b/client/src/app/StreetView.scss
@@ -38,7 +38,7 @@
 }
 
 #street-section-canvas {
-  z-index: $z-01-street-section;
+  z-index: var(--z-01-street-section);
   position: absolute;
   display: block;
   left: 0;

--- a/client/src/app/StreetView.scss
+++ b/client/src/app/StreetView.scss
@@ -1,11 +1,11 @@
-@import "../../styles/variables";
-
 // TODO: Further refactor / split up of this stylesheet
 
 #street-section-outer {
+  --building-space: 360px;
+
   position: absolute;
   display: block;
-  inset: -$gallery-height 0 -20px; // Bottom inset hides the scrollbar
+  inset: calc(-1 * var(--gallery-height)) 0 -20px; // Bottom inset hides the scrollbar
   overflow: scroll hidden;
   touch-action: pan-x;
 
@@ -22,7 +22,7 @@
   display: block;
   left: 0;
   bottom: 130px;
-  height: $canvas-height + 45;
+  height: calc(var(--canvas-height) + 45px);
   user-select: none;
 
   body.read-only & {
@@ -32,7 +32,7 @@
 
 #street-section-editable {
   position: absolute;
-  height: $canvas-height + 80;
+  height: calc(var(--canvas-height) + 80px);
   text-align: left;
   touch-action: pan-x;
 }
@@ -43,9 +43,9 @@
   display: block;
   left: 0;
   top: 0;
-  margin-left: $building-space;
-  margin-right: $building-space;
-  height: $canvas-height + 40;
+  margin-left: var(--building-space);
+  margin-right: var(--building-space);
+  height: calc(var(--canvas-height) + 40px);
 }
 
 .street-section-building {
@@ -53,7 +53,7 @@
   position: absolute;
   top: -105px;
   width: 396px;
-  height: $canvas-height + 70px;
+  height: calc(var(--canvas-height) + 70px);
   touch-action: pan-x;
 
   .hover-bk {

--- a/client/src/app/StreetView.scss
+++ b/client/src/app/StreetView.scss
@@ -63,7 +63,7 @@
   }
 
   &.hover .hover-bk {
-    background: $segment-hover-background;
+    background: var(--segment-hover-background);
   }
 
   canvas {

--- a/client/src/app/StreetViewDirt.scss
+++ b/client/src/app/StreetViewDirt.scss
@@ -8,8 +8,8 @@ $dirt-height-minimum: 5px;
   left: 0;
   right: 0;
   top: $canvas-height - 80px + $dirt-height;
-  border-top: $dirt-height-minimum solid $background-dirt-colour;
-  background: $bottom-background;
+  border-top: $dirt-height-minimum solid var(--background-dirt-color);
+  background: var(--bottom-background);
   z-index: -2;
   pointer-events: none;
 }
@@ -19,7 +19,7 @@ $dirt-height-minimum: 5px;
   content: " ";
   position: absolute;
   top: -($dirt-height + $dirt-height-minimum);
-  background-color: $background-dirt-colour;
+  background-color: var(--background-dirt-color);
   width: 360px;
   height: $dirt-height + $dirt-height-minimum;
 }

--- a/client/src/app/StreetViewDirt.scss
+++ b/client/src/app/StreetViewDirt.scss
@@ -1,14 +1,12 @@
-@import "../../styles/variables";
-
-$dirt-height: 40px;
-$dirt-height-minimum: 5px;
-
 .street-section-dirt {
+  --dirt-height: 40px;
+  --dirt-height-minimum: 5px;
+
   position: absolute;
   left: 0;
   right: 0;
-  top: $canvas-height - 80px + $dirt-height;
-  border-top: $dirt-height-minimum solid var(--background-dirt-color);
+  top: calc(var(--canvas-height) - 80px + var(--dirt-height));
+  border-top: var(--dirt-height-minimum) solid var(--background-dirt-color);
   background: var(--bottom-background);
   z-index: -2;
   pointer-events: none;
@@ -18,10 +16,10 @@ $dirt-height-minimum: 5px;
 .street-section-dirt-right {
   content: " ";
   position: absolute;
-  top: -($dirt-height + $dirt-height-minimum);
+  top: calc(-1 * (var(--dirt-height) + var(--dirt-height-minimum)));
   background-color: var(--background-dirt-color);
   width: 360px;
-  height: $dirt-height + $dirt-height-minimum;
+  height: calc(var(--dirt-height) + var(--dirt-height-minimum));
 }
 
 .street-section-dirt-left {

--- a/client/src/app/StreetmixPlusPrompt.scss
+++ b/client/src/app/StreetmixPlusPrompt.scss
@@ -1,11 +1,9 @@
-@import "../../styles/variables";
-
 .streetmix-plus-prompt {
   button {
-    border: 1px solid $colour-turquoise-400;
+    border: 1px solid var(--color-turquoise-400);
     width: 100%;
     background-color: transparent;
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
   }
 }
 
@@ -13,7 +11,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  color: $colour-copper-600;
+  color: var(--color-copper-600);
   font-weight: 550;
   font-size: 0.9em;
   text-transform: uppercase;

--- a/client/src/app/WelcomePanel.scss
+++ b/client/src/app/WelcomePanel.scss
@@ -104,7 +104,7 @@
 // Component specific tweaks to StreetName
 // Some duped styles from gallery element
 .welcome-panel .street-name {
-  @include street-name-mixin($street-name-gallery-size);
+  --street-name-size: var(--street-name-size-small);
 
   display: inline-block;
   position: relative;

--- a/client/src/app/WelcomePanel.scss
+++ b/client/src/app/WelcomePanel.scss
@@ -3,10 +3,10 @@
 @import "../../styles/mixins";
 @import "../streets/StreetName";
 
-$welcome-panel-border-radius: var(--border-radius);
-$welcome-panel-box-shadow: var(--medium-box-shadow);
-
 .welcome-panel-container {
+  --welcome-panel-border-radius: var(--border-radius);
+  --welcome-panel-box-shadow: var(--medium-box-shadow);
+
   position: absolute;
   top: 0;
   left: 0;
@@ -27,9 +27,9 @@ $welcome-panel-box-shadow: var(--medium-box-shadow);
   font-size: 1.2rem;
   color: rgb(64 64 64);
   pointer-events: auto;
-  border-bottom-left-radius: $welcome-panel-border-radius;
-  border-bottom-right-radius: $welcome-panel-border-radius;
-  box-shadow: $welcome-panel-box-shadow;
+  border-bottom-left-radius: var(--welcome-panel-border-radius);
+  border-bottom-right-radius: var(--welcome-panel-border-radius);
+  box-shadow: var(--welcome-panel-box-shadow);
 }
 
 .welcome-panel-content {

--- a/client/src/app/WelcomePanel.scss
+++ b/client/src/app/WelcomePanel.scss
@@ -3,7 +3,7 @@
 @import "../../styles/mixins";
 @import "../streets/StreetName";
 
-$welcome-panel-border-radius: $border-radius;
+$welcome-panel-border-radius: var(--border-radius);
 $welcome-panel-box-shadow: $medium-box-shadow;
 
 .welcome-panel-container {

--- a/client/src/app/WelcomePanel.scss
+++ b/client/src/app/WelcomePanel.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
 @import "../../styles/mixins";
 @import "../streets/StreetName";
 
@@ -70,7 +68,7 @@
     &:not(:first-child)::before {
       content: "·";
       margin: 0 5px;
-      color: color.adjust($ui-colour, $lightness: -40%);
+      color: var(--deprecated-ui-color-lightness-40);
       padding-left: 0;
     }
   }

--- a/client/src/app/WelcomePanel.scss
+++ b/client/src/app/WelcomePanel.scss
@@ -4,14 +4,14 @@
 @import "../streets/StreetName";
 
 $welcome-panel-border-radius: var(--border-radius);
-$welcome-panel-box-shadow: $medium-box-shadow;
+$welcome-panel-box-shadow: var(--medium-box-shadow);
 
 .welcome-panel-container {
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  z-index: $z-05-welcome;
+  z-index: var(--z-05-welcome);
   text-align: center;
   user-select: none;
   pointer-events: none;

--- a/client/src/dialogs/About/SocialLinks.scss
+++ b/client/src/dialogs/About/SocialLinks.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .social-links {
   li {
     display: inline-block;
@@ -7,10 +5,10 @@
   }
 
   a {
-    color: $colour-midnight-400;
+    color: var(--color-midnight-400);
 
     &:hover {
-      color: $colour-midnight-500;
+      color: var(--color-midnight-500);
     }
   }
 

--- a/client/src/dialogs/About/SocialLinks.scss
+++ b/client/src/dialogs/About/SocialLinks.scss
@@ -21,41 +21,41 @@
 }
 
 .social-github {
-  color: $social-github;
+  color: var(--social-github);
 
   &:hover {
-    color: $social-github-hover;
+    color: var(--social-github-hover);
   }
 }
 
 .social-discord {
-  color: $social-discord;
+  color: var(--social-discord);
 
   &:hover {
-    color: $social-discord-hover;
+    color: var(--social-discord-hover);
   }
 }
 
 .social-mastodon {
-  color: $social-mastodon;
+  color: var(--social-mastodon);
 
   &:hover {
-    color: $social-mastodon-hover;
+    color: var(--social-mastodon-hover);
   }
 }
 
 .social-twitter {
-  color: $social-twitter;
+  color: var(--social-twitter);
 
   &:hover {
-    color: $social-twitter-hover;
+    color: var(--social-twitter-hover);
   }
 }
 
 .social-instagram {
-  color: $social-instagram;
+  color: var(--social-instagram);
 
   &:hover {
-    color: $social-instagram-hover;
+    color: var(--social-instagram-hover);
   }
 }

--- a/client/src/dialogs/AboutDialog.scss
+++ b/client/src/dialogs/AboutDialog.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .about-dialog {
   width: 820px;
   min-height: 660px;
@@ -43,9 +41,8 @@
 }
 
 .about-dialog-left {
-  flex-basis: 240px;
   margin-right: 40px;
-  border-right: 1px solid $colour-turquoise-350;
+  border-right: 1px solid var(--color-turquoise-350);
   padding-right: 40px;
   position: fixed;
   width: 280px;
@@ -53,7 +50,7 @@
   [dir="rtl"] & {
     margin-left: 40px;
     margin-right: 0;
-    border-left: 1px solid $colour-turquoise-350;
+    border-left: 1px solid var(--color-turquoise-350);
     border-right: 0;
     padding-left: 40px;
     padding-right: 0;

--- a/client/src/dialogs/Analytics/SegmentAnalytics.scss
+++ b/client/src/dialogs/Analytics/SegmentAnalytics.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .segment-analytics {
   --analytics-color-1-main: var(--color-emerald-350);
   --analytics-color-1-alt: var(--color-emerald-150);

--- a/client/src/dialogs/Analytics/SegmentAnalytics.scss
+++ b/client/src/dialogs/Analytics/SegmentAnalytics.scss
@@ -1,19 +1,19 @@
 @import "../../../styles/variables";
 
-$color-1-main: $colour-emerald-350;
-$color-1-alt: $colour-emerald-150;
-$color-1-em: $colour-emerald-400;
-$color-2-main: var(--color-turquoise-350);
-$color-2-alt: $colour-turquoise-150;
-$color-2-em: $colour-turquoise-400;
-$color-3-main: $colour-copper-350;
-$color-3-alt: $colour-copper-150;
-$color-3-em: $colour-copper-400;
-$color-4-main: $colour-midnight-350;
-$color-4-alt: $colour-midnight-150;
-$color-4-em: $colour-midnight-400;
-
 .segment-analytics {
+  --analytics-color-1-main: var(--color-emerald-350);
+  --analytics-color-1-alt: var(--color-emerald-150);
+  --analytics-color-1-em: var(--color-emerald-400);
+  --analytics-color-2-main: var(--color-turquoise-350);
+  --analytics-color-2-alt: var(--color-turquoise-150);
+  --analytics-color-2-em: var(--color-turquoise-400);
+  --analytics-color-3-main: var(--color-copper-350);
+  --analytics-color-3-alt: var(--color-copper-150);
+  --analytics-color-3-em: var(--color-copper-400);
+  --analytics-color-4-main: var(--color-midnight-350);
+  --analytics-color-4-alt: var(--color-midnight-150);
+  --analytics-color-4-em: var(--color-midnight-400);
+
   position: relative;
   width: 100%;
   margin-bottom: 0.25em;
@@ -39,19 +39,19 @@ $color-4-em: $colour-midnight-400;
   z-index: 1;
 
   [data-color="1"] & {
-    background-color: $color-1-main;
+    background-color: var(--analytics-color-1-main);
   }
 
   [data-color="2"] & {
-    background-color: $color-2-main;
+    background-color: var(--analytics-color-2-main);
   }
 
   [data-color="3"] & {
-    background-color: $color-3-main;
+    background-color: var(--analytics-color-3-main);
   }
 
   [data-color="4"] & {
-    background-color: $color-4-main;
+    background-color: var(--analytics-color-4-main);
   }
 }
 
@@ -70,19 +70,19 @@ $color-4-em: $colour-midnight-400;
   overflow: hidden;
 
   [data-color="1"] & {
-    border-color: $color-1-em;
+    border-color: var(--analytics-color-1-em);
   }
 
   [data-color="2"] & {
-    border-color: $color-2-em;
+    border-color: var(--analytics-color-2-em);
   }
 
   [data-color="3"] & {
-    border-color: $color-3-em;
+    border-color: var(--analytics-color-3-em);
   }
 
   [data-color="4"] & {
-    border-color: $color-4-em;
+    border-color: var(--analytics-color-4-em);
   }
 
   img {
@@ -99,37 +99,37 @@ $color-4-em: $colour-midnight-400;
 
 .capacity-bar.capacity-bar-average {
   [data-color="1"] & {
-    background-color: $color-1-main;
+    background-color: var(--analytics-color-1-main);
   }
 
   [data-color="2"] & {
-    background-color: $color-2-main;
+    background-color: var(--analytics-color-2-main);
   }
 
   [data-color="3"] & {
-    background-color: $color-3-main;
+    background-color: var(--analytics-color-3-main);
   }
 
   [data-color="4"] & {
-    background-color: $color-4-main;
+    background-color: var(--analytics-color-4-main);
   }
 }
 
 .capacity-bar.capacity-bar-potential {
   [data-color="1"] & {
-    background-color: $color-1-alt;
+    background-color: var(--analytics-color-1-alt);
   }
 
   [data-color="2"] & {
-    background-color: $color-2-alt;
+    background-color: var(--analytics-color-2-alt);
   }
 
   [data-color="3"] & {
-    background-color: $color-3-alt;
+    background-color: var(--analytics-color-3-alt);
   }
 
   [data-color="4"] & {
-    background-color: $color-4-alt;
+    background-color: var(--analytics-color-4-alt);
   }
 }
 

--- a/client/src/dialogs/Analytics/SegmentAnalytics.scss
+++ b/client/src/dialogs/Analytics/SegmentAnalytics.scss
@@ -3,7 +3,7 @@
 $color-1-main: $colour-emerald-350;
 $color-1-alt: $colour-emerald-150;
 $color-1-em: $colour-emerald-400;
-$color-2-main: $colour-turquoise-350;
+$color-2-main: var(--color-turquoise-350);
 $color-2-alt: $colour-turquoise-150;
 $color-2-em: $colour-turquoise-400;
 $color-3-main: $colour-copper-350;

--- a/client/src/dialogs/AnalyticsDialog.scss
+++ b/client/src/dialogs/AnalyticsDialog.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .analytics-dialog {
   width: 820px;
   max-height: 75vh;
@@ -97,11 +95,11 @@
   padding: 0.5em 1em;
   margin: 0.5em auto 0;
   border-radius: var(--border-radius-pill);
-  background-color: $colour-copper-100;
-  color: $colour-copper-700;
+  background-color: var(--color-copper-100);
+  color: var(--color-copper-700);
 
   svg {
     margin-right: 0.75em;
-    color: $colour-copper-500;
+    color: var(--color-copper-500);
   }
 }

--- a/client/src/dialogs/AnalyticsDialog.scss
+++ b/client/src/dialogs/AnalyticsDialog.scss
@@ -96,7 +96,7 @@
   width: max-content;
   padding: 0.5em 1em;
   margin: 0.5em auto 0;
-  border-radius: $border-radius-pill;
+  border-radius: var(--border-radius-pill);
   background-color: $colour-copper-100;
   color: $colour-copper-700;
 

--- a/client/src/dialogs/Dialog.scss
+++ b/client/src/dialogs/Dialog.scss
@@ -1,11 +1,11 @@
 @import "../../styles/variables";
 @import "../../styles/mixins";
 
-$dialog-border-radius: var(--border-radius-large);
-$header-background-colour: var(--color-turquoise-200);
-$header-text-colour: var(--color-turquoise-700);
-
 .dialog-box-container {
+  --dialog-border-radius: var(--border-radius-large);
+  --header-background-color: var(--color-turquoise-200);
+  --header-text-color: var(--color-turquoise-700);
+
   display: flex;
   align-items: center;
   justify-content: center;
@@ -40,7 +40,7 @@ $header-text-colour: var(--color-turquoise-700);
   touch-action: none;
 
   /* New styles! Let's try it! */
-  border-radius: $dialog-border-radius;
+  border-radius: var(--dialog-border-radius);
   overflow: hidden;
   box-shadow: 0 0 20px 0 rgb(0 0 0 / 7.5%);
 
@@ -60,8 +60,8 @@ $header-text-colour: var(--color-turquoise-700);
   header {
     padding: 1.75rem 1em;
     text-align: center;
-    background-color: $header-background-colour;
-    color: $header-text-colour;
+    background-color: var(--header-background-color);
+    color: var(--header-text-color);
   }
 
   h1 {
@@ -141,7 +141,7 @@ button.dialog-primary-action {
   font-weight: normal;
   width: 100%;
   text-align: center;
-  color: $colour-turquoise-600;
+  color: var(--color-turquoise-600);
   min-height: 46px;
   cursor: pointer;
 
@@ -149,7 +149,7 @@ button.dialog-primary-action {
   margin-top: 0 !important;
 
   &:hover {
-    background-color: $colour-turquoise-100;
-    color: $colour-turquoise-700;
+    background-color: var(--color-turquoise-100);
+    color: var(--color-turquoise-700);
   }
 }

--- a/client/src/dialogs/Dialog.scss
+++ b/client/src/dialogs/Dialog.scss
@@ -1,9 +1,9 @@
 @import "../../styles/variables";
 @import "../../styles/mixins";
 
-$dialog-border-radius: $border-radius-large;
-$header-background-colour: $colour-turquoise-200;
-$header-text-colour: $colour-turquoise-700;
+$dialog-border-radius: var(--border-radius-large);
+$header-background-colour: var(--color-turquoise-200);
+$header-text-colour: var(--color-turquoise-700);
 
 .dialog-box-container {
   display: flex;

--- a/client/src/dialogs/Dialog.scss
+++ b/client/src/dialogs/Dialog.scss
@@ -20,7 +20,7 @@
   z-index: var(--z-08-dialog-box-backdrop);
   position: absolute;
   inset: 0;
-  background: fade-out($sky-colour, 0.5);
+  background: var(--sky-color);
   touch-action: none;
 
   /* Transitions */
@@ -113,7 +113,7 @@
 }
 
 .dialog-transition-enter-done .dialog-box-backdrop {
-  opacity: 1;
+  opacity: 0.5;
 }
 
 .dialog-transition-exit .dialog-box-backdrop {
@@ -135,7 +135,7 @@
 
 button.dialog-primary-action {
   border: 0;
-  border-top: 1px solid $colour-turquoise-350;
+  border-top: 1px solid var(--color-turquoise-350);
   border-radius: 0;
   background-color: white;
   font-weight: normal;

--- a/client/src/dialogs/Dialog.scss
+++ b/client/src/dialogs/Dialog.scss
@@ -17,7 +17,7 @@ $header-text-colour: var(--color-turquoise-700);
 }
 
 .dialog-box-backdrop {
-  z-index: $z-08-dialog-box-backdrop;
+  z-index: var(--z-08-dialog-box-backdrop);
   position: absolute;
   inset: 0;
   background: fade-out($sky-colour, 0.5);
@@ -36,7 +36,7 @@ $header-text-colour: var(--color-turquoise-700);
   padding: 0;
   background: white;
   line-height: 1.4;
-  z-index: $z-09-dialog-box;
+  z-index: var(--z-09-dialog-box);
   touch-action: none;
 
   /* New styles! Let's try it! */
@@ -90,7 +90,7 @@ $header-text-colour: var(--color-turquoise-700);
   }
 
   button.close {
-    z-index: $z-09-dialog-box;
+    z-index: var(--z-09-dialog-box);
   }
 
   // Button placement

--- a/client/src/dialogs/Dialog.scss
+++ b/client/src/dialogs/Dialog.scss
@@ -1,4 +1,3 @@
-@import "../../styles/variables";
 @import "../../styles/mixins";
 
 .dialog-box-container {

--- a/client/src/dialogs/GeotagDialog.scss
+++ b/client/src/dialogs/GeotagDialog.scss
@@ -1,8 +1,6 @@
-@import "../../styles/variables";
-
-$geotag-error-banner-margin: 100px;
-
 .geotag-dialog {
+  --geotag-error-banner-margin: 100px;
+
   width: 90vw;
   height: 80vh;
   max-height: 960px; /* Prevent outside of map being shown when default view on large monitors */
@@ -22,6 +20,7 @@ $geotag-error-banner-margin: 100px;
   border-bottom: var(--alert-border);
   border-bottom-left-radius: var(--border-radius-medium);
   border-bottom-right-radius: var(--border-radius-medium);
+  box-shadow: var(--medium-box-shadow);
 
   /* Place error banner above map */
   position: absolute;
@@ -32,8 +31,8 @@ $geotag-error-banner-margin: 100px;
 
   /* Constrain width of banner to allow for zoom widget and close
      dialog button */
-  width: calc(100% - #{$geotag-error-banner-margin * 2});
-  margin: 0 $geotag-error-banner-margin;
+  width: calc(100% - (var(--geotag-error-banner-margin) * 2));
+  margin: 0 var(--geotag-error-banner-margin);
 }
 
 .geotag-input-container {

--- a/client/src/dialogs/GeotagDialog.scss
+++ b/client/src/dialogs/GeotagDialog.scss
@@ -10,7 +10,7 @@ $geotag-error-banner-margin: 100px;
 }
 
 .geotag-dialog .close {
-  z-index: $z-index-10;
+  z-index: var(--z-index-10);
   text-shadow: 0 1px white;
 }
 
@@ -40,7 +40,7 @@ $geotag-error-banner-margin: 100px;
   position: absolute;
   top: 10px;
   width: 100%;
-  z-index: $z-index-10;
+  z-index: var(--z-index-10);
   pointer-events: none;
 }
 
@@ -75,7 +75,7 @@ $geotag-error-banner-margin: 100px;
   border: 1px solid var(--form-element-border);
   border-top: 0;
   background-color: white;
-  font-family: $font-family;
+  font-family: var(--font-family);
   list-style-type: none;
 }
 
@@ -99,7 +99,7 @@ $geotag-error-banner-margin: 100px;
 .leaflet-container {
   background-color: var(--off-white);
   height: 100%;
-  font-family: $font-family;
+  font-family: var(--font-family);
   font-size: inherit;
 }
 
@@ -137,7 +137,7 @@ $geotag-error-banner-margin: 100px;
   bottom: 12px;
   margin-left: -12px;
   transform: rotateZ(45deg);
-  background: $info-bubble-background;
+  background: var(--info-bubble-background);
   box-shadow: none;
 }
 
@@ -162,7 +162,7 @@ $geotag-error-banner-margin: 100px;
 
 .leaflet-touch .leaflet-bar,
 .leaflet-bar {
-  box-shadow: $medium-box-shadow;
+  box-shadow: var(--medium-box-shadow);
   border: 0;
 }
 

--- a/client/src/dialogs/GeotagDialog.scss
+++ b/client/src/dialogs/GeotagDialog.scss
@@ -1,6 +1,5 @@
 @import "../../styles/variables";
 
-$geotag-dialog-background-color: $off-white;
 $geotag-error-banner-margin: 100px;
 
 .geotag-dialog {
@@ -19,10 +18,10 @@ $geotag-error-banner-margin: 100px;
   /* Very similar to the notification bar banner */
   padding: 0.75em 2.5em;
   text-align: center;
-  background-color: $alert-background;
-  border-bottom: $alert-border;
-  border-bottom-left-radius: $border-radius-medium;
-  border-bottom-right-radius: $border-radius-medium;
+  background-color: var(--alert-background);
+  border-bottom: var(--alert-border);
+  border-bottom-left-radius: var(--border-radius-medium);
+  border-bottom-right-radius: var(--border-radius-medium);
 
   /* Place error banner above map */
   position: absolute;
@@ -65,15 +64,15 @@ $geotag-error-banner-margin: 100px;
 .geotag-input {
   width: 100%;
   padding: 3px 24px 3px 6px !important;
-  border: 1px solid $form-element-border;
+  border: 1px solid var(--form-element-border);
   resize: none;
   font-size: inherit;
   line-height: 2;
-  background-color: $form-element-background;
+  background-color: var(--form-element-background);
 }
 
 .geotag-suggestions-container {
-  border: 1px solid $form-element-border;
+  border: 1px solid var(--form-element-border);
   border-top: 0;
   background-color: white;
   font-family: $font-family;
@@ -92,13 +91,13 @@ $geotag-error-banner-margin: 100px;
 }
 
 .geotag-suggestion[aria-selected="true"] {
-  background-color: $form-element-background;
+  background-color: var(--form-element-background);
 }
 
 /* Leaflet overrides */
 
 .leaflet-container {
-  background-color: $geotag-dialog-background-color;
+  background-color: var(--off-white);
   height: 100%;
   font-family: $font-family;
   font-size: inherit;
@@ -117,7 +116,7 @@ $geotag-error-banner-margin: 100px;
 }
 
 .leaflet-popup-content-wrapper {
-  border-radius: $border-radius;
+  border-radius: var(--border-radius);
 }
 
 .leaflet-popup-content-wrapper,

--- a/client/src/dialogs/NewsletterDialog.scss
+++ b/client/src/dialogs/NewsletterDialog.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-
 .newsletter-dialog {
   min-width: 400px;
   max-width: 520px;

--- a/client/src/dialogs/NewsletterDialog.scss
+++ b/client/src/dialogs/NewsletterDialog.scss
@@ -31,11 +31,10 @@
     box-shadow 0.15s;
 
   &:focus {
-    border-color: $colour-turquoise-425;
     outline: 0;
     box-shadow:
       inset 0 1px 1px rgb(0 0 0 / 7%),
-      0 0 8px color.adjust($colour-turquoise-450, $alpha: -0.1);
+      0 0 10px color-mix(in srgb, var(--color-turquoise-450), transparent 25%);
   }
 
   &.subscribe-input-error {

--- a/client/src/dialogs/NewsletterDialog.scss
+++ b/client/src/dialogs/NewsletterDialog.scss
@@ -24,7 +24,7 @@
   border-radius: 3px;
   padding: 0.75em;
   width: 100%;
-  border: $button-border;
+  border: var(--button-border);
   box-shadow: inset 0 1px 1px rgb(0 0 0 / 7%);
   transition:
     border-color 0.15s ease-in-out,

--- a/client/src/dialogs/SaveAsImage/CustomScale.scss
+++ b/client/src/dialogs/SaveAsImage/CustomScale.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .custom-scale {
   margin-bottom: 1em;
   display: flex;
@@ -28,13 +26,13 @@
 }
 
 .custom-scale-info {
-  color: $colour-turquoise-600;
+  color: var(--color-turquoise-600);
 }
 
 .custom-scale-disabled {
-  color: $colour-midnight-300;
+  color: var(--color-midnight-300);
 
   .custom-scale-info {
-    color: $colour-midnight-300;
+    color: var(--color-midnight-300);
   }
 }

--- a/client/src/dialogs/SaveAsImageDialog.scss
+++ b/client/src/dialogs/SaveAsImageDialog.scss
@@ -1,6 +1,3 @@
-@import "../../styles/variables";
-@import "../../styles/mixins";
-
 // Content of Save as Image dialog box
 .save-as-image-dialog {
   width: 720px;
@@ -45,8 +42,8 @@
   margin-top: 20px;
   margin-bottom: 20px;
   max-height: 300px;
-  border-top: 3px dashed $ui-colour;
-  border-bottom: 3px dashed $ui-colour;
+  border-top: 3px dashed var(--color-turquoise-400);
+  border-bottom: 3px dashed var(--color-turquoise-400);
 }
 
 .save-as-image-preview-loading {

--- a/client/src/dialogs/SaveAsImageDialog.scss
+++ b/client/src/dialogs/SaveAsImageDialog.scss
@@ -98,7 +98,7 @@
 
 .save-as-image-too-large-error {
   font-weight: 550;
-  color: $warning-colour;
+  color: var(--warning-color);
 }
 
 .save-as-image-download {

--- a/client/src/dialogs/Settings/ProfileSettings.scss
+++ b/client/src/dialogs/Settings/ProfileSettings.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .profile-settings-item {
   margin-top: 1.2em;
 

--- a/client/src/dialogs/SettingsDialog.scss
+++ b/client/src/dialogs/SettingsDialog.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .settings-dialog {
   width: 650px;
   height: 70vh;
@@ -35,7 +33,7 @@
     cursor: pointer;
 
     &:hover {
-      background-color: $colour-turquoise-200;
+      background-color: var(--color-turquoise-200);
     }
   }
 }
@@ -46,7 +44,7 @@
   overflow: hidden auto;
 
   h2 {
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
     font-weight: normal;
   }
 
@@ -60,15 +58,15 @@
 }
 
 .settings-menu-active {
-  background-color: $colour-turquoise-100;
-  color: $colour-turquoise-700;
+  background-color: var(--color-turquoise-100);
+  color: var(--color-turquoise-700);
   font-weight: 550;
 }
 
 .settings-menu-icon {
   vertical-align: text-top;
   margin-right: 0.5em;
-  color: $colour-turquoise-600;
+  color: var(--color-turquoise-600);
 
   [dir="rtl"] & {
     margin-left: 0.5em;

--- a/client/src/dialogs/SettingsDialog.scss
+++ b/client/src/dialogs/SettingsDialog.scss
@@ -16,11 +16,11 @@
 
 .settings-dialog-left {
   width: 180px;
-  border-right: 1px solid $colour-turquoise-350;
+  border-right: 1px solid var(--color-turquoise-350);
   overflow: hidden auto;
 
   [dir="rtl"] & {
-    border-left: 1px solid $colour-turquoise-350;
+    border-left: 1px solid var(--color-turquoise-350);
   }
 
   ul {

--- a/client/src/dialogs/SignInDialog.scss
+++ b/client/src/dialogs/SignInDialog.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-
 .sign-in-dialog {
   width: 450px;
   min-height: 250px;

--- a/client/src/dialogs/SignInDialog.scss
+++ b/client/src/dialogs/SignInDialog.scss
@@ -23,7 +23,7 @@
   border-radius: 3px;
   padding: 0.75em;
   width: 100%;
-  border: $button-border;
+  border: var(--button-border);
   box-shadow: inset 0 1px 1px rgb(0 0 0 / 7%);
   transition:
     border-color 0.15s ease-in-out,

--- a/client/src/dialogs/SignInDialog.scss
+++ b/client/src/dialogs/SignInDialog.scss
@@ -30,11 +30,10 @@
     box-shadow 0.15s;
 
   &:focus {
-    border-color: $colour-turquoise-425;
     outline: 0;
     box-shadow:
       inset 0 1px 1px rgb(0 0 0 / 7%),
-      0 0 8px color.adjust($colour-turquoise-450, $alpha: -0.1);
+      0 0 10px color-mix(in srgb, var(--color-turquoise-450), transparent 25%);
   }
 
   &.sign-in-input-error {

--- a/client/src/dialogs/SignInDialog.scss
+++ b/client/src/dialogs/SignInDialog.scss
@@ -95,11 +95,11 @@
 }
 
 .sign-in-twitter-button .fa-twitter {
-  color: $social-twitter !important;
+  color: var(--social-twitter) !important;
 }
 
 .sign-in-facebook-button .fa-square-facebook {
-  color: $social-facebook !important;
+  color: var(--social-facebook) !important;
 }
 
 .sign-in-disclaimer {

--- a/client/src/dialogs/WhatsNewDialog.scss
+++ b/client/src/dialogs/WhatsNewDialog.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-
 .whats-new-dialog {
   width: 550px;
   height: 80vh;
@@ -21,13 +18,13 @@
   }
 
   h2 {
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
     font-weight: 550;
     font-size: 1.75rem;
   }
 
   h2:not(:first-of-type) {
-    border-top: 1px solid $colour-turquoise-300;
+    border-top: 1px solid var(--color-turquoise-300);
     padding-top: 1.25em;
     margin-top: 1.25em;
   }
@@ -37,7 +34,7 @@
     margin-bottom: 1em;
     font-weight: 550;
     font-size: 1.35rem;
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
   }
 
   ul {
@@ -61,7 +58,7 @@
   }
 
   .img-ui {
-    border: 1px solid $colour-turquoise-400;
+    border: 1px solid var(--color-turquoise-400);
     border-radius: 6px;
     padding: 10px;
     box-shadow: 0 2px 10px rgb(0 0 0 / 5%);
@@ -80,26 +77,26 @@
   /* Very similar to the notification bar banner */
   padding: 0.75em 2.5em;
   text-align: center;
-  background-color: $alert-background;
-  border-bottom: $alert-border;
+  background-color: var(--alert-background);
+  border-bottom: var(--alert-border);
 }
 
 .whats-new-scroll-shade {
   position: absolute;
   width: 100%;
-  height: 40px;
+  height: max(60px, 10%);
   top: 0;
   left: 0;
   transition: opacity 300ms ease-in-out;
   pointer-events: none;
   background: linear-gradient(
     180deg,
-    color.change($colour-turquoise-500, $alpha: 0.1) 0%,
+    var(--color-turquoise-500) 0%,
     transparent 100%
   );
   opacity: 0;
 }
 
 .whats-new-scroll-shade.visible {
-  opacity: 1;
+  opacity: 0.15;
 }

--- a/client/src/gallery/Gallery.scss
+++ b/client/src/gallery/Gallery.scss
@@ -1,13 +1,6 @@
-@use "sass:color";
-@import "../../styles/variables";
-
-$gallery-border-radius: var(--border-radius);
-$gallery-box-shadow: var(--medium-box-shadow);
-$selection-highlight-colour: $colour-copper-500;
-
 body.gallery-visible {
   .main-screen {
-    transform: translateY($gallery-height - 90px);
+    transform: translateY(calc(var(--gallery-height) - 90px));
   }
 
   .street-nameplate-container {
@@ -20,22 +13,25 @@ body:not(.safari).gallery-visible .street-section-sky {
 }
 
 .gallery-panel {
+  --gallery-border-radius: var(--border-radius);
+  --gallery-box-shadow: var(--medium-box-shadow);
+
   position: absolute;
   left: var(--left-right-inset);
   right: var(--left-right-inset);
   top: 0;
-  height: $gallery-height;
+  height: var(--gallery-height);
   display: flex;
   flex-direction: column;
   padding: 10px 16px 16px;
   z-index: var(--z-09-gallery);
-  border-bottom-left-radius: $gallery-border-radius;
-  border-bottom-right-radius: $gallery-border-radius;
+  border-bottom-left-radius: var(--gallery-border-radius);
+  border-bottom-right-radius: var(--gallery-border-radius);
   background: white;
-  box-shadow: $gallery-box-shadow;
+  box-shadow: var(--gallery-box-shadow);
   overflow: hidden;
   pointer-events: none;
-  transform: translateY(-$gallery-height) rotateX(25deg);
+  transform: translateY(calc(-1 * var(--gallery-height))) rotateX(25deg);
   transform-origin: 50% 0;
 }
 

--- a/client/src/gallery/Gallery.scss
+++ b/client/src/gallery/Gallery.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 @import "../../styles/variables";
 
-$gallery-border-radius: $border-radius;
+$gallery-border-radius: var(--border-radius);
 $gallery-box-shadow: $medium-box-shadow;
 $selection-highlight-colour: $colour-copper-500;
 
@@ -21,8 +21,8 @@ body:not(.safari).gallery-visible .street-section-sky {
 
 .gallery-panel {
   position: absolute;
-  left: $left-right-inset;
-  right: $left-right-inset;
+  left: var(--left-right-inset);
+  right: var(--left-right-inset);
   top: 0;
   height: $gallery-height;
   display: flex;

--- a/client/src/gallery/Gallery.scss
+++ b/client/src/gallery/Gallery.scss
@@ -2,7 +2,7 @@
 @import "../../styles/variables";
 
 $gallery-border-radius: var(--border-radius);
-$gallery-box-shadow: $medium-box-shadow;
+$gallery-box-shadow: var(--medium-box-shadow);
 $selection-highlight-colour: $colour-copper-500;
 
 body.gallery-visible {
@@ -28,7 +28,7 @@ body:not(.safari).gallery-visible .street-section-sky {
   display: flex;
   flex-direction: column;
   padding: 10px 16px 16px;
-  z-index: $z-09-gallery;
+  z-index: var(--z-09-gallery);
   border-bottom-left-radius: $gallery-border-radius;
   border-bottom-right-radius: $gallery-border-radius;
   background: white;
@@ -48,7 +48,7 @@ body:not(.safari).gallery-visible .street-section-sky {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  z-index: $z-03-gallery-message;
+  z-index: var(--z-03-gallery-message);
 
   a {
     color: inherit;

--- a/client/src/gallery/GalleryContents.scss
+++ b/client/src/gallery/GalleryContents.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-
 .gallery-header {
   display: flex;
   flex-direction: row;

--- a/client/src/gallery/GalleryContents.scss
+++ b/client/src/gallery/GalleryContents.scss
@@ -43,7 +43,7 @@
 .streets-scrollable-container {
   position: relative;
   top: 1px;
-  height: $gallery-height;
+  height: var(--gallery-height);
   min-width: 0; // Allows content to overflow flex element
   flex-grow: 1;
 
@@ -65,7 +65,7 @@
     padding: 0;
     margin: 0;
     white-space: nowrap;
-    height: $gallery-height + 20px; // To cover the scroll bar
+    height: calc(var(--gallery-height) + 20px); // To cover the scroll bar
     overflow-x: scroll;
   }
 }

--- a/client/src/gallery/GalleryShield.scss
+++ b/client/src/gallery/GalleryShield.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .gallery-shield {
   position: absolute;
   left: 0;
@@ -7,5 +5,5 @@
   width: 100vw;
   height: 100vh;
   cursor: pointer;
-  z-index: $z-08-gallery-shield;
+  z-index: var(--z-08-gallery-shield);
 }

--- a/client/src/gallery/GalleryStreetItem.scss
+++ b/client/src/gallery/GalleryStreetItem.scss
@@ -1,13 +1,15 @@
 @use "sass:color";
 @import "../../styles/variables";
 
-$selection-highlight-colour: $colour-copper-500;
-
 .gallery-street-item {
+  --selection-highlight-color: var(--color-copper-500);
+  --thumbnail-width: 180px;
+  --thumbnail-height: 110px;
+
   display: inline-block;
   position: relative;
-  width: $thumbnail-width;
-  height: $thumbnail-height;
+  width: var(--thumbnail-width);
+  height: var(--thumbnail-height);
   border-radius: var(--border-radius-medium);
 
   /* this spacing is so that the selected border is not cut off when calling scrollIntoView() */
@@ -51,7 +53,7 @@ $selection-highlight-colour: $colour-copper-500;
 
 .gallery-street-item.gallery-selected > a {
   border: 2px solid white;
-  box-shadow: 0 0 0 2px $selection-highlight-colour;
+  box-shadow: 0 0 0 2px var(--selection-highlight-color);
 
   canvas {
     opacity: 1;
@@ -77,8 +79,8 @@ $selection-highlight-colour: $colour-copper-500;
     position: absolute;
     left: 0;
     bottom: -2px;
-    width: $thumbnail-width;
-    height: $thumbnail-height;
+    width: var(--thumbnail-width);
+    height: var(--thumbnail-height);
     border-radius: var(--border-radius-medium);
     opacity: 0.5;
     filter: grayscale(0.25);
@@ -142,12 +144,12 @@ $selection-highlight-colour: $colour-copper-500;
   }
 
   svg {
-    color: $colour-turquoise-500 !important;
+    color: var(--color-turquoise-500) !important;
     width: 12px;
   }
 
   &:hover svg {
-    color: $colour-turquoise-600 !important;
+    color: var(--color-turquoise-600) !important;
   }
 }
 
@@ -156,7 +158,7 @@ $selection-highlight-colour: $colour-copper-500;
   align-items: center;
   justify-content: center;
   height: 100%;
-  color: $colour-turquoise-600;
+  color: var(--color-turquoise-600);
 
   // Top/bottom padding accounts for street name
   padding: 20px 1.5em 2px;

--- a/client/src/gallery/GalleryStreetItem.scss
+++ b/client/src/gallery/GalleryStreetItem.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-
 .gallery-street-item {
   --selection-highlight-color: var(--color-copper-500);
   --thumbnail-width: 180px;
@@ -34,7 +31,7 @@
 .gallery-street-item > a {
   display: block;
   text-decoration: none;
-  border: 2px solid color.adjust($ui-colour, $lightness: -10%);
+  border: 2px solid var(--deprecated-ui-color-lightness-10);
   background-color: #f0f0f0;
   cursor: pointer;
   position: relative;

--- a/client/src/gallery/GalleryStreetItem.scss
+++ b/client/src/gallery/GalleryStreetItem.scss
@@ -8,7 +8,7 @@ $selection-highlight-colour: $colour-copper-500;
   position: relative;
   width: $thumbnail-width;
   height: $thumbnail-height;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
 
   /* this spacing is so that the selected border is not cut off when calling scrollIntoView() */
   padding: 5px;
@@ -40,7 +40,7 @@ $selection-highlight-colour: $colour-copper-500;
   top: 0;
   width: 100%;
   height: 100%;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
 
   &:hover canvas {
     opacity: 1;
@@ -79,7 +79,7 @@ $selection-highlight-colour: $colour-copper-500;
     bottom: -2px;
     width: $thumbnail-width;
     height: $thumbnail-height;
-    border-radius: $border-radius-medium;
+    border-radius: var(--border-radius-medium);
     opacity: 0.5;
     filter: grayscale(0.25);
     transform: scale(1.4); // Crops excess space for most streets

--- a/client/src/info_bubble/InfoBubble.scss
+++ b/client/src/info_bubble/InfoBubble.scss
@@ -1,7 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-@import "../../styles/mixins";
-
 // TODO: Further refactoring / splitting up of these styles
 
 .info-bubble {
@@ -42,7 +38,7 @@
     font-size: 1.2em;
     font-weight: 300;
     color: white;
-    background: color.adjust($ui-colour, $lightness: -20%);
+    background: var(--deprecated-ui-color-lightness-20);
     border-top-left-radius: var(--info-bubble-border-radius);
     border-top-right-radius: var(--info-bubble-border-radius);
   }
@@ -183,7 +179,7 @@
     right: -40px;
     width: 0;
     height: 0;
-    border-top: 40px solid color.adjust($ui-colour, $lightness: -20%);
+    border-top: 40px solid var(--deprecated-ui-color-lightness-20);
     border-right: 40px solid transparent;
 
     [dir="rtl"] & {
@@ -208,7 +204,7 @@
 
 .info-bubble-warnings {
   margin-top: 1px;
-  border-top: 1px solid $ui-colour;
+  border-top: 1px solid var(--deprecated-ui-color);
   padding: 0.5em 1.5em 0.5em 1em;
   white-space: normal;
   color: var(--warning-color);

--- a/client/src/info_bubble/InfoBubble.scss
+++ b/client/src/info_bubble/InfoBubble.scss
@@ -3,15 +3,17 @@
 @import "../../styles/mixins";
 
 // TODO: Further refactoring / splitting up of these styles
-$info-bubble-border-radius: var(--border-radius);
 
 .info-bubble {
+  --info-bubble-button-size: 30px;
+  --info-bubble-border-radius: var(--border-radius);
+
   position: absolute;
   min-width: 275px;
   opacity: 0;
-  background: $info-bubble-background;
-  border-radius: $info-bubble-border-radius;
-  box-shadow: $light-box-shadow;
+  background: var(--info-bubble-background);
+  border-radius: var(--info-bubble-border-radius);
+  box-shadow: var(--light-box-shadow);
   transition:
     transform 100ms,
     margin-top 150ms,
@@ -19,7 +21,7 @@ $info-bubble-border-radius: var(--border-radius);
     opacity 150ms;
   transform: rotateX(-80deg);
   perspective: 1200px;
-  z-index: $z-06-info-bubble;
+  z-index: var(--z-06-info-bubble);
   pointer-events: none;
   touch-action: none;
 
@@ -35,14 +37,14 @@ $info-bubble-border-radius: var(--border-radius);
     justify-content: space-between;
     position: relative;
     padding: 4px 10px;
-    height: $info-bubble-button-size + 10px;
-    line-height: $info-bubble-button-size + 2px;
+    height: calc(var(--info-bubble-button-size) + 10px);
+    line-height: calc(var(--info-bubble-button-size) + 2px);
     font-size: 1.2em;
     font-weight: 300;
     color: white;
     background: color.adjust($ui-colour, $lightness: -20%);
-    border-top-left-radius: $info-bubble-border-radius;
-    border-top-right-radius: $info-bubble-border-radius;
+    border-top-left-radius: var(--info-bubble-border-radius);
+    border-top-right-radius: var(--info-bubble-border-radius);
   }
 
   .icon {
@@ -65,7 +67,7 @@ $info-bubble-border-radius: var(--border-radius);
   .variants {
     text-align: left;
     margin-right: 20px;
-    min-height: $info-bubble-button-size;
+    min-height: var(--info-bubble-button-size);
     white-space: nowrap;
     user-select: none;
 
@@ -158,8 +160,8 @@ $info-bubble-border-radius: var(--border-radius);
   }
 
   button {
-    width: $info-bubble-button-size;
-    height: $info-bubble-button-size;
+    width: var(--info-bubble-button-size);
+    height: var(--info-bubble-button-size);
   }
 }
 
@@ -169,7 +171,7 @@ $info-bubble-border-radius: var(--border-radius);
 
   [dir="rtl"] & {
     border-top-left-radius: 0;
-    border-top-right-radius: $info-bubble-border-radius;
+    border-top-right-radius: var(--info-bubble-border-radius);
     margin-left: 140px;
     margin-right: 0;
   }

--- a/client/src/info_bubble/InfoBubble.scss
+++ b/client/src/info_bubble/InfoBubble.scss
@@ -92,7 +92,7 @@
       position: absolute;
       top: -2px;
       right: -2px;
-      color: $colour-copper-600;
+      color: var(--color-copper-600);
 
       [dir="rtl"] & {
         left: -2px;
@@ -150,7 +150,7 @@
 
   .variant-selected,
   .variant-selected:hover {
-    background: $colour-copper-300 !important;
+    background: var(--color-copper-300) !important;
     opacity: 1;
 
     .icon {

--- a/client/src/info_bubble/InfoBubble.scss
+++ b/client/src/info_bubble/InfoBubble.scss
@@ -3,7 +3,7 @@
 @import "../../styles/mixins";
 
 // TODO: Further refactoring / splitting up of these styles
-$info-bubble-border-radius: $border-radius;
+$info-bubble-border-radius: var(--border-radius);
 
 .info-bubble {
   position: absolute;
@@ -209,7 +209,7 @@ $info-bubble-border-radius: $border-radius;
   border-top: 1px solid $ui-colour;
   padding: 0.5em 1.5em 0.5em 1em;
   white-space: normal;
-  color: $warning-colour;
+  color: var(--warning-color);
 
   ul {
     padding: 0;
@@ -224,7 +224,7 @@ $info-bubble-border-radius: $border-radius;
 }
 
 .info-bubble-warning-alert {
-  color: $alert-text-colour;
+  color: var(--alert-text-color);
 
   img {
     width: 1.6em;

--- a/client/src/info_bubble/InfoBubbleControls/BuildingHeightControl.scss
+++ b/client/src/info_bubble/InfoBubbleControls/BuildingHeightControl.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .building-height .up-down-input {
   /* Re-organizes the up/down input so that elements are stacked
   veritcally, and flips the icons so that up above the element */

--- a/client/src/info_bubble/InfoBubbleControls/BuildingHeightControl.scss
+++ b/client/src/info_bubble/InfoBubbleControls/BuildingHeightControl.scss
@@ -11,15 +11,15 @@
     width: 100px;
     margin-top: 5px;
     margin-bottom: 5px;
-    border-left: 1px solid $form-element-border;
-    border-right: 1px solid $form-element-border;
+    border-left: 1px solid var(--form-element-border);
+    border-right: 1px solid var(--form-element-border);
   }
 
   .up-down-input-decrement {
-    border-radius: $border-radius-medium;
+    border-radius: var(--border-radius-medium);
   }
 
   .up-down-input-increment {
-    border-radius: $border-radius-medium;
+    border-radius: var(--border-radius-medium);
   }
 }

--- a/client/src/info_bubble/InfoBubbleControls/UpDownInput.scss
+++ b/client/src/info_bubble/InfoBubbleControls/UpDownInput.scss
@@ -2,7 +2,7 @@
 
 .up-down-input-element {
   width: 50px;
-  font-family: $font-family;
+  font-family: var(--font-family);
   text-align: center;
   background: var(--form-element-background);
   border: 1px solid var(--form-element-border);

--- a/client/src/info_bubble/InfoBubbleControls/UpDownInput.scss
+++ b/client/src/info_bubble/InfoBubbleControls/UpDownInput.scss
@@ -4,8 +4,8 @@
   width: 50px;
   font-family: $font-family;
   text-align: center;
-  background: $form-element-background;
-  border: 1px solid $form-element-border;
+  background: var(--form-element-background);
+  border: 1px solid var(--form-element-border);
   border-left: 0;
   border-right: 0;
   vertical-align: bottom;
@@ -25,5 +25,5 @@
 }
 
 .up-down-input button svg {
-  color: $colour-midnight-700 !important;
+  color: var(--color-midnight-700) !important;
 }

--- a/client/src/info_bubble/InfoBubbleControls/UpDownInput.scss
+++ b/client/src/info_bubble/InfoBubbleControls/UpDownInput.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .up-down-input-element {
   width: 50px;
   font-family: var(--font-family);

--- a/client/src/info_bubble/InfoBubbleLower/DescriptionPanel.scss
+++ b/client/src/info_bubble/InfoBubbleLower/DescriptionPanel.scss
@@ -34,8 +34,8 @@
   right: -50px;
   pointer-events: none;
   border-radius: var(--border-radius);
-  box-shadow: $light-box-shadow;
-  background: $info-bubble-background;
+  box-shadow: var(--light-box-shadow);
+  background: var(--info-bubble-background);
 }
 
 .description {

--- a/client/src/info_bubble/InfoBubbleLower/DescriptionPanel.scss
+++ b/client/src/info_bubble/InfoBubbleLower/DescriptionPanel.scss
@@ -1,22 +1,19 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .description-prompt,
 .description-close {
-  border-top: 1px solid $ui-colour;
+  border-top: 1px solid var(--deprecated-ui-color);
   white-space: normal;
   text-align: center;
   padding: 1em 2em;
   user-select: none;
-  color: color.adjust($ui-colour, $lightness: -20%);
+  color: var(--deprecated-ui-color-lightness-20);
   cursor: pointer;
   overflow: hidden;
   border-bottom-left-radius: var(--border-radius);
   border-bottom-right-radius: var(--border-radius);
 
   &:hover {
-    color: color.adjust($ui-colour, $lightness: -40%);
-    background: color.mix($ui-colour, white, 50%);
+    color: var(--deprecated-ui-color-lightness-40);
+    background: var(--deprecated-ui-color-mix-white);
   }
 }
 

--- a/client/src/info_bubble/InfoBubbleLower/DescriptionPanel.scss
+++ b/client/src/info_bubble/InfoBubbleLower/DescriptionPanel.scss
@@ -11,8 +11,8 @@
   color: color.adjust($ui-colour, $lightness: -20%);
   cursor: pointer;
   overflow: hidden;
-  border-bottom-left-radius: $border-radius;
-  border-bottom-right-radius: $border-radius;
+  border-bottom-left-radius: var(--border-radius);
+  border-bottom-right-radius: var(--border-radius);
 
   &:hover {
     color: color.adjust($ui-colour, $lightness: -40%);
@@ -33,7 +33,7 @@
   top: -50px;
   right: -50px;
   pointer-events: none;
-  border-radius: $border-radius;
+  border-radius: var(--border-radius);
   box-shadow: $light-box-shadow;
   background: $info-bubble-background;
 }
@@ -67,8 +67,8 @@
 }
 
 .description-content {
-  border-top-left-radius: $border-radius;
-  border-top-right-radius: $border-radius;
+  border-top-left-radius: var(--border-radius);
+  border-top-right-radius: var(--border-radius);
   overflow: hidden auto;
   touch-action: pan-y;
 }

--- a/client/src/info_bubble/InfoBubbleLower/Triangle.scss
+++ b/client/src/info_bubble/InfoBubbleLower/Triangle.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .info-bubble-triangle {
   position: absolute;
   bottom: -24px;
@@ -25,5 +22,5 @@
 }
 
 .info-bubble-triangle-highlight::before {
-  background: color.mix($ui-colour, white, 50%);
+  background: var(--deprecated-ui-color-mix-white);
 }

--- a/client/src/info_bubble/InfoBubbleLower/Triangle.scss
+++ b/client/src/info_bubble/InfoBubbleLower/Triangle.scss
@@ -18,8 +18,8 @@
     bottom: 12px;
     margin-left: -12px;
     transform: rotateZ(45deg);
-    background: $info-bubble-background;
-    box-shadow: $light-box-shadow;
+    background: var(--info-bubble-background);
+    box-shadow: var(--light-box-shadow);
     pointer-events: none;
   }
 }

--- a/client/src/menubar/InstanceBadge.scss
+++ b/client/src/menubar/InstanceBadge.scss
@@ -1,7 +1,5 @@
-@import "../../styles/variables";
-
 .instance-badge {
-  z-index: $z-02-menu-bar;
+  z-index: var(--z-02-menu-bar);
   display: none;
   position: absolute;
   left: 14px;

--- a/client/src/menubar/MenuBar.scss
+++ b/client/src/menubar/MenuBar.scss
@@ -6,7 +6,7 @@ $menu-bar-text-color: var(--segment-text);
 $menu-bar-text-color-hover: color.adjust($ui-colour, $lightness: -30%);
 $menu-bar-text-color-active: color.adjust($ui-colour, $lightness: -40%);
 $menu-bar-border-radius: var(--border-radius);
-$menu-bar-box-shadow: $light-box-shadow;
+$menu-bar-box-shadow: var(--light-box-shadow);
 
 .menu-bar {
   --menu-bar-background: var(--off-white);

--- a/client/src/menubar/MenuBar.scss
+++ b/client/src/menubar/MenuBar.scss
@@ -2,24 +2,26 @@
 @import "../../styles/variables";
 @import "../../styles/mixins";
 
-$menu-bar-text-color: $segment-text;
+$menu-bar-text-color: var(--segment-text);
 $menu-bar-text-color-hover: color.adjust($ui-colour, $lightness: -30%);
 $menu-bar-text-color-active: color.adjust($ui-colour, $lightness: -40%);
-$menu-bar-border-radius: $border-radius;
+$menu-bar-border-radius: var(--border-radius);
 $menu-bar-box-shadow: $light-box-shadow;
 
 .menu-bar {
-  z-index: $z-02-menu-bar;
+  --menu-bar-background: var(--off-white);
+
+  z-index: var(--z-02-menu-bar);
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
   position: absolute;
-  left: $menu-side-inset;
-  right: $menu-side-inset;
+  left: var(--menu-side-inset);
+  right: var(--menu-side-inset);
   top: 0;
   border-bottom-left-radius: $menu-bar-border-radius;
   border-bottom-right-radius: $menu-bar-border-radius;
-  background: $menu-bar-background;
+  background: var(--menu-bar-background);
   background-clip: padding-box;
   box-shadow: $menu-bar-box-shadow;
   user-select: none;
@@ -32,7 +34,7 @@ $menu-bar-box-shadow: $light-box-shadow;
     top: -150px;
     width: 100%;
     height: 150px;
-    background-color: $menu-bar-background;
+    background-color: var(--menu-bar-background);
   }
 
   body.read-only & {

--- a/client/src/menubar/MenuBar.scss
+++ b/client/src/menubar/MenuBar.scss
@@ -1,15 +1,11 @@
-@use "sass:color";
-@import "../../styles/variables";
 @import "../../styles/mixins";
 
-$menu-bar-text-color: var(--segment-text);
-$menu-bar-text-color-hover: color.adjust($ui-colour, $lightness: -30%);
-$menu-bar-text-color-active: color.adjust($ui-colour, $lightness: -40%);
-$menu-bar-border-radius: var(--border-radius);
-$menu-bar-box-shadow: var(--light-box-shadow);
-
 .menu-bar {
+  --menu-bar-text-color: var(--segment-text);
+  --menu-bar-text-color-active: var(--deprecated-ui-color-lightness-40);
+  --menu-bar-border-radius: var(--border-radius);
   --menu-bar-background: var(--off-white);
+  --menu-bar-box-shadow: var(--light-box-shadow);
 
   z-index: var(--z-02-menu-bar);
   display: flex;
@@ -19,11 +15,11 @@ $menu-bar-box-shadow: var(--light-box-shadow);
   left: var(--menu-side-inset);
   right: var(--menu-side-inset);
   top: 0;
-  border-bottom-left-radius: $menu-bar-border-radius;
-  border-bottom-right-radius: $menu-bar-border-radius;
+  border-bottom-left-radius: var(--menu-bar-border-radius);
+  border-bottom-right-radius: var(--menu-bar-border-radius);
   background: var(--menu-bar-background);
   background-clip: padding-box;
-  box-shadow: $menu-bar-box-shadow;
+  box-shadow: var(--menu-bar-box-shadow);
   user-select: none;
   touch-action: none;
 
@@ -47,7 +43,7 @@ $menu-bar-box-shadow: var(--light-box-shadow);
     padding: 3px 1em;
     margin: 0;
     line-height: 32px;
-    color: $menu-bar-text-color;
+    color: var(--menu-bar-text-color);
   }
 
   li {
@@ -67,7 +63,7 @@ $menu-bar-box-shadow: var(--light-box-shadow);
     padding: 0 10px;
 
     &:active {
-      color: $menu-bar-text-color-active;
+      color: var(--menu-bar-text-color-active);
     }
 
     // Button "hover" state is actually wider than the button
@@ -111,7 +107,7 @@ $menu-bar-box-shadow: var(--light-box-shadow);
     }
 
     &:active {
-      color: $menu-bar-text-color-active;
+      color: var(--menu-bar-text-color-active);
     }
 
     // Button "hover" state is actually wider than the button

--- a/client/src/menubar/MenusContainer.scss
+++ b/client/src/menubar/MenusContainer.scss
@@ -2,7 +2,7 @@
 
 .menus-container {
   position: absolute;
-  inset: 0 $menu-side-inset;
+  inset: 0 var(--menu-side-inset);
   pointer-events: none;
   z-index: $z-07-menu;
 

--- a/client/src/menubar/MenusContainer.scss
+++ b/client/src/menubar/MenusContainer.scss
@@ -1,10 +1,8 @@
-@import "../../styles/variables";
-
 .menus-container {
   position: absolute;
   inset: 0 var(--menu-side-inset);
   pointer-events: none;
-  z-index: $z-07-menu;
+  z-index: var(--z-07-menu);
 
   // Required in Firefox to get perspective to work on menus
   transform-style: preserve-3d;

--- a/client/src/menubar/SignInButton.scss
+++ b/client/src/menubar/SignInButton.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .menu-bar .menu-sign-in {
   margin-left: 0.5em;
   margin-right: 0.1em;

--- a/client/src/menubar/UpgradeButton.scss
+++ b/client/src/menubar/UpgradeButton.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .menu-bar .menu-upgrade {
   display: flex;
   align-items: center;

--- a/client/src/menubar/menus/IdentityMenu.scss
+++ b/client/src/menubar/menus/IdentityMenu.scss
@@ -1,12 +1,9 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .identity-menu {
   white-space: nowrap;
 }
 
 .identity-section {
-  border-bottom: 1px solid $colour-turquoise-200;
+  border-bottom: 1px solid var(--color-turquoise-200);
   padding: 0.8em;
   min-width: 150px;
   max-width: 300px;
@@ -47,7 +44,7 @@
 
 .identity-avatar-display-name {
   font-weight: 550;
-  color: $colour-turquoise-700;
+  color: var(--color-turquoise-700);
 }
 
 .identity-roles {
@@ -65,7 +62,7 @@
     display: inline-flex;
     justify-content: center;
     align-items: center;
-    border-radius: $border-radius;
+    border-radius: var(--border-radius-medium);
     padding: 0.3em 0.6em;
     margin-right: 0.35em;
     margin-bottom: 0.35em;
@@ -79,13 +76,13 @@
   }
 
   .role-badge-generic {
-    background-color: $colour-midnight-100;
-    color: $colour-midnight-600;
+    background-color: var(--color-midnight-100);
+    color: var(--color-midnight-600);
   }
 
   .role-badge-subscriber {
-    background-color: $colour-turquoise-200;
-    color: $colour-turquoise-700;
+    background-color: var(--color-turquoise-200);
+    color: var(--color-turquoise-700);
 
     img {
       height: 1em;
@@ -99,7 +96,7 @@
   }
 
   .role-badge-admin {
-    background-color: $alert-border-colour;
-    color: color.scale($alert-border-colour, $lightness: -75%);
+    background-color: var(--alert-border-color);
+    color: var(--color-copper-700);
   }
 }

--- a/client/src/menubar/menus/Menu.scss
+++ b/client/src/menubar/menus/Menu.scss
@@ -2,7 +2,7 @@
 @import "../../../styles/mixins";
 
 $menu-border-radius: var(--border-radius);
-$menu-box-shadow: $medium-box-shadow;
+$menu-box-shadow: var(--medium-box-shadow);
 
 .menu {
   position: absolute;

--- a/client/src/menubar/menus/Menu.scss
+++ b/client/src/menubar/menus/Menu.scss
@@ -1,7 +1,7 @@
 @import "../../../styles/variables";
 @import "../../../styles/mixins";
 
-$menu-border-radius: $border-radius;
+$menu-border-radius: var(--border-radius);
 $menu-box-shadow: $medium-box-shadow;
 
 .menu {
@@ -39,7 +39,7 @@ $menu-box-shadow: $medium-box-shadow;
     display: block;
     position: relative;
     padding: 0.8em 2.5em;
-    border-bottom: 1px solid $colour-turquoise-200;
+    border-bottom: 1px solid var(--color-turquoise-200);
     text-decoration: none;
     color: black;
 
@@ -48,7 +48,7 @@ $menu-box-shadow: $medium-box-shadow;
     }
 
     &:hover {
-      background-color: $colour-turquoise-100;
+      background-color: var(--color-turquoise-100);
     }
 
     &:active {
@@ -58,8 +58,8 @@ $menu-box-shadow: $medium-box-shadow;
 
   input {
     appearance: none;
-    background: $form-element-background;
-    border: 1px solid $form-element-border;
+    background: var(--form-element-background);
+    border: 1px solid var(--form-element-border);
     resize: none;
   }
 
@@ -69,7 +69,7 @@ $menu-box-shadow: $medium-box-shadow;
     left: 0.8em;
     width: 16px;
     height: 16px;
-    color: $colour-midnight-600;
+    color: var(--color-midnight-600);
 
     [dir="rtl"] & {
       left: auto;
@@ -84,7 +84,7 @@ $menu-box-shadow: $medium-box-shadow;
     left: 0.8em;
     width: 15px;
     height: 15px;
-    color: $colour-midnight-600;
+    color: var(--color-midnight-600);
 
     [dir="rtl"] & {
       left: auto;
@@ -95,7 +95,7 @@ $menu-box-shadow: $medium-box-shadow;
   .menu-item-external-link {
     vertical-align: text-top;
     margin-left: 0.25em;
-    color: $colour-midnight-400;
+    color: var(--color-midnight-400);
   }
 }
 
@@ -112,8 +112,8 @@ body.safari .menu {
   list-style: none;
   padding: 0;
   margin: 0;
-  border-top: 1px solid $colour-turquoise-200;
-  border-bottom: 1px solid $colour-turquoise-200;
+  border-top: 1px solid var(--color-turquoise-200);
+  border-bottom: 1px solid var(--color-turquoise-200);
 
   // Remove the top border if menu group is the first element in a menu
   &:first-child {
@@ -138,7 +138,7 @@ body.safari .menu {
   cursor: pointer;
 
   &:hover {
-    background-color: $colour-turquoise-100;
+    background-color: var(--color-turquoise-100);
   }
 
   .fa-check {

--- a/client/src/menubar/menus/Menu.scss
+++ b/client/src/menubar/menus/Menu.scss
@@ -183,22 +183,22 @@ body.safari .menu {
 .menu-item-icon {
   &.fa-facebook,
   &.fa-square-facebook {
-    color: $social-facebook;
+    color: var(--social-facebook);
   }
 
   &.fa-twitter {
-    color: $social-twitter;
+    color: var(--social-twitter);
   }
 
   &.fa-discord {
-    color: $social-discord;
+    color: var(--social-discord);
   }
 
   &.fa-github {
-    color: $social-github;
+    color: var(--social-github);
   }
 
   &.fa-mastodon {
-    color: $social-mastodon;
+    color: var(--social-mastodon);
   }
 }

--- a/client/src/menubar/menus/Menu.scss
+++ b/client/src/menubar/menus/Menu.scss
@@ -1,10 +1,7 @@
-@import "../../../styles/variables";
-@import "../../../styles/mixins";
-
-$menu-border-radius: var(--border-radius);
-$menu-box-shadow: var(--medium-box-shadow);
-
 .menu {
+  --menu-border-radius: var(--border-radius);
+  --menu-box-shadow: var(--medium-box-shadow);
+
   position: absolute;
   margin-top: 10px;
   touch-action: none;
@@ -16,8 +13,8 @@ $menu-box-shadow: var(--medium-box-shadow);
     transform 100ms,
     opacity 100ms;
   pointer-events: none;
-  border-radius: $menu-border-radius;
-  box-shadow: $menu-box-shadow;
+  border-radius: var(--menu-border-radius);
+  box-shadow: var(--menu-box-shadow);
   line-height: 1.4;
 
   /* Allows scrolling if the menu length is longer than height of viewport */

--- a/client/src/menubar/menus/Menu.scss
+++ b/client/src/menubar/menus/Menu.scss
@@ -52,7 +52,7 @@ $menu-box-shadow: var(--medium-box-shadow);
     }
 
     &:active {
-      background-color: $colour-turquoise-150;
+      background-color: var(--color-turquoise-150);
     }
   }
 

--- a/client/src/menubar/menus/ShareMenu/ShareMenu.scss
+++ b/client/src/menubar/menus/ShareMenu/ShareMenu.scss
@@ -1,16 +1,14 @@
-@import "../../../../styles/variables";
-
-$share-menu-width: 350px;
-
 .share-menu {
-  min-width: $share-menu-width;
+  --share-menu-width: 350px;
+
+  min-width: var(--share-menu-width);
 }
 
 .share-via-link-container {
   position: relative;
-  width: $share-menu-width;
+  width: var(--share-menu-width);
   padding: 0.8em 1em 0.8em 2.5em;
-  border-bottom: 1px solid $colour-turquoise-200;
+  border-bottom: 1px solid var(--color-turquoise-200);
 
   [dir="rtl"] & {
     padding: 0.8em 2.5em 0.8em 1em;
@@ -48,7 +46,7 @@ $share-menu-width: 350px;
 
 .share-sign-in-promo {
   // Prevent element from setting its own width
-  width: $share-menu-width;
+  width: var(--share-menu-width);
   text-align: center;
   background-color: var(--alert-background);
   border-bottom: var(--alert-border);

--- a/client/src/menubar/menus/ShareMenu/ShareMenu.scss
+++ b/client/src/menubar/menus/ShareMenu/ShareMenu.scss
@@ -50,8 +50,8 @@ $share-menu-width: 350px;
   // Prevent element from setting its own width
   width: $share-menu-width;
   text-align: center;
-  background-color: $alert-background;
-  border-bottom: $alert-border;
+  background-color: var(--alert-background);
+  border-bottom: var(--alert-border);
   border-bottom-width: 2px;
   padding: 1em 2.5em;
 

--- a/client/src/palette/EnvironmentButton.scss
+++ b/client/src/palette/EnvironmentButton.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .supermoon-tooltip {
   padding: 1.25em;
   position: fixed;

--- a/client/src/palette/PaletteContainer.scss
+++ b/client/src/palette/PaletteContainer.scss
@@ -22,7 +22,7 @@
   flex-direction: row;
   justify-content: space-between;
   background: var(--palette-background);
-  z-index: $z-02-palette;
+  z-index: var(--z-02-palette);
   user-select: none;
   touch-action: none;
   border-top-left-radius: var(--border-radius-large);

--- a/client/src/palette/PaletteContainer.scss
+++ b/client/src/palette/PaletteContainer.scss
@@ -27,7 +27,7 @@
   border-top-right-radius: var(--border-radius-large);
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (width >= 768px) {
   .palette-container-outer {
     padding-left: 0;
     padding-right: 0;

--- a/client/src/palette/PaletteContainer.scss
+++ b/client/src/palette/PaletteContainer.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .palette-container-outer {
   --palette-height: 64px;
   --palette-background: var(--off-white);
@@ -29,7 +27,7 @@
   border-top-right-radius: var(--border-radius-large);
 }
 
-@media only screen and (max-width: $breakpoint-md) {
+@media only screen and (max-width: 768px) {
   .palette-container-outer {
     padding-left: 0;
     padding-right: 0;

--- a/client/src/palette/PaletteContainer.scss
+++ b/client/src/palette/PaletteContainer.scss
@@ -1,14 +1,15 @@
 @import "../../styles/variables";
 
-$palette-height: 64px;
-
 .palette-container-outer {
+  --palette-height: 64px;
+  --palette-background: var(--off-white);
+
   position: absolute;
   bottom: 0;
   width: 100%;
-  height: $palette-height;
-  padding-left: $left-right-inset;
-  padding-right: $left-right-inset;
+  height: var(--palette-height);
+  padding-left: var(--left-right-inset);
+  padding-right: var(--left-right-inset);
   display: flex;
   justify-content: center;
 }
@@ -16,16 +17,16 @@ $palette-height: 64px;
 .palette-container {
   position: relative;
   width: 100%;
-  min-width: $breakpoint-md;
+  min-width: var(--breakpoint-md);
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  background: $palette-background;
+  background: var(--palette-background);
   z-index: $z-02-palette;
   user-select: none;
   touch-action: none;
-  border-top-left-radius: $border-radius-large;
-  border-top-right-radius: $border-radius-large;
+  border-top-left-radius: var(--border-radius-large);
+  border-top-right-radius: var(--border-radius-large);
 }
 
 @media only screen and (max-width: $breakpoint-md) {

--- a/client/src/palette/PaletteItem.scss
+++ b/client/src/palette/PaletteItem.scss
@@ -2,16 +2,17 @@
   display: inline-block;
   position: relative;
   margin: 14px 0;
+  margin-right: 1px;
   height: 80px;
   width: 60px;
   top: 0;
+
   // While the preferred mixing method is in oklch, there is a bug(?) in
   // Safari where doing so also causes the hue to shift unexpectedly.
   // Mixing transparency in srgb will only affect alpha channel as expected
   // in tested browsers (Firefox + Chrome) including Safari.
   // See also hover state below.
   background-color: color-mix(in srgb, var(--sky-color), transparent 30%);
-  margin-right: 1px;
   transform-origin: 50% 75%;
   transition: transform 50ms !important;
 }
@@ -53,6 +54,7 @@
   // Workaround is to store the saturation value as a separate variable and
   // bring it into the hsl() function.
   --palette-item-disabled-saturation: 0%;
+
   background-color: color-mix(
     in hsl,
     var(--sky-color),

--- a/client/src/palette/PaletteItem.scss
+++ b/client/src/palette/PaletteItem.scss
@@ -40,12 +40,18 @@
 }
 
 .palette-item-disabled {
-  // This complicated color-mix replaces the previous thing in SCSS:
+  // This complicated color-mix replaces this previous SCSS statement:
   //    color.adjust(fade-out($sky-colour, 0.3), $saturation: -100%);
-  // However it's also being compressed so none is 0, instead of "don't change"
-  // so for now let's just hard-code the resultant color value
-  // background-color: color-mix(in hsl, var(--sky-color), hsl(none 0% none / 70%) 100%);
-  background-color: #c2c2c2b3;
+  // The CSS postprocesser will squash hsl(none 0% none) to #000000, which
+  // is wrong. `none` is meant as "absence of change", not "value equals zero".
+  // Workaround is to store the saturation value as a separate variable and
+  // bring it into the hsl() function.
+  --palette-item-disabled-saturation: 0%;
+  background-color: color-mix(
+    in hsl,
+    var(--sky-color),
+    hsl(none var(--palette-item-disabled-saturation) none / 70%) 100%
+  );
 
   .palette-item-image {
     filter: grayscale(0.8);

--- a/client/src/palette/PaletteItem.scss
+++ b/client/src/palette/PaletteItem.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
-
 .palette-item {
   display: inline-block;
   position: relative;
@@ -8,7 +5,7 @@
   height: 80px;
   width: 60px;
   top: 0;
-  background-color: fade-out($sky-colour, 0.3);
+  background-color: color-mix(in oklch, var(--sky-color), transparent 30%);
   margin-right: 1px;
   transform-origin: 50% 75%;
   transition: transform 50ms !important;
@@ -23,7 +20,7 @@
 
 .palette-item:not(.palette-item-disabled):hover,
 .palette-item:not(.palette-item-disabled) > div:focus {
-  background: fade-out($sky-colour, 0.05);
+  background-color: color-mix(in oklch, var(--sky-color), transparent 5%);
   z-index: 1;
 
   .palette-item-image {
@@ -43,7 +40,12 @@
 }
 
 .palette-item-disabled {
-  background: color.adjust(fade-out($sky-colour, 0.3), $saturation: -100%);
+  // This complicated color-mix replaces the previous thing in SCSS:
+  //    color.adjust(fade-out($sky-colour, 0.3), $saturation: -100%);
+  // However it's also being compressed so none is 0, instead of "don't change"
+  // so for now let's just hard-code the resultant color value
+  // background-color: color-mix(in hsl, var(--sky-color), hsl(none 0% none / 70%) 100%);
+  background-color: #c2c2c2b3;
 
   .palette-item-image {
     filter: grayscale(0.8);
@@ -55,7 +57,7 @@
     right: 4px;
     top: 4px;
     z-index: 2;
-    color: $colour-copper-600;
+    color: var(--color-copper-600);
 
     [dir="rtl"] & {
       left: 4px;

--- a/client/src/palette/PaletteItem.scss
+++ b/client/src/palette/PaletteItem.scss
@@ -5,7 +5,12 @@
   height: 80px;
   width: 60px;
   top: 0;
-  background-color: color-mix(in oklch, var(--sky-color), transparent 30%);
+  // While the preferred mixing method is in oklch, there is a bug(?) in
+  // Safari where doing so also causes the hue to shift unexpectedly.
+  // Mixing transparency in srgb will only affect alpha channel as expected
+  // in tested browsers (Firefox + Chrome) including Safari.
+  // See also hover state below.
+  background-color: color-mix(in srgb, var(--sky-color), transparent 30%);
   margin-right: 1px;
   transform-origin: 50% 75%;
   transition: transform 50ms !important;
@@ -20,7 +25,8 @@
 
 .palette-item:not(.palette-item-disabled):hover,
 .palette-item:not(.palette-item-disabled) > div:focus {
-  background-color: color-mix(in oklch, var(--sky-color), transparent 5%);
+  // See note above re: mixing in srgb over oklch here.
+  background-color: color-mix(in srgb, var(--sky-color), transparent 5%);
   z-index: 1;
 
   .palette-item-image {

--- a/client/src/palette/PaletteItems.scss
+++ b/client/src/palette/PaletteItems.scss
@@ -1,8 +1,3 @@
-@import "./PaletteContainer";
-
-// TODO
-// Not included here: segments
-
 // Applied by the wrapping element created by Scrollable.jsx component
 .palette-items-scrollable-container {
   position: relative;

--- a/client/src/palette/PaletteItems.scss
+++ b/client/src/palette/PaletteItems.scss
@@ -45,7 +45,7 @@
   // Palette item is tall enough to "overhang" above the top edge of the palette bar
   // It also must extend below the viewport to hide the horizontal scroll bar
   // We rely on flexbox vertical alignment for positioning here
-  height: $palette-height + 60px;
+  height: calc(var(--palette-height) + 60px);
   position: absolute;
   left: 0;
   right: 0;

--- a/client/src/palette/PaletteTrashcan.scss
+++ b/client/src/palette/PaletteTrashcan.scss
@@ -1,19 +1,15 @@
-@use "sass:color";
-@import "../../styles/variables";
-@import "./PaletteContainer";
-
-// Contrast ratio of at least 3:1 compared to background
-$palette-text-color: rgb(108 108 108);
-
 .palette-trashcan {
+  // Contrast ratio of at least 3:1 compared to background
+  --palette-text-color: rgb(108 108 108);
+
   // Stretch out to fit the width of the viewport
   position: absolute;
-  left: -$left-right-inset;
-  right: -$left-right-inset;
+  left: calc(-1 * var(--left-right-inset));
+  right: calc(-1 * var(--left-right-inset));
   bottom: 0;
 
   // Tall enough to cover the top "overhang" of palette items
-  height: $palette-height + 30px;
+  height: calc(var(--palette-height) + 30px);
 
   // Center text in box
   display: flex;
@@ -25,12 +21,12 @@ $palette-text-color: rgb(108 108 108);
   transform: translateY(0);
 
   // Rest of styles
-  z-index: $z-07-trashcan;
-  border-top: 2px dashed $palette-text-color;
-  color: $palette-text-color;
+  z-index: var(--z-07-trashcan);
+  border-top: 2px dashed var(--palette-text-color);
+  color: var(--palette-text-color);
   font-size: 1.75rem;
   font-weight: 400;
-  background: color.adjust($bottom-background, $lightness: 5%);
+  background-color: color-mix(in oklch, white 25%, var(--bottom-background));
   pointer-events: none;
   transition:
     transform 150ms,

--- a/client/src/segments/EmptySegment.scss
+++ b/client/src/segments/EmptySegment.scss
@@ -7,6 +7,7 @@
 
   .segment-label,
   .segment-width {
-    color: $empty-segment-text;
+    color: var(--segment-text);
+    opacity: 0.5;
   }
 }

--- a/client/src/segments/EmptySegment.scss
+++ b/client/src/segments/EmptySegment.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .segment-empty {
   position: absolute;
   pointer-events: none;

--- a/client/src/segments/ResizeGuides.scss
+++ b/client/src/segments/ResizeGuides.scss
@@ -7,7 +7,7 @@ $resize-guide-line-inverted: 1px dashed fade-out(white, 0.6);
 
 .resize-guides {
   position: absolute;
-  z-index: $z-07-resize-guide;
+  z-index: var(--z-07-resize-guide);
   top: -75px;
   bottom: 120px;
   left: 50%; /* Will be overridden by component */

--- a/client/src/segments/ResizeGuides.scss
+++ b/client/src/segments/ResizeGuides.scss
@@ -1,11 +1,9 @@
-@import "../../styles/variables";
-
-$resize-guide-text-color: fade-out(black, 0.4);
-$resize-guide-text-inverted-color: fade-out(white, 0.4);
-$resize-guide-line: 1px dashed fade-out(black, 0.6);
-$resize-guide-line-inverted: 1px dashed fade-out(white, 0.6);
-
 .resize-guides {
+  --resize-guide-text-color: rgb(0 0 0 / 60%);
+  --resize-guide-text-inverted-color: rgb(255 255 255 / 60%);
+  --resize-guide-line: 1px dashed rgb(0 0 0 / 40%);
+  --resize-guide-line-inverted: 1px dashed rgb(255 255 255 / 40%);
+
   position: absolute;
   z-index: var(--z-07-resize-guide);
   top: -75px;
@@ -17,13 +15,13 @@ $resize-guide-line-inverted: 1px dashed fade-out(white, 0.6);
 .resize-guide {
   position: absolute;
   height: 100%;
-  border-left: $resize-guide-line;
-  border-right: $resize-guide-line;
+  border-left: var(--resize-guide-line);
+  border-right: var(--resize-guide-line);
 
   // Invert the UI text color when there is a dark background
   body.dark-skybox-invert-ui & {
-    border-left: $resize-guide-line-inverted;
-    border-right: $resize-guide-line-inverted;
+    border-left: var(--resize-guide-line-inverted);
+    border-right: var(--resize-guide-line-inverted);
   }
 }
 
@@ -35,11 +33,11 @@ $resize-guide-line-inverted: 1px dashed fade-out(white, 0.6);
   position: absolute;
   bottom: 400px;
   font-size: 0.8rem;
-  color: $resize-guide-text-color;
+  color: var(--resize-guide-text-color);
 
   // Invert the UI text color when there is a dark background
   body.dark-skybox-invert-ui & {
-    color: $resize-guide-text-inverted-color;
+    color: var(--resize-guide-text-inverted-color);
   }
 }
 

--- a/client/src/segments/Segment.scss
+++ b/client/src/segments/Segment.scss
@@ -1,12 +1,10 @@
-@import "../../styles/variables";
-
 // TODO: Further split-up and refactoring of styles
 
 .segment {
   display: block;
   position: absolute;
   top: -150px;
-  height: $canvas-height + 85px + 30px;
+  height: calc(var(--canvas-height) + 85px + 30px);
   text-align: center;
   perspective: 500px;
   touch-action: none;
@@ -47,7 +45,7 @@ body.immediate-segment-resize .segment {
   right: 0;
   top: 10px;
   z-index: -1;
-  height: $canvas-baseline - 10px;
+  height: calc(var(--canvas-baseline) - 10px);
   pointer-events: none;
 }
 
@@ -74,7 +72,7 @@ body.segment-move-dragging #street-section-editable .segment {
   transition:
     left 100ms,
     transform 300ms;
-  height: $canvas-height + 85px + 30px + 90px;
+  height: calc(var(--canvas-height) + 85px + 30px + 90px);
 }
 
 .switching-away-exit {

--- a/client/src/segments/Segment.scss
+++ b/client/src/segments/Segment.scss
@@ -79,20 +79,20 @@ body.segment-move-dragging #street-section-editable .segment {
 
 .switching-away-exit {
   position: absolute;
-  z-index: $z-10-switch-away;
+  z-index: var(--z-10-switch-away);
   pointer-events: none;
   transform: none !important;
   perspective: 400px;
 }
 
 .switching-away-exit-done {
-  z-index: $z-10-switch-away !important;
+  z-index: var(--z-10-switch-away) !important;
 }
 
 .switching-away-exit-active canvas {
   transition:
-    transform $segment-switching-time ease-in,
-    opacity $segment-switching-time ease-in !important;
+    transform var(--segment-switching-time) ease-in,
+    opacity var(--segment-switching-time) ease-in !important;
   transform: rotateX(-60deg);
   transform-origin: 50% 120%;
   opacity: 0;
@@ -116,7 +116,7 @@ body.segment-move-dragging #street-section-editable .segment {
 .switching-in-enter-active canvas {
   opacity: 1;
   transition:
-    transform $segment-switching-time,
-    opacity $segment-switching-time !important;
+    transform var(--segment-switching-time),
+    opacity var(--segment-switching-time) !important;
   transform: none;
 }

--- a/client/src/segments/Segment.scss
+++ b/client/src/segments/Segment.scss
@@ -37,11 +37,11 @@ body.immediate-segment-resize .segment {
 }
 
 .segment.hover {
-  z-index: $z-02-segment-focused !important;
+  z-index: var(--z-02-segment-focused) !important;
 }
 
 .segment.hover .hover-bk {
-  background: $segment-hover-background;
+  background: var(--segment-hover-background);
   position: absolute;
   left: 0;
   right: 0;

--- a/client/src/segments/SegmentDragHandles.scss
+++ b/client/src/segments/SegmentDragHandles.scss
@@ -13,14 +13,14 @@ body.segment-resize-dragging * {
   top: 320px;
   width: 30px;
   height: 100px;
-  border-top: 5px solid $colour-turquoise-200;
-  border-bottom: 5px solid $colour-turquoise-200;
+  border-top: 5px solid var(--color-turquoise-200);
+  border-bottom: 5px solid var(--color-turquoise-200);
   border-radius: var(--border-radius-medium);
   font-size: 1.5rem;
-  color: $colour-turquoise-500;
-  z-index: $z-06-drag-handle;
+  color: var(--color-turquoise-500);
+  z-index: var(--z-06-drag-handle);
   pointer-events: none;
-  background: $info-bubble-background;
+  background: var(--info-bubble-background);
   cursor: col-resize;
   transition:
     transform 150ms,
@@ -28,7 +28,7 @@ body.segment-resize-dragging * {
   opacity: 0;
 
   &:hover {
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
   }
 }
 
@@ -53,7 +53,7 @@ body.segment-resize-dragging * {
 }
 
 .drag-handle.floating {
-  background-color: $colour-turquoise-500;
+  background-color: var(--color-turquoise-500);
 }
 
 body.segment-resize-dragging .drag-handle.floating,

--- a/client/src/segments/SegmentDragHandles.scss
+++ b/client/src/segments/SegmentDragHandles.scss
@@ -15,7 +15,7 @@ body.segment-resize-dragging * {
   height: 100px;
   border-top: 5px solid $colour-turquoise-200;
   border-bottom: 5px solid $colour-turquoise-200;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
   font-size: 1.5rem;
   color: $colour-turquoise-500;
   z-index: $z-06-drag-handle;

--- a/client/src/segments/SegmentDragHandles.scss
+++ b/client/src/segments/SegmentDragHandles.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 body.segment-resize-dragging,
 body.segment-resize-dragging * {
   cursor: col-resize !important;

--- a/client/src/segments/SegmentDragLayer.scss
+++ b/client/src/segments/SegmentDragLayer.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .segment-drag-layer {
   position: fixed;
   pointer-events: none;
@@ -15,7 +13,7 @@
   left: 0;
   top: 0;
   opacity: 0.75;
-  z-index: $z-02-segment-focused;
+  z-index: var(--z-02-segment-focused);
   pointer-events: none;
   transition: none !important;
 }

--- a/client/src/segments/SegmentLabelContainer.scss
+++ b/client/src/segments/SegmentLabelContainer.scss
@@ -18,7 +18,7 @@
   left: 2px;
   right: 2px;
   top: 44px;
-  color: $segment-text;
+  color: var(--segment-text);
   pointer-events: none;
   line-height: 1.4;
 }
@@ -40,13 +40,13 @@
   right: auto;
   overflow: visible;
   z-index: 1;
-  background-color: $bottom-background;
+  background-color: var(--bottom-background);
   padding: 4px;
   margin-top: -4px;
 }
 
 .segment.warning .segment-label {
-  color: $segment-warning-text;
+  color: var(--warning-color);
 }
 
 .segment-width {
@@ -56,7 +56,7 @@
   top: 22px;
   height: 24px;
   line-height: 20px;
-  color: $segment-text;
+  color: var(--segment-text);
   overflow: hidden;
   pointer-events: none;
 }

--- a/client/src/segments/SegmentLabelContainer.scss
+++ b/client/src/segments/SegmentLabelContainer.scss
@@ -1,13 +1,16 @@
 @import "../../styles/variables";
 
 .segment-label-container {
+  --segment-rule-color: rgb(160 160 160);
+  --segment-grid-height: 10px;
+
   display: flex;
   justify-content: center;
   position: absolute;
   left: 0;
   right: -1px;
-  border-left: 1px solid $segment-width-rule;
-  border-right: 1px solid $segment-width-rule;
+  border-left: 1px solid var(--segment-rule-color);
+  border-right: 1px solid var(--segment-rule-color);
   top: $canvas-baseline;
   height: 90px;
   font-size: 0.9em;
@@ -72,13 +75,13 @@ the width element is inside the street layout which is forced `ltr` */
   left: -1px;
   right: -1px;
   top: 0;
-  height: $segment-grid-height;
+  height: var(--segment-grid-height);
   pointer-events: none;
 
   // Creates grid lines
   background-image: linear-gradient(
     90deg,
-    $segment-width-rule 1px,
+    var(--segment-rule-color) 1px,
     transparent 1px
   );
   background-repeat: repeat-x;

--- a/client/src/segments/SegmentLabelContainer.scss
+++ b/client/src/segments/SegmentLabelContainer.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .segment-label-container {
   --segment-rule-color: rgb(160 160 160);
   --segment-grid-height: 10px;
@@ -11,7 +9,7 @@
   right: -1px;
   border-left: 1px solid var(--segment-rule-color);
   border-right: 1px solid var(--segment-rule-color);
-  top: $canvas-baseline;
+  top: var(--canvas-baseline);
   height: 90px;
   font-size: 0.9em;
 }
@@ -88,10 +86,10 @@ the width element is inside the street layout which is forced `ltr` */
 
   // Change background-size width to adjust spacing of grid lines
   &.units-imperial {
-    background-size: $tile-size 100%;
+    background-size: var(--tile-size) 100%;
   }
 
   &.units-metric {
-    background-size: calc($tile-size * 100 / 30 / 2) 100%;
+    background-size: calc(var(--tile-size) * 100 / 30 / 2) 100%;
   }
 }

--- a/client/src/sentiment/SentimentIcon.scss
+++ b/client/src/sentiment/SentimentIcon.scss
@@ -4,7 +4,7 @@
   width: 60px;
   height: 60px;
   margin: 0;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
   border: 0;
   color: white;
   font-size: 2em;

--- a/client/src/sentiment/SentimentIcon.scss
+++ b/client/src/sentiment/SentimentIcon.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .sentiment-icon {
   width: 60px;
   height: 60px;
@@ -31,6 +29,6 @@
   }
 
   &.sentiment-5 {
-    background-color: $colour-emerald-400;
+    background-color: var(--color-emerald-400);
   }
 }

--- a/client/src/sentiment/SentimentSurvey.scss
+++ b/client/src/sentiment/SentimentSurvey.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .sentiment-survey-container {
   position: absolute;
   z-index: 190; // Underlay menubar and street meta area
@@ -48,7 +46,7 @@
   h2 {
     margin-top: 0.5em;
     margin-bottom: 0;
-    color: $colour-turquoise-700;
+    color: var(--color-turquoise-700);
     font-weight: normal;
 
     em {

--- a/client/src/sentiment/SentimentSurvey.scss
+++ b/client/src/sentiment/SentimentSurvey.scss
@@ -41,7 +41,7 @@
   width: max-content;
   max-width: 600px;
   padding: 1.5em 3em;
-  box-shadow: $medium-box-shadow;
+  box-shadow: var(--medium-box-shadow);
   text-align: center;
   pointer-events: auto;
 

--- a/client/src/sentiment/SentimentSurvey.scss
+++ b/client/src/sentiment/SentimentSurvey.scss
@@ -33,7 +33,7 @@
 
 .sentiment-survey-dialog {
   background-color: white;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
   margin: 0 auto;
   margin-top: 160px; // Clear street meta area
   margin-bottom: 15px;

--- a/client/src/sentiment/VoteReceipt.scss
+++ b/client/src/sentiment/VoteReceipt.scss
@@ -67,7 +67,7 @@
   input {
     flex-grow: 1;
     margin-right: 0.5em;
-    border-radius: $border-radius-medium;
+    border-radius: var(--border-radius-medium);
     border: 1px solid $colour-turquoise-400;
     height: 2.25em;
   }

--- a/client/src/sentiment/VoteReceipt.scss
+++ b/client/src/sentiment/VoteReceipt.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .sentiment-survey-done-container {
   position: absolute;
   top: 20px;
@@ -45,7 +43,7 @@
   margin: 1em 0;
 
   strong:first-of-type {
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
   }
 
   .sentiment-icon {
@@ -68,7 +66,7 @@
     flex-grow: 1;
     margin-right: 0.5em;
     border-radius: var(--border-radius-medium);
-    border: 1px solid $colour-turquoise-400;
+    border: 1px solid var(--color-turquoise-400);
     height: 2.25em;
   }
 

--- a/client/src/sky/SkyBox/SkyBox.scss
+++ b/client/src/sky/SkyBox/SkyBox.scss
@@ -22,7 +22,7 @@
   width: 100%;
   background-repeat: repeat-x;
   background-position: 0 0;
-  transition: opacity $skybox-transition;
+  transition: opacity var(--skybox-transition);
 }
 
 .rear-clouds {
@@ -83,8 +83,8 @@
   left: 0;
   width: 100%;
   height: 100%;
-  transition: opacity $skybox-transition;
-  z-index: $z-01-foreground;
+  transition: opacity var(--skybox-transition);
+  z-index: var(--z-01-foreground);
   pointer-events: none;
   opacity: 0;
 }

--- a/client/src/sky/SkyBox/SkyBox.scss
+++ b/client/src/sky/SkyBox/SkyBox.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .street-section-sky {
   position: absolute;
   left: 0;

--- a/client/src/sky/SkyBox/SkyObjects.scss
+++ b/client/src/sky/SkyBox/SkyObjects.scss
@@ -11,8 +11,8 @@
   opacity: 0;
   transform: translateY(-14px);
   transition:
-    opacity $skybox-transition,
-    transform $skybox-transition;
+    opacity var(--skybox-transition),
+    transform var(--skybox-transition);
 }
 
 .sky-background-object-enter-done {

--- a/client/src/sky/SkyBox/SkyObjects.scss
+++ b/client/src/sky/SkyBox/SkyObjects.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .sky-background-objects {
   position: absolute;
   left: 0;

--- a/client/src/sky/SkyPicker/SkyOptions.scss
+++ b/client/src/sky/SkyPicker/SkyOptions.scss
@@ -16,7 +16,7 @@ $selection-focus-colour: $colour-turquoise-500;
   position: relative;
   width: 40px;
   height: 40px;
-  border-radius: $border-radius-large;
+  border-radius: var(--border-radius-large);
   cursor: pointer;
   transition: 120ms box-shadow;
 
@@ -46,7 +46,7 @@ $selection-focus-colour: $colour-turquoise-500;
     left: 0;
     width: 100%;
     height: 100%;
-    border-radius: $border-radius-large;
+    border-radius: var(--border-radius-large);
     background-color: rgba(221 221 221 / 65%);
   }
 

--- a/client/src/sky/SkyPicker/SkyOptions.scss
+++ b/client/src/sky/SkyPicker/SkyOptions.scss
@@ -1,9 +1,7 @@
-@import "../../../styles/variables";
-
-$selection-highlight-colour: $colour-copper-500;
-$selection-focus-colour: $colour-turquoise-500;
-
 .sky-options {
+  --selection-highlight-color: var(--color-copper-500);
+  --selection-focus-color: var(--color-turquoise-500);
+
   display: grid;
   height: auto;
   grid-template-columns: 1fr 1fr 1fr 1fr;
@@ -26,14 +24,14 @@ $selection-focus-colour: $colour-turquoise-500;
 
   &:focus {
     box-shadow:
-      0 0 0 2px $selection-focus-colour,
+      0 0 0 2px var(--selection-focus-color),
       inset 0 0 0 2px rgb(255 255 255 / 100%);
   }
 }
 
 .sky-option-item.sky-selected {
   box-shadow:
-    0 0 0 2px $selection-highlight-colour,
+    0 0 0 2px var(--selection-highlight-color),
     inset 0 0 0 2px rgb(255 255 255 / 100%);
 }
 
@@ -55,7 +53,7 @@ $selection-focus-colour: $colour-turquoise-500;
     right: 4px;
     top: 4px;
     z-index: 2;
-    color: $colour-copper-600;
+    color: var(--color-copper-600);
 
     [dir="rtl"] & {
       left: 4px;

--- a/client/src/sky/SkyPicker/SkyOptions.scss
+++ b/client/src/sky/SkyPicker/SkyOptions.scss
@@ -21,6 +21,7 @@
   // These are functionally buttons, reset appearance
   appearance: none;
   border: 0;
+  padding: 0;
 
   &:focus {
     box-shadow:

--- a/client/src/sky/SkyPicker/SkyPicker.scss
+++ b/client/src/sky/SkyPicker/SkyPicker.scss
@@ -1,12 +1,12 @@
 @use "sass:color";
 @import "../../../styles/variables";
 
-$sky-picker-border-radius: var(--border-radius-large);
-$sky-picker-box-shadow: var(--medium-box-shadow);
-$header-background-colour: var(--color-turquoise-200);
-$header-text-colour: var(--color-turquoise-700);
-
 .sky-picker-container-outer {
+  --sky-picker-border-radius: var(--border-radius-large);
+  --sky-picker-box-shadow: var(--medium-box-shadow);
+  --header-background-color: var(--color-turquoise-200);
+  --header-text-color: var(--color-turquoise-700);
+
   z-index: var(--z-07-sky-picker);
   position: absolute;
 
@@ -19,9 +19,9 @@ $header-text-colour: var(--color-turquoise-700);
 
 .sky-picker-container-inner {
   background-color: white;
-  border-radius: $sky-picker-border-radius;
+  border-radius: var(--sky-picker-border-radius);
   overflow: hidden;
-  box-shadow: $sky-picker-box-shadow;
+  box-shadow: var(--sky-picker-box-shadow);
   user-select: none;
 
   [dir="rtl"] & {
@@ -32,8 +32,8 @@ $header-text-colour: var(--color-turquoise-700);
 
 .sky-picker header {
   padding: 0.5em;
-  background-color: $header-background-colour;
-  color: $header-text-colour;
+  background-color: var(--header-background-color);
+  color: var(--header-text-color);
   display: flex;
   align-items: center;
 }
@@ -103,7 +103,7 @@ $header-text-colour: var(--color-turquoise-700);
     color: var(--color-copper-600);
 
     &:disabled {
-      border: 1px solid color.adjust($colour-copper-200, $saturation: -50%);
+      filter: grayscale(0.8);
     }
 
     &:hover {

--- a/client/src/sky/SkyPicker/SkyPicker.scss
+++ b/client/src/sky/SkyPicker/SkyPicker.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .sky-picker-container-outer {
   --sky-picker-border-radius: var(--border-radius-large);
   --sky-picker-box-shadow: var(--medium-box-shadow);

--- a/client/src/sky/SkyPicker/SkyPicker.scss
+++ b/client/src/sky/SkyPicker/SkyPicker.scss
@@ -2,12 +2,12 @@
 @import "../../../styles/variables";
 
 $sky-picker-border-radius: var(--border-radius-large);
-$sky-picker-box-shadow: $medium-box-shadow;
-$header-background-colour: $colour-turquoise-200;
-$header-text-colour: $colour-turquoise-700;
+$sky-picker-box-shadow: var(--medium-box-shadow);
+$header-background-colour: var(--color-turquoise-200);
+$header-text-colour: var(--color-turquoise-700);
 
 .sky-picker-container-outer {
-  z-index: $z-07-sky-picker;
+  z-index: var(--z-07-sky-picker);
   position: absolute;
 
   // TODO: use button trigger to set initial position,
@@ -100,7 +100,7 @@ $header-text-colour: $colour-turquoise-700;
     width: auto;
     font-weight: 550;
     background-color: transparent;
-    color: $colour-copper-600;
+    color: var(--color-copper-600);
 
     &:disabled {
       border: 1px solid color.adjust($colour-copper-200, $saturation: -50%);
@@ -108,7 +108,7 @@ $header-text-colour: $colour-turquoise-700;
 
     &:hover {
       background-color: transparent;
-      color: $colour-copper-700;
+      color: var(--color-copper-700);
     }
   }
 }

--- a/client/src/sky/SkyPicker/SkyPicker.scss
+++ b/client/src/sky/SkyPicker/SkyPicker.scss
@@ -1,7 +1,7 @@
 @use "sass:color";
 @import "../../../styles/variables";
 
-$sky-picker-border-radius: $border-radius-large;
+$sky-picker-border-radius: var(--border-radius-large);
 $sky-picker-box-shadow: $medium-box-shadow;
 $header-background-colour: $colour-turquoise-200;
 $header-text-colour: $colour-turquoise-700;
@@ -84,17 +84,17 @@ $header-text-colour: $colour-turquoise-700;
 
 .sky-picker-upgrade {
   padding: 0.75em 1em;
-  background-color: $alert-background-light;
+  background-color: color-mix(in oklch, white 20%, var(--alert-background));
   font-size: 1rem;
   line-height: 1.2;
   text-align: center;
-  color: $colour-copper-700;
+  color: var(--color-copper-700);
 
   /* Very similar to .toast-action style */
   button {
     display: block !important;
-    border: 1px solid $colour-copper-400;
-    border-radius: $border-radius-medium;
+    border: 1px solid var(--color-copper-400);
+    border-radius: var(--border-radius-medium);
     padding: 0.5em 1em;
     margin: 0.75em auto 0.25em;
     width: auto;

--- a/client/src/streets/StreetMeta/StreetMeta.scss
+++ b/client/src/streets/StreetMeta/StreetMeta.scss
@@ -9,7 +9,7 @@
   color: black;
   user-select: none;
   pointer-events: auto;
-  transition: color $skybox-transition;
+  transition: color var(--skybox-transition);
   font-size: 0.925rem;
 
   > div:not(:first-child) {

--- a/client/src/streets/StreetMeta/StreetMeta.scss
+++ b/client/src/streets/StreetMeta/StreetMeta.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .street-meta {
   display: flex;
   flex-wrap: wrap;

--- a/client/src/streets/StreetMeta/StreetMetaItem.scss
+++ b/client/src/streets/StreetMeta/StreetMetaItem.scss
@@ -13,7 +13,7 @@
     height: 2rem;
     padding: 0 0.5em;
     cursor: pointer;
-    border-radius: $border-radius-large;
+    border-radius: var(--border-radius-large);
 
     &:hover {
       background-color: rgba(255 255 255 / 20%);

--- a/client/src/streets/StreetMeta/StreetMetaItem.scss
+++ b/client/src/streets/StreetMeta/StreetMetaItem.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .street-meta-item {
   display: flex;
   align-items: center;

--- a/client/src/streets/StreetMeta/StreetMetaWidthLabel.scss
+++ b/client/src/streets/StreetMeta/StreetMetaWidthLabel.scss
@@ -29,7 +29,7 @@
 .street-width-under {
   margin-left: 0.25em;
   color: rgb(96 96 96);
-  transition: color $skybox-transition;
+  transition: color var(--skybox-transition);
 
   [dir="rtl"] & {
     margin-right: 0.25em;

--- a/client/src/streets/StreetMeta/StreetMetaWidthLabel.scss
+++ b/client/src/streets/StreetMeta/StreetMetaWidthLabel.scss
@@ -1,6 +1,3 @@
-@use "sass:color";
-@import "../../../styles/variables";
-
 .street-width {
   display: inline-flex;
   align-items: center;

--- a/client/src/streets/StreetMeta/StreetMetaWidthLabel.scss
+++ b/client/src/streets/StreetMeta/StreetMetaWidthLabel.scss
@@ -18,7 +18,7 @@
 
 .street-width-over {
   margin-left: 0.25em;
-  color: $warning-colour;
+  color: var(--warning-color);
 
   [dir="rtl"] & {
     margin-right: 0.25em;

--- a/client/src/streets/StreetName.scss
+++ b/client/src/streets/StreetName.scss
@@ -9,7 +9,7 @@ $street-name-size: 1.5;
 
 @mixin street-name-inside-mixin($size: $street-name-size) {
   height: 50px * $size;
-  border: 3px * $size solid $street-name-text;
+  border: 3px * $size solid var(--street-name-text);
   padding: 10px * $size 20px * $size;
   padding-top: 11px * $size;
   padding-bottom: 5px * $size;
@@ -25,9 +25,12 @@ $street-name-size: 1.5;
 .street-name {
   @include street-name-mixin;
 
+  --street-name-text: black;
+  --street-name-background: white;
+
   display: inline-block;
-  background: $street-name-background;
-  color: $street-name-text;
+  background: var(--street-name-background);
+  color: var(--street-name-text);
   user-select: none;
   white-space: nowrap;
 }

--- a/client/src/streets/StreetName.scss
+++ b/client/src/streets/StreetName.scss
@@ -3,10 +3,6 @@
 
 $street-name-size: 1.5;
 
-@mixin street-name-mixin($size: $street-name-size) {
-  padding: 3px * $size;
-}
-
 @mixin street-name-inside-mixin($size: $street-name-size) {
   height: 50px * $size;
   border: 3px * $size solid var(--street-name-text);
@@ -23,12 +19,11 @@ $street-name-size: 1.5;
 }
 
 .street-name {
-  @include street-name-mixin;
-
   --street-name-text: black;
   --street-name-background: white;
 
   display: inline-block;
+  padding: calc(3px * var(--street-name-size));
   background: var(--street-name-background);
   color: var(--street-name-text);
   user-select: none;
@@ -46,7 +41,7 @@ $street-name-size: 1.5;
 }
 
 .gallery .streets .street-name {
-  @include street-name-mixin($street-name-gallery-size);
+  --street-name-size: var(--street-name-size-small);
 
   max-width: 95%;
   position: relative;

--- a/client/src/streets/StreetNameplateContainer.scss
+++ b/client/src/streets/StreetNameplateContainer.scss
@@ -1,13 +1,9 @@
-@import "../../styles/variables";
-
-$street-name-top: 10px;
-
 .street-nameplate-container {
   position: absolute;
   left: 150px;
   right: 150px;
-  top: $street-name-top;
-  z-index: $z-03-street-name;
+  top: 10px;
+  z-index: var(--z-03-street-name);
   text-align: center;
   pointer-events: none;
 

--- a/client/src/ui/Button.scss
+++ b/client/src/ui/Button.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-@import "../../styles/variables";
 @import "../../styles/mixins";
 
 .btn,
@@ -32,10 +30,7 @@ a.btn {
   }
 
   &[disabled] {
-    background-color: color.adjust(
-      fade-out($ui-colour, 0.7),
-      $saturation: -100%
-    ) !important;
+    background-color: var(--deprecated-ui-color-fade-desaturate) !important;
     color: #999 !important;
     cursor: auto;
 
@@ -45,10 +40,7 @@ a.btn {
     }
 
     &:hover {
-      background-color: color.adjust(
-        fade-out($ui-colour, 0.7),
-        $saturation: -100%
-      ) !important;
+      background-color: var(--deprecated-ui-color-fade-desaturate) !important;
     }
   }
 

--- a/client/src/ui/Button.scss
+++ b/client/src/ui/Button.scss
@@ -11,8 +11,8 @@ a.btn {
   border: 0;
   border-radius: var(--border-radius-medium);
   padding: 0.75em 2em;
-  background-color: $colour-turquoise-225;
-  color: $colour-midnight-700;
+  background-color: var(--color-turquoise-250);
+  color: var(--color-midnight-700);
   font-weight: 550;
   text-align: center;
   text-decoration: none;
@@ -20,15 +20,15 @@ a.btn {
 
   // stylelint-disable-next-line selector-class-pattern
   &:not([disabled]) .svg-inline--fa {
-    color: $colour-midnight-700;
+    color: var(--color-midnight-700);
   }
 
   &:hover {
-    background-color: $colour-turquoise-250;
+    background-color: var(--color-turquoise-300);
   }
 
   &:active {
-    background-color: $colour-turquoise-250;
+    background-color: var(--color-turquoise-300);
   }
 
   &[disabled] {
@@ -53,42 +53,44 @@ a.btn {
   }
 
   &.btn-primary {
-    background-color: $colour-emerald-400;
+    background-color: var(--color-emerald-400);
     color: white;
 
     &:hover {
-      background-color: color.mix(
-        $colour-emerald-400,
-        $colour-emerald-500,
-        75%
+      // TODO: replace with new color stop?
+      background-color: color-mix(
+        in oklch,
+        var(--color-emerald-400),
+        var(--color-emerald-500) 25%
       );
     }
   }
 
   &.btn-secondary {
-    background-color: $colour-turquoise-500;
+    background-color: var(--color-turquoise-500);
     color: white;
 
     &:hover {
-      background-color: color.mix(
-        $colour-turquoise-500,
-        $colour-turquoise-600,
-        75%
+      // TODO: replace with new color stop?
+      background-color: color-mix(
+        in oklch,
+        var(--color-emerald-500),
+        var(--color-emerald-600) 25%
       );
     }
   }
 
   &.btn-tertiary {
     background-color: transparent;
-    color: $colour-turquoise-600;
+    color: var(--color-turquoise-600);
 
     &:not(:disabled) {
-      border: 1px solid $colour-turquoise-400;
+      border: 1px solid var(--color-turquoise-400);
     }
 
     &:hover {
-      background-color: $colour-turquoise-100;
-      color: $colour-turquoise-700;
+      background-color: var(--color-turquoise-100);
+      color: var(--color-turquoise-700);
     }
   }
 }

--- a/client/src/ui/Button.scss
+++ b/client/src/ui/Button.scss
@@ -9,7 +9,7 @@ a.btn {
   display: inline-block;
   outline: none;
   border: 0;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
   padding: 0.75em 2em;
   background-color: $colour-turquoise-225;
   color: $colour-midnight-700;

--- a/client/src/ui/Checkbox.scss
+++ b/client/src/ui/Checkbox.scss
@@ -1,32 +1,30 @@
-@import "../../styles/variables";
-
-// UI color ramp
-$color-1: $colour-midnight-300 !default;
-$color-2: $colour-turquoise-500 !default;
-
-// Special colors
-$disabled-color: $colour-midnight-300 !default;
-
-// Colors for stylized checkbox input
-$input-default-border-color: $color-1;
-$input-unchecked-background-color: transparent;
-$input-checked-border-color: $color-1;
-$input-checked-background-color: white;
-$input-hover-border-color: $color-2;
-$input-active-border-color: $color-2;
-$input-active-background-color: $color-2;
-$input-disabled-border-color: $disabled-color;
-
-// Colors for checkmark icon
-$checkmark-checked-color: $color-2;
-$checkmark-active-color: white;
-$checkmark-disabled-color: $disabled-color;
-
-// Colors for label
-$label-disabled-text-color: $disabled-color;
-$label-outline-color: $color-2;
-
 .checkbox-item {
+  // UI color ramp
+  --color-1: var(--color-midnight-300);
+  --color-2: var(--color-turquoise-500);
+
+  // Special colors
+  --disabled-color: var(--color-midnight-300);
+
+  // Colors for stylized checkbox input
+  --input-default-border-color: var(--color-1);
+  --input-unchecked-background-color: transparent;
+  --input-checked-border-color: var(--color-1);
+  --input-checked-background-color: white;
+  --input-hover-border-color: var(--color-2);
+  --input-active-border-color: var(--color-2);
+  --input-active-background-color: var(--color-2);
+  --input-disabled-border-color: var(--disabled-color);
+
+  // Colors for checkmark icon
+  --checkmark-checked-color: var(--color-2);
+  --checkmark-active-color: white;
+  --checkmark-disabled-color: var(--disabled-color);
+
+  // Colors for label
+  --label-disabled-text-color: var(--disabled-color);
+  --label-outline-color: var(--color-2);
+
   position: relative;
 
   /* Fits DOM element to content, so check mark is aligned to box
@@ -68,13 +66,13 @@ $label-outline-color: $color-2;
     content: "";
     display: block;
     position: absolute;
-    left: -1.2em;
+    left: -1.25em;
     top: 0.25em;
     height: 1em;
     width: 1em;
-    background-color: $input-unchecked-background-color;
+    background-color: var(--input-unchecked-background-color);
     border-radius: var(--border-radius-small);
-    border: 1px solid $input-default-border-color;
+    border: 1px solid var(--input-default-border-color);
     color: inherit;
     transition:
       background-color 60ms,
@@ -83,31 +81,31 @@ $label-outline-color: $color-2;
 
   /* Stylized checkbox, when checked */
   input:checked ~ label::before {
-    background-color: $input-checked-background-color;
-    border-color: $input-checked-border-color;
+    background-color: var(--input-checked-background-color);
+    border-color: var(--input-checked-border-color);
   }
 
   /* Stylized checkbox, when active (during click) */
   input:active:not(:disabled) ~ label::before {
-    background-color: $input-active-border-color;
-    border-color: $input-active-border-color;
+    background-color: var(--input-active-border-color);
+    border-color: var(--input-active-border-color);
   }
 
   /* Stylized checkbox, when focused or hovered */
   input:focus:not(:disabled) ~ label::before,
   input:hover:not(:disabled) ~ label::before {
-    border: 1px solid $input-hover-border-color;
+    border: 1px solid var(--input-hover-border-color);
   }
 
   /* Stylized checkbox, when checked, and focused or hovered */
   input:focus:checked:not(:disabled) + label::before,
   input:hover:checked:not(:disabled) + label::before {
-    border-color: $input-active-border-color;
+    border-color: var(--input-active-border-color);
   }
 
   /* Stylized checkbox, when disabled */
   input:disabled + label::before {
-    border-color: $input-disabled-border-color;
+    border-color: var(--input-disabled-border-color);
   }
 
   /* Checkmark */
@@ -126,28 +124,28 @@ $label-outline-color: $color-2;
 
   /* Checkmark, when checked */
   input:checked ~ svg {
-    color: $checkmark-checked-color;
+    color: var(--checkmark-checked-color);
     opacity: 1;
   }
 
   /* Checkmark, when active (during click) */
   input:active ~ svg {
-    color: $checkmark-active-color;
+    color: var(--checkmark-active-color);
   }
 
   /* Checkmark, when input disabled */
   input:checked:disabled ~ svg {
-    color: $checkmark-disabled-color;
+    color: var(--checkmark-disabled-color);
   }
 
   /* Label, when input is focused */
   input:focus ~ label {
-    outline: 1px dotted $label-outline-color;
+    outline: 1px dotted var(--label-outline-color);
   }
 
   /* Label, when input is disabled */
   input:disabled ~ label {
-    color: $label-disabled-text-color;
+    color: var(--label-disabled-text-color);
     cursor: default;
   }
 }

--- a/client/src/ui/Checkbox.scss
+++ b/client/src/ui/Checkbox.scss
@@ -73,7 +73,7 @@ $label-outline-color: $color-2;
     height: 1em;
     width: 1em;
     background-color: $input-unchecked-background-color;
-    border-radius: $border-radius-small;
+    border-radius: var(--border-radius-small);
     border: 1px solid $input-default-border-color;
     color: inherit;
     transition:

--- a/client/src/ui/CloseButton.scss
+++ b/client/src/ui/CloseButton.scss
@@ -1,32 +1,32 @@
 @import "../../styles/variables";
 
-$close-button-margin: 2px;
-$close-button-size: 34px;
-$close-icon-colour: $colour-turquoise-500;
-$close-icon-colour-hover: $colour-turquoise-600;
-
 button.close {
+  --close-button-margin: 2px;
+  --close-button-size: 34px;
+  --close-icon-color: var(--color-turquoise-500);
+  --close-icon-color-hover: var(--color-turquoise-600);
+
   // Position in dialog boxes
   position: absolute;
-  right: $close-button-margin;
-  top: $close-button-margin;
+  right: var(--close-button-margin);
+  top: var(--close-button-margin);
 
   // Mirror position in rtl
   [dir="rtl"] & {
     right: auto;
-    left: $close-button-margin;
+    left: var(--close-button-margin);
   }
 
   // Touch-friendly size
-  width: $close-button-size;
-  height: $close-button-size;
+  width: var(--close-button-size);
+  height: var(--close-button-size);
 
   // Appearance
   appearance: none;
   padding: 0;
   border: 0;
   border-radius: 50%;
-  color: $close-icon-colour;
+  color: var(--close-icon-color);
   cursor: pointer;
   user-select: none;
   background-color: transparent;
@@ -39,7 +39,7 @@ button.close {
 
   &:hover {
     background-color: rgb(255 255 255 / 50%);
-    color: $close-icon-colour-hover;
+    color: var(--close-icon-color-hover);
   }
 
   &:active {

--- a/client/src/ui/CloseButton.scss
+++ b/client/src/ui/CloseButton.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 button.close {
   --close-button-margin: 2px;
   --close-button-size: 34px;

--- a/client/src/ui/LoadingSpinner.scss
+++ b/client/src/ui/LoadingSpinner.scss
@@ -1,12 +1,3 @@
-@import "../../styles/variables";
-
-$spinner-default-size: 30px;
-$spinner-small-size: 13px;
-$spinner-border-default-width: 3px;
-$spinner-border-small-width: 2px;
-$spinner-primary-colour: $colour-turquoise-500;
-$spinner-secondary-colour: $colour-turquoise-200;
-
 // The loading spinner is one <div> element for placement and sizing,
 // and a pseudo-element for the visual animation itself. The base
 // element sets the default size, but not the default placement. It
@@ -14,11 +5,18 @@ $spinner-secondary-colour: $colour-turquoise-200;
 // text-align, or similar) or it can override the CSS rules of
 // the .loading-spinner element itself.
 .loading-spinner {
+  --spinner-default-size: 30px;
+  --spinner-small-size: 13px;
+  --spinner-border-default-width: 3px;
+  --spinner-border-small-width: 2px;
+  --spinner-primary-colour: var(--color-turquoise-500);
+  --spinner-secondary-colour: var(--color-turquoise-200);
+
   position: relative;
 
   // Default size of spinner
-  width: $spinner-default-size;
-  height: $spinner-default-size;
+  width: var(--spinner-default-size);
+  height: var(--spinner-default-size);
 }
 
 // The visual spinner exists in a pseudo-element set up to
@@ -31,19 +29,19 @@ $spinner-secondary-colour: $colour-turquoise-200;
   width: 100%;
   height: 100%;
   border-radius: 50%;
-  border-width: $spinner-border-default-width;
+  border-width: var(--spinner-border-default-width);
   border-style: solid;
-  border-color: $spinner-secondary-colour;
-  border-top-color: $spinner-primary-colour;
+  border-color: var(--spinner-secondary-colour);
+  border-top-color: var(--spinner-primary-colour);
   animation: spinner 0.75s linear infinite;
 }
 
 .loading-spinner-small {
-  width: $spinner-small-size;
-  height: $spinner-small-size;
+  width: var(--spinner-small-size);
+  height: var(--spinner-small-size);
 
   &::before {
-    border-width: $spinner-border-small-width;
+    border-width: var(--spinner-border-small-width);
   }
 }
 

--- a/client/src/ui/Popover.scss
+++ b/client/src/ui/Popover.scss
@@ -29,8 +29,8 @@
   box-shadow:
     rgba(24 37 73 / 15%) 0 5px 20px 0,
     rgba(24 37 73 / 5%) 0 10px 20px -5px;
-  font-family: $font-family;
-  font-size: $font-size-base;
+  font-family: var(--font-family);
+  font-size: var(--font-size-base);
   font-weight: normal;
   text-align: center;
   overflow: hidden;

--- a/client/src/ui/Popover.scss
+++ b/client/src/ui/Popover.scss
@@ -8,7 +8,7 @@
   width: 23px;
   height: 23px;
   border: 0;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
   margin: 0 0.35em;
   padding: 0;
   color: $colour-midnight-500;
@@ -25,7 +25,7 @@
   padding: 0.8em 1.2em;
   color: rgba(65 65 65);
   background-color: white;
-  border-radius: $border-radius-large;
+  border-radius: var(--border-radius-large);
   box-shadow:
     rgba(24 37 73 / 15%) 0 5px 20px 0,
     rgba(24 37 73 / 5%) 0 10px 20px -5px;

--- a/client/src/ui/Popover.scss
+++ b/client/src/ui/Popover.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .popover-trigger {
   display: inline-flex;
   align-items: center;
@@ -11,12 +9,12 @@
   border-radius: var(--border-radius-medium);
   margin: 0 0.35em;
   padding: 0;
-  color: $colour-midnight-500;
+  color: var(--color-midnight-500);
   background-color: transparent;
   cursor: pointer;
 
   &:hover {
-    background-color: $colour-midnight-100;
+    background-color: var(--color-midnight-100);
   }
 }
 

--- a/client/src/ui/RadioGroup.scss
+++ b/client/src/ui/RadioGroup.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .radio-group-item {
   display: flex;
   margin: 0.8em 0;
@@ -13,7 +11,7 @@
   height: 21px;
   border: 0;
   background-color: white;
-  box-shadow: 0 0 0 1px $colour-turquoise-500;
+  box-shadow: 0 0 0 1px var(--color-turquoise-500);
   transition: background-color 120ms;
   border-radius: 9999px;
   cursor: pointer;
@@ -22,7 +20,7 @@
 
   &:focus,
   &:active:not(:disabled) {
-    box-shadow: 0 0 0 2px $colour-turquoise-500;
+    box-shadow: 0 0 0 2px var(--color-turquoise-500);
   }
 
   &:disabled {
@@ -58,7 +56,7 @@
     width: 11px;
     height: 11px;
     border-radius: 50%;
-    background-color: $colour-turquoise-500;
+    background-color: var(--color-turquoise-500);
   }
 }
 

--- a/client/src/ui/Slider.scss
+++ b/client/src/ui/Slider.scss
@@ -1,18 +1,15 @@
-@import "../../styles/variables";
-
-$slider-thumb-color: var(--color-turquoise-500) !default;
-$slider-thumb-color-hover: $colour-turquoise-450 !default;
-$slider-thumb-color-focus: var(--color-turquoise-500) !default;
-$slider-thumb-size: 19px !default;
-$slider-track-color: $colour-turquoise-150 !default;
-$slider-track-height: 7px !default;
-$slider-range-color: var(--color-turquoise-350) !default;
-
 .slider-root {
+  --slider-thumb-color: var(--color-turquoise-500);
+  --slider-thumb-color-hover: var(--color-turquoise-450);
+  --slider-thumb-size: 19px;
+  --slider-track-color: var(--color-turquoise-150);
+  --slider-track-height: 7px;
+  --slider-range-color: var(--color-turquoise-350);
+
   position: relative;
   display: flex;
   width: 100%;
-  height: max($slider-thumb-size, $slider-track-height);
+  height: max(var(--slider-thumb-size), var(--slider-track-height));
   margin: 0.25em 0;
   align-items: center;
   user-select: none;
@@ -22,9 +19,9 @@ $slider-range-color: var(--color-turquoise-350) !default;
 .slider-track {
   position: relative;
   flex-grow: 1;
-  height: $slider-track-height;
+  height: var(--slider-track-height);
   border-radius: var(--border-radius-pill);
-  background-color: $slider-track-color;
+  background-color: var(--slider-track-color);
 
   &[data-disabled] {
     background-color: var(--color-midnight-100);
@@ -35,9 +32,9 @@ $slider-range-color: var(--color-turquoise-350) !default;
   position: absolute;
   top: 0;
   left: 0;
-  height: $slider-track-height;
+  height: var(--slider-track-height);
   border-radius: var(--border-radius-pill);
-  background-color: $slider-range-color;
+  background-color: var(--slider-range-color);
 
   &[data-disabled] {
     background-color: var(--color-midnight-200);
@@ -47,12 +44,12 @@ $slider-range-color: var(--color-turquoise-350) !default;
 .slider-thumb {
   position: absolute;
   display: block;
-  width: $slider-thumb-size;
-  height: $slider-thumb-size;
-  margin-top: calc($slider-thumb-size / -2);
-  margin-left: calc($slider-thumb-size / -2);
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  margin-top: calc(var(--slider-thumb-size) / -2);
+  margin-left: calc(var(--slider-thumb-size) / -2);
   border-radius: var(--border-radius-pill);
-  background-color: $slider-thumb-color;
+  background-color: var(--slider-thumb-color);
   cursor: pointer;
   box-shadow: 0 2px 10px rgba(0 0 0 / 14%);
 
@@ -61,7 +58,7 @@ $slider-range-color: var(--color-turquoise-350) !default;
   }
 
   &:hover:not([data-disabled]) {
-    background: $slider-thumb-color-hover;
+    background-color: var(--slider-thumb-color-hover);
   }
 
   &:focus:not([data-disabled]) {

--- a/client/src/ui/Slider.scss
+++ b/client/src/ui/Slider.scss
@@ -1,12 +1,12 @@
 @import "../../styles/variables";
 
-$slider-thumb-color: $colour-turquoise-500 !default;
+$slider-thumb-color: var(--color-turquoise-500) !default;
 $slider-thumb-color-hover: $colour-turquoise-450 !default;
-$slider-thumb-color-focus: $colour-turquoise-500 !default;
+$slider-thumb-color-focus: var(--color-turquoise-500) !default;
 $slider-thumb-size: 19px !default;
 $slider-track-color: $colour-turquoise-150 !default;
 $slider-track-height: 7px !default;
-$slider-range-color: $colour-turquoise-350 !default;
+$slider-range-color: var(--color-turquoise-350) !default;
 
 .slider-root {
   position: relative;
@@ -27,7 +27,7 @@ $slider-range-color: $colour-turquoise-350 !default;
   background-color: $slider-track-color;
 
   &[data-disabled] {
-    background-color: $colour-midnight-100;
+    background-color: var(--color-midnight-100);
   }
 }
 
@@ -40,7 +40,7 @@ $slider-range-color: $colour-turquoise-350 !default;
   background-color: $slider-range-color;
 
   &[data-disabled] {
-    background-color: $colour-midnight-200;
+    background-color: var(--color-midnight-200);
   }
 }
 
@@ -57,7 +57,7 @@ $slider-range-color: $colour-turquoise-350 !default;
   box-shadow: 0 2px 10px rgba(0 0 0 / 14%);
 
   &[data-disabled] {
-    background-color: $colour-midnight-300;
+    background-color: var(--color-midnight-300);
   }
 
   &:hover:not([data-disabled]) {
@@ -68,6 +68,6 @@ $slider-range-color: $colour-turquoise-350 !default;
     box-shadow:
       inset 0 0 0 1px white,
       0 0 0 1px white,
-      /* Match background color */ 0 0 0 3px $colour-turquoise-500;
+      /* Match background color */ 0 0 0 3px var(--color-turquoise-500);
   }
 }

--- a/client/src/ui/Slider.scss
+++ b/client/src/ui/Slider.scss
@@ -23,7 +23,7 @@ $slider-range-color: $colour-turquoise-350 !default;
   position: relative;
   flex-grow: 1;
   height: $slider-track-height;
-  border-radius: $border-radius-pill;
+  border-radius: var(--border-radius-pill);
   background-color: $slider-track-color;
 
   &[data-disabled] {
@@ -36,7 +36,7 @@ $slider-range-color: $colour-turquoise-350 !default;
   top: 0;
   left: 0;
   height: $slider-track-height;
-  border-radius: $border-radius-pill;
+  border-radius: var(--border-radius-pill);
   background-color: $slider-range-color;
 
   &[data-disabled] {
@@ -51,7 +51,7 @@ $slider-range-color: $colour-turquoise-350 !default;
   height: $slider-thumb-size;
   margin-top: calc($slider-thumb-size / -2);
   margin-left: calc($slider-thumb-size / -2);
-  border-radius: $border-radius-pill;
+  border-radius: var(--border-radius-pill);
   background-color: $slider-thumb-color;
   cursor: pointer;
   box-shadow: 0 2px 10px rgba(0 0 0 / 14%);

--- a/client/src/ui/Switch.scss
+++ b/client/src/ui/Switch.scss
@@ -12,7 +12,7 @@
   height: 21px;
   border: 0;
   background-color: white;
-  box-shadow: 0 0 0 1px $colour-turquoise-500;
+  box-shadow: 0 0 0 1px var(--color-turquoise-500);
   transition: background-color 120ms;
   border-radius: 9999px;
   cursor: pointer;
@@ -21,7 +21,7 @@
 
   &:focus,
   &:active:not(:disabled) {
-    box-shadow: 0 0 0 2px $colour-turquoise-500;
+    box-shadow: 0 0 0 2px var(--color-turquoise-500);
   }
 
   &:disabled {
@@ -33,12 +33,12 @@
   }
 
   &[data-state="checked"] {
-    background-color: $colour-turquoise-150;
-    box-shadow: 0 0 0 1px $colour-turquoise-500;
+    background-color: var(--color-turquoise-150);
+    box-shadow: 0 0 0 1px var(--color-turquoise-500);
 
     &:focus,
     &:active:not(:disabled) {
-      box-shadow: 0 0 0 2px $colour-turquoise-500;
+      box-shadow: 0 0 0 2px var(--color-turquoise-500);
     }
   }
 
@@ -57,7 +57,7 @@
   display: block;
   width: 15px;
   height: 15px;
-  background-color: $colour-midnight-150;
+  background-color: var(--color-midnight-150);
   border-radius: 9999px;
   transition:
     transform 100ms,
@@ -70,7 +70,7 @@
 
   &[data-state="checked"] {
     transform: translateX(21px);
-    background-color: $colour-turquoise-450;
+    background-color: var(--color-turquoise-450);
   }
 
   &[data-disabled] {

--- a/client/src/ui/Switch.scss
+++ b/client/src/ui/Switch.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .switch-item {
   display: flex;
 }

--- a/client/src/ui/Toasts/Toast.scss
+++ b/client/src/ui/Toasts/Toast.scss
@@ -22,8 +22,8 @@
   min-width: 200px;
   padding: 1em 1.25em;
   font-size: 13px;
-  border-top: $alert-border;
-  background-color: $alert-background;
+  border-top: var(--alert-border);
+  background-color: var(--alert-background);
 
   // Restore line-height after being unset by parent element
   line-height: 1.4;
@@ -49,7 +49,7 @@
 .toast-action button {
   display: block;
   border: 1px solid $colour-copper-400;
-  border-radius: $border-radius-medium;
+  border-radius: var(--border-radius-medium);
   padding: 0.25em 0.5em;
   margin: 0;
   width: 100%;

--- a/client/src/ui/Toasts/Toast.scss
+++ b/client/src/ui/Toasts/Toast.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .toast {
   position: relative;
   overflow: hidden;
@@ -48,7 +46,7 @@
 
 .toast-action button {
   display: block;
-  border: 1px solid $colour-copper-400;
+  border: 1px solid var(--color-copper-400);
   border-radius: var(--border-radius-medium);
   padding: 0.25em 0.5em;
   margin: 0;
@@ -56,20 +54,20 @@
   min-height: 32px;
   font-weight: 550;
   background-color: transparent;
-  color: $colour-copper-600;
+  color: var(--color-copper-600);
   cursor: pointer;
 
   &:hover {
     background-color: transparent;
-    color: $colour-copper-700;
+    color: var(--color-copper-700);
   }
 }
 
-$close-icon-colour: $colour-copper-500;
-$close-icon-colour-hover: $colour-copper-600;
-
 /* Close button overrides */
 .toast .close {
+  --close-icon-color: var(--color-copper-500);
+  --close-icon-color-hover: var(--color-copper-600);
+
   width: 24px;
   height: 24px;
   padding: 0;
@@ -78,7 +76,7 @@ $close-icon-colour-hover: $colour-copper-600;
   display: flex !important;
   justify-content: center;
   align-items: center !important;
-  color: $close-icon-colour;
+  color: var(--close-icon-color);
 
   [dir="rtl"] & {
     right: auto;
@@ -87,7 +85,7 @@ $close-icon-colour-hover: $colour-copper-600;
 
   &:hover {
     background-color: rgb(255 255 255 / 50%);
-    color: $close-icon-colour-hover;
+    color: var(--close-icon-color-hover);
   }
 
   &:active {
@@ -102,28 +100,28 @@ $close-icon-colour-hover: $colour-copper-600;
 
 .toast-success {
   .toast-content {
-    background-color: $colour-emerald-200;
-    border-top-color: $colour-emerald-300;
+    background-color: var(--color-emerald-200);
+    border-top-color: var(--color-emerald-300);
   }
 
   h3 {
-    color: $colour-emerald-700;
+    color: var(--color-emerald-700);
   }
 
   .close {
-    color: $colour-emerald-500;
+    color: var(--color-emerald-500);
 
     &:hover {
-      color: $colour-emerald-600;
+      color: var(--color-emerald-600);
     }
   }
 
   .toast-action button {
-    color: $colour-emerald-600;
-    border-color: $colour-emerald-500;
+    color: var(--color-emerald-600);
+    border-color: var(--color-emerald-500);
 
     &:hover {
-      color: $colour-emerald-700;
+      color: var(--color-emerald-700);
     }
   }
 }

--- a/client/src/ui/Toasts/ToastContainer.scss
+++ b/client/src/ui/Toasts/ToastContainer.scss
@@ -1,12 +1,10 @@
-@import "../../../styles/variables";
-
 .toast-container {
   position: absolute;
   top: 50px;
   right: 30px;
   min-width: 300px;
   max-width: 330px;
-  z-index: $z-07-toasts;
+  z-index: var(--z-07-toasts);
 
   // Align all toasts to right edge
   display: flex;

--- a/client/src/ui/Toasts/ToastWebMonetization.scss
+++ b/client/src/ui/Toasts/ToastWebMonetization.scss
@@ -1,5 +1,3 @@
-@import "../../../styles/variables";
-
 .toast-web-monetization {
   img.wm-icon {
     width: 36px;
@@ -14,12 +12,12 @@
 
   a,
   a:visited {
-    color: $colour-emerald-600;
+    color: var(--color-emerald-600);
   }
 
   a:hover,
   a:active {
-    color: $colour-emerald-500;
+    color: var(--color-emerald-500);
   }
 }
 

--- a/client/src/ui/Tooltip.scss
+++ b/client/src/ui/Tooltip.scss
@@ -1,19 +1,17 @@
-@import "../../styles/variables";
-
-$tooltip-background-colour: #2a2b2a;
-$tooltip-font-colour: white;
-$tooltip-font-weight: 550;
-$tooltip-max-width: 150px;
-
 // Styles must be used in conjunction with the default tippy.js css
 .tippy-box {
-  background-color: $tooltip-background-colour;
+  --tooltip-background-colour: #2a2b2a;
+  --tooltip-font-colour: white;
+  --tooltip-font-weight: 550;
+  --tooltip-max-width: 150px;
+
+  background-color: var(--tooltip-background-colour);
   padding: 0.5em 1.25em;
-  font-weight: $tooltip-font-weight;
-  color: $tooltip-font-colour;
+  font-weight: var(--tooltip-font-weight);
+  color: var(--tooltip-font-colour);
   border-radius: var(--border-radius);
   text-align: center;
-  max-width: $tooltip-max-width;
+  max-width: var(--tooltip-max-width);
   box-shadow: var(--medium-box-shadow);
   opacity: 0.85;
 }
@@ -30,5 +28,5 @@ $tooltip-max-width: 150px;
 }
 
 .tippy-arrow {
-  color: $tooltip-background-colour;
+  color: var(--tooltip-background-colour);
 }

--- a/client/src/ui/Tooltip.scss
+++ b/client/src/ui/Tooltip.scss
@@ -11,7 +11,7 @@ $tooltip-max-width: 150px;
   padding: 0.5em 1.25em;
   font-weight: $tooltip-font-weight;
   color: $tooltip-font-colour;
-  border-radius: $border-radius;
+  border-radius: var(--border-radius);
   text-align: center;
   max-width: $tooltip-max-width;
   box-shadow: $medium-box-shadow;

--- a/client/src/ui/Tooltip.scss
+++ b/client/src/ui/Tooltip.scss
@@ -14,7 +14,7 @@ $tooltip-max-width: 150px;
   border-radius: var(--border-radius);
   text-align: center;
   max-width: $tooltip-max-width;
-  box-shadow: $medium-box-shadow;
+  box-shadow: var(--medium-box-shadow);
   opacity: 0.85;
 }
 

--- a/client/src/users/Avatar.scss
+++ b/client/src/users/Avatar.scss
@@ -1,5 +1,3 @@
-@import "../../styles/variables";
-
 .avatar {
   display: inline-block;
   position: relative;

--- a/client/styles/_base.scss
+++ b/client/styles/_base.scss
@@ -93,7 +93,7 @@ textarea {
 
 hr {
   border: 0;
-  border-top: 1px solid $colour-turquoise-350;
+  border-top: 1px solid var(--color-turquoise-350);
   margin-top: 1em;
   margin-bottom: 1em;
   width: 100%;

--- a/client/styles/_base.scss
+++ b/client/styles/_base.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-
 html {
   height: 100%;
   overflow: hidden;

--- a/client/styles/_base.scss
+++ b/client/styles/_base.scss
@@ -63,14 +63,14 @@ a,
   @include tap-highlight-color("transparent !important");
 
   cursor: pointer;
-  color: color.adjust($ui-colour, $lightness: -30%);
+  color: var(--deprecated-ui-color-lightness-30);
 
   &:hover {
-    color: color.adjust($ui-colour, $lightness: -50%);
+    color: var(--deprecated-ui-color-lightness-50);
   }
 
   &:active {
-    color: color.adjust($ui-colour, $lightness: -70%);
+    color: var(--deprecated-ui-color-lightness-70);
   }
 }
 
@@ -83,11 +83,8 @@ textarea {
   padding: 3px;
 
   &[disabled] {
-    background: color.adjust(
-      fade-out($ui-colour, 0.7),
-      $saturation: -100%
-    ) !important;
-    border-color: color.adjust($ui-colour, $saturation: -100%) !important;
+    background: var(--deprecated-ui-color-fade-desaturate) !important;
+    border-color: var(--deprecated-ui-color-desaturate) !important;
   }
 }
 

--- a/client/styles/_base.scss
+++ b/client/styles/_base.scss
@@ -50,7 +50,7 @@ button {
 
 .main-screen {
   position: relative;
-  z-index: $z-01-main-screen;
+  z-index: var(--z-01-main-screen);
   flex-grow: 1;
 
   body:not(.safari) & {
@@ -105,7 +105,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $header-font-family;
+  font-family: var(--header-font-family);
 }
 
 // Some utility classes.

--- a/client/styles/_chrome.scss
+++ b/client/styles/_chrome.scss
@@ -103,7 +103,7 @@ body.phone #loading {
   transition: opacity 120ms;
   opacity: 1;
   will-change: opacity;
-  background-color: $colour-emerald-200;
+  background-color: var(--color-emerald-200);
 
   &.hidden {
     opacity: 0;
@@ -113,10 +113,10 @@ body.phone #loading {
   .loading-stuck {
     position: absolute;
     bottom: 20px;
-    background-color: $alert-background;
-    border-bottom: $alert-border;
+    background-color: var(--alert-background);
+    border-bottom: var(--alert-border);
     padding: 1em;
-    border-radius: $border-radius-medium;
+    border-radius: var(--border-radius-medium);
     opacity: 0;
     transition:
       opacity 120ms,

--- a/client/styles/_chrome.scss
+++ b/client/styles/_chrome.scss
@@ -36,7 +36,7 @@ body.phone #loading {
 
 #error,
 #loading {
-  color: $colour-turquoise-700;
+  color: var(--color-turquoise-700);
 
   h1 {
     @include large-message-text;

--- a/client/styles/_chrome.scss
+++ b/client/styles/_chrome.scss
@@ -48,8 +48,8 @@ body.phone #loading {
 #error {
   @include blocking-shield;
 
-  z-index: $z-09-error;
-  background-color: $colour-turquoise-200;
+  z-index: var(--z-09-error);
+  background-color: var(--color-turquoise-200);
 
   // Errors may be displayed on old browsers without flexbox.
   // This forces vertical centering
@@ -87,11 +87,11 @@ body.phone #loading {
     a,
     a:visited,
     a:active {
-      color: $colour-turquoise-700;
+      color: var(--color-turquoise-700);
     }
 
     a:hover {
-      color: $colour-turquoise-600;
+      color: var(--color-turquoise-600);
     }
   }
 }
@@ -99,7 +99,7 @@ body.phone #loading {
 #loading {
   @include blocking-shield;
 
-  z-index: $z-09-loading;
+  z-index: var(--z-09-loading);
   transition: opacity 120ms;
   opacity: 1;
   will-change: opacity;
@@ -156,7 +156,7 @@ body.phone #loading {
 
 .debug-hover-polygon {
   position: absolute;
-  z-index: $z-07-debug-hover-polygon;
+  z-index: var(--z-07-debug-hover-polygon);
   inset: 0;
   pointer-events: none;
 

--- a/client/styles/_typography.scss
+++ b/client/styles/_typography.scss
@@ -6,14 +6,14 @@
 
 /* Set root font-size */
 html {
-  font-size: $font-size-base;
+  font-size: var(--font-size-base);
 }
 
 body,
 input,
 select,
 option {
-  font-family: $font-family;
+  font-family: var(--font-family);
   font-size: 1rem;
 }
 

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -129,9 +129,15 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
     white 25%,
     var(--color-turquoise-100)
   );
+  --color-turquoise-350: color-mix(
+    in oklch,
+    var(--color-turquoise-300),
+    var(--color-turquoise-400)
+  );
 
   // Misc colors
   --background-dirt-color: rgb(53 45 39);
+  --sky-color: rgb(169 204 219);
   --form-element-background: var(--color-turquoise-50);
   --form-element-border: var(--color-turquoise-200);
   --button-border: 1px solid var(--color-turquoise-400);

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -16,47 +16,46 @@
 $breakpoint-md: 768px;
 
 // Brand colours
-$colour-emerald-700: rgb(9 63 20);
-$colour-emerald-600: rgb(31 114 52);
-$colour-emerald-500: rgb(26 145 78);
-$colour-emerald-400: rgb(91 193 125);
-$colour-emerald-300: rgb(147 219 169);
-$colour-emerald-200: rgb(200 237 209);
-$colour-emerald-100: rgb(231 247 234);
-$colour-turquoise-700: rgb(21 68 71);
-$colour-turquoise-600: rgb(48 108 114);
-$colour-turquoise-500: rgb(82 162 175);
-$colour-turquoise-400: rgb(137 193 206);
-$colour-turquoise-300: rgb(193 235 247);
-$colour-turquoise-200: rgb(220 243 249);
-$colour-turquoise-100: rgb(235 249 252);
-$colour-copper-700: rgb(86 34 17);
-$colour-copper-600: rgb(137 69 40);
-$colour-copper-500: rgb(181 109 72);
-$colour-copper-400: rgb(216 141 100);
-$colour-copper-300: rgb(248 184 144);
-$colour-copper-200: rgb(249 213 192);
-$colour-copper-100: rgb(249 238 232);
-$colour-midnight-700: rgb(24 37 73);
-$colour-midnight-600: rgb(53 67 119);
-$colour-midnight-500: rgb(83 100 145);
-$colour-midnight-400: rgb(123 139 173);
-$colour-midnight-300: rgb(166 178 200);
-$colour-midnight-200: rgb(212 219 232);
-$colour-midnight-100: rgb(230 235 244);
+// $colour-emerald-700: rgb(9 63 20);
+// $colour-emerald-600: rgb(31 114 52);
+// $colour-emerald-500: rgb(26 145 78);
+// $colour-emerald-400: rgb(91 193 125);
+// $colour-emerald-300: rgb(147 219 169);
+// $colour-emerald-200: rgb(200 237 209);
+// $colour-emerald-100: rgb(231 247 234);
+// $colour-turquoise-700: rgb(21 68 71);
+// $colour-turquoise-600: rgb(48 108 114);
+// $colour-turquoise-500: rgb(82 162 175);
+// $colour-turquoise-400: rgb(137 193 206);
+// $colour-turquoise-300: rgb(193 235 247);
+// $colour-turquoise-200: rgb(220 243 249);
+// $colour-turquoise-100: rgb(235 249 252);
+// $colour-copper-700: rgb(86 34 17);
+// $colour-copper-600: rgb(137 69 40);
+// $colour-copper-500: rgb(181 109 72);
+// $colour-copper-400: rgb(216 141 100);
+// $colour-copper-300: rgb(248 184 144);
+// $colour-copper-200: rgb(249 213 192);
+// $colour-copper-100: rgb(249 238 232);
+// $colour-midnight-700: rgb(24 37 73);
+// $colour-midnight-600: rgb(53 67 119);
+// $colour-midnight-500: rgb(83 100 145);
+// $colour-midnight-400: rgb(123 139 173);
+// $colour-midnight-300: rgb(166 178 200);
+// $colour-midnight-200: rgb(212 219 232);
+// $colour-midnight-100: rgb(230 235 244);
 // $colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
-$colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 20%);
-$colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
-$colour-turquoise-250: color.scale($colour-turquoise-200, $lightness: -10%);
-$colour-turquoise-350: color.scale($colour-turquoise-300, $lightness: -10%);
-$colour-turquoise-425: color.scale($colour-turquoise-400, $lightness: -5%);
-$colour-turquoise-450: color.scale($colour-turquoise-400, $lightness: -10%);
-$colour-emerald-150: color.scale($colour-emerald-200, $lightness: 20%);
-$colour-emerald-350: color.scale($colour-emerald-300, $lightness: -10%);
-$colour-copper-150: color.scale($colour-copper-200, $lightness: 20%);
-$colour-copper-350: color.scale($colour-copper-300, $lightness: -10%);
-$colour-midnight-150: color.scale($colour-midnight-200, $lightness: 20%);
-$colour-midnight-350: color.scale($colour-midnight-300, $lightness: -10%);
+// $colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 20%);
+// $colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
+// $colour-turquoise-250: color.scale($colour-turquoise-200, $lightness: -10%);
+// $colour-turquoise-350: color.scale($colour-turquoise-300, $lightness: -10%);
+// $colour-turquoise-450: color.scale($colour-turquoise-400, $lightness: -10%);
+// $colour-emerald-150: color.scale($colour-emerald-200, $lightness: 20%);
+// $colour-emerald-350: color.scale($colour-emerald-300, $lightness: -10%);
+// $colour-copper-150: color.scale($colour-copper-200, $lightness: 20%);
+// $colour-copper-350: color.scale($colour-copper-300, $lightness: -10%);
+// $colour-midnight-150: color.scale($colour-midnight-200, $lightness: 20%);
+// $colour-midnight-350: color.scale($colour-midnight-300, $lightness: -10%);
 
 // Colours
 // commenting out variables replaced by css custom properties so that
@@ -124,16 +123,38 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
   --color-midnight-200: rgb(212 219 232);
   --color-midnight-100: rgb(230 235 244);
 
-  --color-turquoise-50: color-mix(
-    in oklch,
-    white 25%,
-    var(--color-turquoise-100)
-  );
-  --color-turquoise-350: color-mix(
-    in oklch,
-    var(--color-turquoise-300),
-    var(--color-turquoise-400)
-  );
+  // "extrapolated" color stops
+  // We want to eventually calculate color stops through color-mixing, e.g.:
+  // --color-turquoise-50: color-mix(in oklch, white 25%, var(--color-turquoise-100));
+  // --color-turquoise-150: color-mix(in oklch, var(--color-turquoise-100), var(--color-turquoise-200));
+  // --color-turquoise-250: color-mix(in oklch, var(--color-turquoise-200), var(--color-turquoise-300));
+  // For now, while transitioning to CSS custom properties, the formerly
+  // computed values in SCSS will be hard-coded values. The original SCSS
+  // functions are retained below.
+  --color-turquoise-50: #effafd;
+  --color-turquoise-150: #e3f5fa;
+  --color-turquoise-225: #c8ecf6;
+  --color-turquoise-250: #b4e5f2;
+  --color-turquoise-350: #9adef2;
+  --color-turquoise-450: #71b4c4;
+  --color-emerald-150: #d3f1da;
+  --color-emerald-350: #78d293;
+  --color-copper-150: #faddcd;
+  --color-copper-350: #f6a06b;
+  --color-midnight-150: #dde2ed;
+  --color-midnight-350: #8f9eba;
+  // $colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
+  // $colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 20%);
+  // $colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
+  // $colour-turquoise-250: color.scale($colour-turquoise-200, $lightness: -10%);
+  // $colour-turquoise-350: color.scale($colour-turquoise-300, $lightness: -10%);
+  // $colour-turquoise-450: color.scale($colour-turquoise-400, $lightness: -10%);
+  // $colour-emerald-150: color.scale($colour-emerald-200, $lightness: 20%);
+  // $colour-emerald-350: color.scale($colour-emerald-300, $lightness: -10%);
+  // $colour-copper-150: color.scale($colour-copper-200, $lightness: 20%);
+  // $colour-copper-350: color.scale($colour-copper-300, $lightness: -10%);
+  // $colour-midnight-150: color.scale($colour-midnight-200, $lightness: 20%);
+  // $colour-midnight-350: color.scale($colour-midnight-300, $lightness: -10%);
 
   // Misc colors
   --background-dirt-color: rgb(53 45 39);

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -57,18 +57,6 @@ $street-name-gallery-size: 0.5;
   // For now, while transitioning to CSS custom properties, the formerly
   // computed values in SCSS will be hard-coded values. The original SCSS
   // functions are retained below.
-  --color-turquoise-50: #effafd;
-  --color-turquoise-150: #e3f5fa;
-  --color-turquoise-225: #c8ecf6;
-  --color-turquoise-250: #b4e5f2;
-  --color-turquoise-350: #9adef2;
-  --color-turquoise-450: #71b4c4;
-  --color-emerald-150: #d3f1da;
-  --color-emerald-350: #78d293;
-  --color-copper-150: #faddcd;
-  --color-copper-350: #f6a06b;
-  --color-midnight-150: #dde2ed;
-  --color-midnight-350: #8f9eba;
   // $colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
   // $colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 20%);
   // $colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
@@ -81,6 +69,18 @@ $street-name-gallery-size: 0.5;
   // $colour-copper-350: color.scale($colour-copper-300, $lightness: -10%);
   // $colour-midnight-150: color.scale($colour-midnight-200, $lightness: 20%);
   // $colour-midnight-350: color.scale($colour-midnight-300, $lightness: -10%);
+  --color-turquoise-50: #effafd;
+  --color-turquoise-150: #e3f5fa;
+  --color-turquoise-225: #c8ecf6;
+  --color-turquoise-250: #b4e5f2;
+  --color-turquoise-350: #9adef2;
+  --color-turquoise-450: #71b4c4;
+  --color-emerald-150: #d3f1da;
+  --color-emerald-350: #78d293;
+  --color-copper-150: #faddcd;
+  --color-copper-350: #f6a06b;
+  --color-midnight-150: #dde2ed;
+  --color-midnight-350: #8f9eba;
 
   // Misc colors
   --background-dirt-color: rgb(53 45 39);
@@ -90,7 +90,7 @@ $street-name-gallery-size: 0.5;
   --button-border: 1px solid var(--color-turquoise-400);
   --alert-background: #fff0c0;
   --alert-border-color: #ffd755;
-  --alert-border: 5px solid --var(--alert-border-color);
+  --alert-border: 5px solid var(--alert-border-color);
   --alert-text-color: rgb(255 131 0);
   --off-white: rgb(247 247 247);
   --bottom-background: rgb(216 211 203);
@@ -104,10 +104,9 @@ $street-name-gallery-size: 0.5;
   // the original sky color. It is preserved here because many elements of UI
   // still use it, and its value is now hardcoded, but it was originally
   // calculated as `color.adjust($sky-colour, $lightness: 10%)`. Do not use
-  // when creating or refactoring UI.
+  // when creating or refactoring UI. Other variations of "UI color" are
+  // hardcoded here also. Remove when no longer needed.
   --deprecated-ui-color: #cde1ea;
-  // Other variations of "UI color" are hardcoded here also. Remove when
-  // no longer needed.
   --deprecated-ui-color-lightness-10: #a9ccdb; // color.adjust($ui-colour, $lightness: -10%);
   --deprecated-ui-color-lightness-20: #85b7cc; // color.adjust($ui-colour, $lightness: -20%);
   --deprecated-ui-color-lightness-30: #61a1bd; // color.adjust($ui-colour, $lightness: -30%);

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -91,37 +91,45 @@ $street-name-text: black;
 $street-name-background: white;
 $control-disabled-colour: gray;
 
-// Third-party brand colours (e.g. social, etc) in alphabetical order
-// All colors must be official (please update them as necessary)
-// unless noted (e.g. if we need a special color for contrast, etc)
-// If we don't have an official dark color for hover, it is
-// computed with Sass
+:root {
+  // Third-party brand colors (e.g. social, etc) in alphabetical order
+  // All colors must be official (please update them as necessary)
+  // unless noted (e.g. if we need a special color for contrast, etc)
+  // If there isn't an official dark color for hover, it is computed
 
-// Discord (https://discord.com/branding)
-$social-discord: #5865f2;
-$social-discord-hover: color.scale($social-discord, $lightness: -10%);
+  // Note: color-mix() is a draft specification.
+  // https://drafts.csswg.org/css-color-5
 
-// Facebook (https://about.meta.com/brand/resources/facebookapp/logo)
-$social-facebook: rgb(24 119 242);
-$social-facebook-hover: color.scale($social-facebook, $lightness: -10%);
+  // Discord (https://discord.com/branding)
+  --social-discord: #5865f2;
+  --social-discord-hover: color-mix(in oklch, black 10%, var(--social-discord));
 
-// GitHub (https://github.com/logos)
-$social-github: #171515;
-$social-github-hover: color.scale($social-github, $lightness: -10%);
+  // Facebook (https://about.meta.com/brand/resources/facebookapp/logo)
+  --social-facebook: rgb(24 119 242);
+  --social-facebook-hover: color-mix(
+    in oklch,
+    black 10%,
+    var(--social-facebook)
+  );
 
-// Instagram
-// Difficult to reproduce their gradient, so we use colors from
-// https://brandpalettes.com/instagram-color-codes/
-$social-instagram: #e1306c;
-$social-instagram-hover: #c13584;
+  // GitHub (https://github.com/logos)
+  --social-github: #171515;
+  --social-github-hover: color-mix(in oklch, black 10%, var(--social-github));
 
-// Mastodon (https://joinmastodon.org/branding)
-$social-mastodon: #6364ff;
-$social-mastodon-hover: #563acc;
+  // Instagram
+  // Difficult to reproduce their gradient, so we use colors from
+  // https://brandpalettes.com/instagram-color-codes/
+  --social-instagram: #e1306c;
+  --social-instagram-hover: #c13584;
 
-// Twitter (https://about.twitter.com/en/who-we-are/brand-toolkit)
-$social-twitter: #4a99e9;
-$social-twitter-hover: color.scale($social-twitter, $lightness: -10%);
+  // Mastodon (https://joinmastodon.org/branding)
+  --social-mastodon: #6364ff;
+  --social-mastodon-hover: #563acc;
+
+  // Twitter (https://about.twitter.com/en/who-we-are/brand-toolkit)
+  --social-twitter: #4a99e9;
+  --social-twitter-hover: color-mix(in oklch, black 10%, var(--social-twitter));
+}
 
 // Layered UI box shadows
 $light-box-shadow: 0 0 14px 0 rgb(0 0 0 / 7.5%);

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -1,14 +1,11 @@
 @use "sass:color";
 
 // Dimensions
-$tile-size: 12px;
-$canvas-height: 480px;
-$canvas-ground: 35px;
-$canvas-baseline: $canvas-height - $canvas-ground + 150px;
-$gallery-height: 180px;
-$thumbnail-width: 180px;
-$thumbnail-height: 110px;
-$building-space: 360px;
+// $tile-size: 12px;
+// $canvas-height: 480px;
+// $canvas-ground: 35px;
+// $canvas-baseline: $canvas-height - $canvas-ground + 150px;
+// $gallery-height: 180px;
 // $left-right-inset: 50px;
 // $menu-side-inset: $left-right-inset - 20px;
 // $border-radius: 4px; // Deprecated. Use the following instead.
@@ -83,6 +80,11 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
 
 :root {
   // Dimensions
+  --tile-size: 12px;
+  --canvas-height: 480px;
+  --canvas-ground: 35px;
+  --canvas-baseline: calc(var(--canvas-height) - var(--canvas-ground) + 150px);
+  --gallery-height: 180px;
   --left-right-inset: 50px;
   --menu-side-inset: calc(var(--left-right-inset) - 20px);
   --border-radius-small: 2px;

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -9,7 +9,6 @@ $gallery-height: 180px;
 $thumbnail-width: 180px;
 $thumbnail-height: 110px;
 $building-space: 360px;
-$segment-grid-height: 10px;
 // $left-right-inset: 50px;
 // $menu-side-inset: $left-right-inset - 20px;
 // $border-radius: 4px; // Deprecated. Use the following instead.
@@ -80,12 +79,7 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
 // $warning-colour: rgb(220 20 20);
 // $segment-text: rgb(40 35 30);
 // $segment-hover-background: rgb(255 255 255 / 20%);
-$light-text-colour: rgb(240 240 240);
-$info-bubble-background: white;
-$segment-width-rule: rgb(160 160 160);
-$street-name-text: black;
-$street-name-background: white;
-$control-disabled-colour: gray;
+// $info-bubble-background: white;
 
 :root {
   // Dimensions
@@ -148,6 +142,7 @@ $control-disabled-colour: gray;
   --warning-color: rgb(220 20 20);
   --segment-text: rgb(40 35 30);
   --segment-hover-background: rgb(255 255 255 / 20%);
+  --info-bubble-background: white; // TODO: rename
 
   // Third-party brand colors (e.g. social, etc) in alphabetical order
   // All colors must be official (please update them as necessary)
@@ -186,83 +181,26 @@ $control-disabled-colour: gray;
   // Twitter (https://about.twitter.com/en/who-we-are/brand-toolkit)
   --social-twitter: #4a99e9;
   --social-twitter-hover: color-mix(in oklch, black 10%, var(--social-twitter));
-}
 
-// Layered UI box shadows
-$light-box-shadow: 0 0 14px 0 rgb(0 0 0 / 7.5%);
-$medium-box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
-$heavy-box-shadow: 0 0 10px 0 rgb(0 0 0 / 20%);
+  // Layered UI box shadows
+  --light-box-shadow: 0 0 14px 0 rgb(0 0 0 / 7.5%);
+  --medium-box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
+  --heavy-box-shadow: 0 0 10px 0 rgb(0 0 0 / 20%); // UNUSED
+}
 
 // Design
 $street-name-gallery-size: 0.5;
-$info-bubble-button-size: 30px;
-
-// Typography
-$font-family: "Rubik Variable", system-ui, sans-serif;
-$font-size-base: 13px;
-$header-font-family: "Manrope Variable", system-ui, sans-serif;
-
-// Timing
-$segment-switching-time: 250ms;
-$skybox-transition: 500ms ease;
-
-// Z-INDEX SCALE
-$z-index-01: 100;
-$z-index-02: 200;
-$z-index-03: 300;
-$z-index-04: 400;
-$z-index-05: 500;
-$z-index-06: 600;
-$z-index-07: 700;
-$z-index-08: 800;
-$z-index-09: 900;
-$z-index-10: 1000;
-
-// Z-INDEX COMPONENTS
-// Variables are assigned to scale, above.
-// These are kept here so you can quickly ascertain
-// the hierarchy of elements.
-// They are also named with the scale position so that
-// when they are referenced in other CSS files, their
-// z-scale position is also obvious at a glance.
-// Between scale positions, one can fine-tune placement
-// by adding a +number to the defined scale.
-// Please note, the z-index scale does not defeat limitations
-// imposed by stacking contexts.
-$z-01-main-screen: $z-index-01;
-$z-01-street-section: $z-index-01;
-$z-01-foreground: $z-index-01;
-$z-02-segment-focused: $z-index-02;
-$z-02-palette: $z-index-02;
-$z-02-menu-bar: $z-index-02;
-$z-03-street-name: $z-index-03;
-$z-03-gallery-message: $z-index-03;
-$z-05-welcome: $z-index-05;
-$z-06-info-bubble: $z-index-06;
-$z-06-drag-handle: $z-index-06;
-$z-07-street-scroll: $z-index-07;
-$z-07-toasts: $z-index-07;
-$z-07-trashcan: $z-index-07;
-$z-07-resize-guide: $z-index-07;
-$z-07-debug-hover-polygon: $z-index-07;
-$z-07-sky-picker: $z-index-07 + 50;
-$z-07-menu: $z-index-07 + 75;
-$z-08-dialog-box-backdrop: $z-index-08;
-$z-08-gallery-shield: $z-index-08;
-$z-08-notification-bar: $z-index-08;
-$z-09-gallery: $z-index-09;
-$z-09-dialog-box: $z-index-09;
-$z-09-debug: $z-index-09;
-
-// Blocking overlays
-$z-09-loading: $z-index-09;
-$z-09-error: $z-index-09;
-$z-09-blocking-shield: $z-index-09;
-$z-10-flash-border: $z-index-10;
-$z-10-switch-away: $z-index-10;
-$z-10-print: $z-index-10;
 
 :root {
+  // Typography
+  --font-family: "Rubik Variable", system-ui, sans-serif;
+  --font-size-base: 13px;
+  --header-font-family: "Manrope Variable", system-ui, sans-serif;
+
+  // Timing
+  --segment-switching-time: 250ms;
+  --skybox-transition: 500ms ease;
+
   // Z-INDEX SCALE
   --z-index-01: 100;
   --z-index-02: 200;

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -1,5 +1,3 @@
-@use "sass:color";
-
 // TODO: refactor out; still used by scss mixin
 $street-name-gallery-size: 0.5;
 

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -1,81 +1,7 @@
 @use "sass:color";
 
-// Dimensions
-// $tile-size: 12px;
-// $canvas-height: 480px;
-// $canvas-ground: 35px;
-// $canvas-baseline: $canvas-height - $canvas-ground + 150px;
-// $gallery-height: 180px;
-// $left-right-inset: 50px;
-// $menu-side-inset: $left-right-inset - 20px;
-// $border-radius: 4px; // Deprecated. Use the following instead.
-// $border-radius-small: 2px;
-// $border-radius-medium: 4px;
-// $border-radius-large: 6px;
-// $border-radius-pill: 999em; // because 50% creates ovals, not pills
-$breakpoint-md: 768px;
-
-// Brand colours
-// $colour-emerald-700: rgb(9 63 20);
-// $colour-emerald-600: rgb(31 114 52);
-// $colour-emerald-500: rgb(26 145 78);
-// $colour-emerald-400: rgb(91 193 125);
-// $colour-emerald-300: rgb(147 219 169);
-// $colour-emerald-200: rgb(200 237 209);
-// $colour-emerald-100: rgb(231 247 234);
-// $colour-turquoise-700: rgb(21 68 71);
-// $colour-turquoise-600: rgb(48 108 114);
-// $colour-turquoise-500: rgb(82 162 175);
-// $colour-turquoise-400: rgb(137 193 206);
-// $colour-turquoise-300: rgb(193 235 247);
-// $colour-turquoise-200: rgb(220 243 249);
-// $colour-turquoise-100: rgb(235 249 252);
-// $colour-copper-700: rgb(86 34 17);
-// $colour-copper-600: rgb(137 69 40);
-// $colour-copper-500: rgb(181 109 72);
-// $colour-copper-400: rgb(216 141 100);
-// $colour-copper-300: rgb(248 184 144);
-// $colour-copper-200: rgb(249 213 192);
-// $colour-copper-100: rgb(249 238 232);
-// $colour-midnight-700: rgb(24 37 73);
-// $colour-midnight-600: rgb(53 67 119);
-// $colour-midnight-500: rgb(83 100 145);
-// $colour-midnight-400: rgb(123 139 173);
-// $colour-midnight-300: rgb(166 178 200);
-// $colour-midnight-200: rgb(212 219 232);
-// $colour-midnight-100: rgb(230 235 244);
-// $colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
-// $colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 20%);
-// $colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
-// $colour-turquoise-250: color.scale($colour-turquoise-200, $lightness: -10%);
-// $colour-turquoise-350: color.scale($colour-turquoise-300, $lightness: -10%);
-// $colour-turquoise-450: color.scale($colour-turquoise-400, $lightness: -10%);
-// $colour-emerald-150: color.scale($colour-emerald-200, $lightness: 20%);
-// $colour-emerald-350: color.scale($colour-emerald-300, $lightness: -10%);
-// $colour-copper-150: color.scale($colour-copper-200, $lightness: 20%);
-// $colour-copper-350: color.scale($colour-copper-300, $lightness: -10%);
-// $colour-midnight-150: color.scale($colour-midnight-200, $lightness: 20%);
-// $colour-midnight-350: color.scale($colour-midnight-300, $lightness: -10%);
-
-// Colours
-// commenting out variables replaced by css custom properties so that
-// properties can retain sort order after it's all ported
-// $background-dirt-colour: rgb(53 45 39);
-$sky-colour: rgb(169 204 219);
-$ui-colour: color.adjust($sky-colour, $lightness: 10%);
-// $form-element-background: $colour-turquoise-50;
-// $form-element-border: $colour-turquoise-200;
-// $button-border: 1px solid $colour-turquoise-400;
-// $alert-background: #fff0c0;
-// $alert-border-colour: #ffd755;
-// $alert-border: 5px solid $alert-border-colour;
-// $alert-text-colour: rgb(255 131 0);
-// $off-white: rgb(247 247 247);
-// $bottom-background: rgb(216 211 203);
-// $warning-colour: rgb(220 20 20);
-// $segment-text: rgb(40 35 30);
-// $segment-hover-background: rgb(255 255 255 / 20%);
-// $info-bubble-background: white;
+// TODO: refactor out; still used by scss mixin
+$street-name-gallery-size: 0.5;
 
 :root {
   // Dimensions
@@ -123,7 +49,7 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
   --color-midnight-200: rgb(212 219 232);
   --color-midnight-100: rgb(230 235 244);
 
-  // "extrapolated" color stops
+  // "Extrapolated" color stops
   // We want to eventually calculate color stops through color-mixing, e.g.:
   // --color-turquoise-50: color-mix(in oklch, white 25%, var(--color-turquoise-100));
   // --color-turquoise-150: color-mix(in oklch, var(--color-turquoise-100), var(--color-turquoise-200));
@@ -173,6 +99,25 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
   --segment-hover-background: rgb(255 255 255 / 20%);
   --info-bubble-background: white; // TODO: rename
 
+  // Deprecated UI color
+  // "UI color" is a deprecated method of extrapolating a color scheme from
+  // the original sky color. It is preserved here because many elements of UI
+  // still use it, and its value is now hardcoded, but it was originally
+  // calculated as `color.adjust($sky-colour, $lightness: 10%)`. Do not use
+  // when creating or refactoring UI.
+  --deprecated-ui-color: #cde1ea;
+  // Other variations of "UI color" are hardcoded here also. Remove when
+  // no longer needed.
+  --deprecated-ui-color-lightness-10: #a9ccdb; // color.adjust($ui-colour, $lightness: -10%);
+  --deprecated-ui-color-lightness-20: #85b7cc; // color.adjust($ui-colour, $lightness: -20%);
+  --deprecated-ui-color-lightness-30: #61a1bd; // color.adjust($ui-colour, $lightness: -30%);
+  --deprecated-ui-color-lightness-40: #4589a6; // color.adjust($ui-colour, $lightness: -40%);
+  --deprecated-ui-color-lightness-50: #366b82; // color.adjust($ui-colour, $lightness: -50%);
+  --deprecated-ui-color-lightness-70: #18303a; // color.adjust($ui-colour, $lightness: -70%);
+  --deprecated-ui-color-mix-white: #e6f0f5; // color.mix($ui-colour, white, 50%);
+  --deprecated-ui-color-desaturate: #dcdcdc; // color.adjust($ui-colour, $saturation: -100%);
+  --deprecated-ui-color-fade-desaturate: #dcdcdc4d; // color.adjust(fade-out($ui-colour, 0.7), $saturation: -100%);
+
   // Third-party brand colors (e.g. social, etc) in alphabetical order
   // All colors must be official (please update them as necessary)
   // unless noted (e.g. if we need a special color for contrast, etc)
@@ -219,12 +164,7 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
   // Design
   --street-name-size: 1.5;
   --street-name-size-small: 0.5;
-}
 
-// Design
-$street-name-gallery-size: 0.5;
-
-:root {
   // Typography
   --font-family: "Rubik Variable", system-ui, sans-serif;
   --font-size-base: 13px;

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -10,13 +10,13 @@ $thumbnail-width: 180px;
 $thumbnail-height: 110px;
 $building-space: 360px;
 $segment-grid-height: 10px;
-$left-right-inset: 50px;
-$border-radius: 4px; // Deprecated. Use the following instead.
-$border-radius-small: 2px;
-$border-radius-medium: 4px;
-$border-radius-large: 6px;
-$border-radius-pill: 999em; // because 50% creates ovals, not pills
-$menu-side-inset: $left-right-inset - 20px;
+// $left-right-inset: 50px;
+// $menu-side-inset: $left-right-inset - 20px;
+// $border-radius: 4px; // Deprecated. Use the following instead.
+// $border-radius-small: 2px;
+// $border-radius-medium: 4px;
+// $border-radius-large: 6px;
+// $border-radius-pill: 999em; // because 50% creates ovals, not pills
 $breakpoint-md: 768px;
 
 // Brand colours
@@ -48,7 +48,7 @@ $colour-midnight-400: rgb(123 139 173);
 $colour-midnight-300: rgb(166 178 200);
 $colour-midnight-200: rgb(212 219 232);
 $colour-midnight-100: rgb(230 235 244);
-$colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
+// $colour-turquoise-50: color.scale($colour-turquoise-100, $lightness: 20%);
 $colour-turquoise-150: color.scale($colour-turquoise-200, $lightness: 20%);
 $colour-turquoise-225: color.scale($colour-turquoise-200, $lightness: -5%);
 $colour-turquoise-250: color.scale($colour-turquoise-200, $lightness: -10%);
@@ -63,27 +63,23 @@ $colour-midnight-150: color.scale($colour-midnight-200, $lightness: 20%);
 $colour-midnight-350: color.scale($colour-midnight-300, $lightness: -10%);
 
 // Colours
-$background-dirt-colour: rgb(53 45 39);
+// commenting out variables replaced by css custom properties so that
+// properties can retain sort order after it's all ported
+// $background-dirt-colour: rgb(53 45 39);
 $sky-colour: rgb(169 204 219);
 $ui-colour: color.adjust($sky-colour, $lightness: 10%);
-$form-element-background: $colour-turquoise-50;
-$form-element-border: $colour-turquoise-200;
-$button-border: 1px solid $colour-turquoise-400;
-$alert-background: #fff0c0;
-$alert-background-light: color.scale($alert-background, $lightness: 15%);
-$alert-border-colour: #ffd755;
-$alert-border: 5px solid $alert-border-colour;
-$alert-text-colour: rgb(255 131 0);
-$off-white: rgb(247 247 247);
-$palette-background: $off-white;
-$menu-bar-background: $off-white;
-$bottom-background: rgb(216 211 203);
-$warning-colour: rgb(220 20 20);
-$segment-text: rgb(40 35 30);
-$segment-hover-text: color.adjust($segment-text, $lightness: 30%);
-$segment-warning-text: $warning-colour;
-$empty-segment-text: fade-out($segment-text, 0.5);
-$segment-hover-background: rgb(255 255 255 / 20%);
+// $form-element-background: $colour-turquoise-50;
+// $form-element-border: $colour-turquoise-200;
+// $button-border: 1px solid $colour-turquoise-400;
+// $alert-background: #fff0c0;
+// $alert-border-colour: #ffd755;
+// $alert-border: 5px solid $alert-border-colour;
+// $alert-text-colour: rgb(255 131 0);
+// $off-white: rgb(247 247 247);
+// $bottom-background: rgb(216 211 203);
+// $warning-colour: rgb(220 20 20);
+// $segment-text: rgb(40 35 30);
+// $segment-hover-background: rgb(255 255 255 / 20%);
 $light-text-colour: rgb(240 240 240);
 $info-bubble-background: white;
 $segment-width-rule: rgb(160 160 160);
@@ -92,6 +88,67 @@ $street-name-background: white;
 $control-disabled-colour: gray;
 
 :root {
+  // Dimensions
+  --left-right-inset: 50px;
+  --menu-side-inset: calc(var(--left-right-inset) - 20px);
+  --border-radius-small: 2px;
+  --border-radius-medium: 4px;
+  --border-radius-large: 6px;
+  --border-radius-pill: 999em; // because 50% creates ovals, not pills
+  --border-radius: var(--border-radius-medium); // Alias
+  --breakpoint-md: 768px;
+
+  // Brand colors
+  --color-emerald-700: rgb(9 63 20);
+  --color-emerald-600: rgb(31 114 52);
+  --color-emerald-500: rgb(26 145 78);
+  --color-emerald-400: rgb(91 193 125);
+  --color-emerald-300: rgb(147 219 169);
+  --color-emerald-200: rgb(200 237 209);
+  --color-emerald-100: rgb(231 247 234);
+  --color-turquoise-700: rgb(21 68 71);
+  --color-turquoise-600: rgb(48 108 114);
+  --color-turquoise-500: rgb(82 162 175);
+  --color-turquoise-400: rgb(137 193 206);
+  --color-turquoise-300: rgb(193 235 247);
+  --color-turquoise-200: rgb(220 243 249);
+  --color-turquoise-100: rgb(235 249 252);
+  --color-copper-700: rgb(86 34 17);
+  --color-copper-600: rgb(137 69 40);
+  --color-copper-500: rgb(181 109 72);
+  --color-copper-400: rgb(216 141 100);
+  --color-copper-300: rgb(248 184 144);
+  --color-copper-200: rgb(249 213 192);
+  --color-copper-100: rgb(249 238 232);
+  --color-midnight-700: rgb(24 37 73);
+  --color-midnight-600: rgb(53 67 119);
+  --color-midnight-500: rgb(83 100 145);
+  --color-midnight-400: rgb(123 139 173);
+  --color-midnight-300: rgb(166 178 200);
+  --color-midnight-200: rgb(212 219 232);
+  --color-midnight-100: rgb(230 235 244);
+
+  --color-turquoise-50: color-mix(
+    in oklch,
+    white 25%,
+    var(--color-turquoise-100)
+  );
+
+  // Misc colors
+  --background-dirt-color: rgb(53 45 39);
+  --form-element-background: var(--color-turquoise-50);
+  --form-element-border: var(--color-turquoise-200);
+  --button-border: 1px solid var(--color-turquoise-400);
+  --alert-background: #fff0c0;
+  --alert-border-color: #ffd755;
+  --alert-border: 5px solid --var(--alert-border-color);
+  --alert-text-color: rgb(255 131 0);
+  --off-white: rgb(247 247 247);
+  --bottom-background: rgb(216 211 203);
+  --warning-color: rgb(220 20 20);
+  --segment-text: rgb(40 35 30);
+  --segment-hover-background: rgb(255 255 255 / 20%);
+
   // Third-party brand colors (e.g. social, etc) in alphabetical order
   // All colors must be official (please update them as necessary)
   // unless noted (e.g. if we need a special color for contrast, etc)
@@ -204,3 +261,61 @@ $z-09-blocking-shield: $z-index-09;
 $z-10-flash-border: $z-index-10;
 $z-10-switch-away: $z-index-10;
 $z-10-print: $z-index-10;
+
+:root {
+  // Z-INDEX SCALE
+  --z-index-01: 100;
+  --z-index-02: 200;
+  --z-index-03: 300;
+  --z-index-04: 400;
+  --z-index-05: 500;
+  --z-index-06: 600;
+  --z-index-07: 700;
+  --z-index-08: 800;
+  --z-index-09: 900;
+  --z-index-10: 1000;
+
+  // Z-INDEX COMPONENTS
+  // Variables are assigned to scale, above.
+  // These are kept here so you can quickly ascertain
+  // the hierarchy of elements.
+  // They are also named with the scale position so that
+  // when they are referenced in other CSS files, their
+  // z-scale position is also obvious at a glance.
+  // Between scale positions, one can fine-tune placement
+  // by adding a +number to the defined scale.
+  // Please note, the z-index scale does not defeat limitations
+  // imposed by stacking contexts.
+  --z-01-main-screen: var(--z-index-01);
+  --z-01-street-section: var(--z-index-01);
+  --z-01-foreground: var(--z-index-01);
+  --z-02-segment-focused: var(--z-index-02);
+  --z-02-palette: var(--z-index-02);
+  --z-02-menu-bar: var(--z-index-02);
+  --z-03-street-name: var(--z-index-03);
+  --z-03-gallery-message: var(--z-index-03);
+  --z-05-welcome: var(--z-index-05);
+  --z-06-info-bubble: var(--z-index-06);
+  --z-06-drag-handle: var(--z-index-06);
+  --z-07-street-scroll: var(--z-index-07);
+  --z-07-toasts: var(--z-index-07);
+  --z-07-trashcan: var(--z-index-07);
+  --z-07-resize-guide: var(--z-index-07);
+  --z-07-debug-hover-polygon: var(--z-index-07);
+  --z-07-sky-picker: calc(var(--z-index-07) + 50);
+  --z-07-menu: calc(var(--z-index-07) + 75);
+  --z-08-dialog-box-backdrop: var(--z-index-08);
+  --z-08-gallery-shield: var(--z-index-08);
+  --z-08-notification-bar: var(--z-index-08);
+  --z-09-gallery: var(--z-index-09);
+  --z-09-dialog-box: var(--z-index-09);
+  --z-09-debug: var(--z-index-09);
+
+  // Blocking overlays
+  --z-09-loading: var(--z-index-09);
+  --z-09-error: var(--z-index-09);
+  --z-09-blocking-shield: var(--z-index-09);
+  --z-10-flash-border: var(--z-index-10);
+  --z-10-switch-away: var(--z-index-10);
+  --z-10-print: var(--z-index-10);
+}

--- a/client/styles/_variables.scss
+++ b/client/styles/_variables.scss
@@ -194,6 +194,10 @@ $ui-colour: color.adjust($sky-colour, $lightness: 10%);
   --light-box-shadow: 0 0 14px 0 rgb(0 0 0 / 7.5%);
   --medium-box-shadow: 0 0 10px 0 rgb(0 0 0 / 10%);
   --heavy-box-shadow: 0 0 10px 0 rgb(0 0 0 / 20%); // UNUSED
+
+  // Design
+  --street-name-size: 1.5;
+  --street-name-size-small: 0.5;
 }
 
 // Design

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -7,21 +7,21 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --colour-emerald-700: rgb(9, 63, 20);
-  --colour-emerald-600: rgb(31, 114, 52);
-  --colour-emerald-500: rgb(26, 145, 78);
-  --colour-emerald-400: rgb(91, 193, 125);
-  --colour-emerald-300: rgb(147, 219, 169);
-  --colour-emerald-200: rgb(200, 237, 209);
-  --colour-emerald-100: rgb(231, 247, 234);
+  --color-emerald-700: rgb(9, 63, 20);
+  --color-emerald-600: rgb(31, 114, 52);
+  --color-emerald-500: rgb(26, 145, 78);
+  --color-emerald-400: rgb(91, 193, 125);
+  --color-emerald-300: rgb(147, 219, 169);
+  --color-emerald-200: rgb(200, 237, 209);
+  --color-emerald-100: rgb(231, 247, 234);
 
-  --ifm-color-primary: var(--colour-emerald-400);
-  --ifm-color-primary-dark: var(--colour-emerald-500);
-  --ifm-color-primary-darker: var(--colour-emerald-600);
-  --ifm-color-primary-darkest: var(--colour-emerald-700);
-  --ifm-color-primary-light: var(--colour-emerald-300);
-  --ifm-color-primary-lighter: var(--colour-emerald-200);
-  --ifm-color-primary-lightest: var(--colour-emerald-100);
+  --ifm-color-primary: var(--color-emerald-400);
+  --ifm-color-primary-dark: var(--color-emerald-500);
+  --ifm-color-primary-darker: var(--color-emerald-600);
+  --ifm-color-primary-darkest: var(--color-emerald-700);
+  --ifm-color-primary-light: var(--color-emerald-300);
+  --ifm-color-primary-lighter: var(--color-emerald-200);
+  --ifm-color-primary-lightest: var(--color-emerald-100);
   --ifm-code-font-size: 95%;
 
   --streetmix-font: "Manrope Variable";
@@ -55,11 +55,11 @@ footer {
 }
 
 html[data-theme="light"] .navbar__title {
-  color: var(--colour-emerald-500);
+  color: var(--color-emerald-500);
 }
 
 html[data-theme="dark"] .navbar__title {
-  color: var(--colour-emerald-300);
+  color: var(--color-emerald-300);
 }
 
 footer.footer--dark {
@@ -115,8 +115,8 @@ footer.footer--dark {
   appearance: none;
   -webkit-appearance: none;
   background-color: transparent;
-  border: 2px solid var(--colour-emerald-400);
-  color: var(--colour-emerald-400);
+  border: 2px solid var(--color-emerald-400);
+  color: var(--color-emerald-400);
   font-size: 1em;
   text-decoration: none;
   display: block;
@@ -124,7 +124,7 @@ footer.footer--dark {
 }
 
 .stmx-cta-button:hover {
-  background-color: var(--colour-emerald-400);
+  background-color: var(--color-emerald-400);
   color: white;
   text-decoration: none;
 }


### PR DESCRIPTION
Here's the thing -- CSS custom properties (as "variables") is easier to work with at runtime to do things like manipulate other properties that should be adjusted in different situations... like dark mode(!) or even mobile(!)

Plus -- if we can eventually fully remove a build-time dependency (SCSS) more's the better.