### PR TITLE
chore(package): pin node22 to 22.10.x or higher to fix Parcel segfault

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": "^18.10.x || ^20.10.x || ^22.x",
+    "node": "^18.10.x || ^20.10.x || ^22.10.x",
     "npm": ">=9.x"
   },
   "type": "module",


### PR DESCRIPTION
Node version 22.7.0 through 22.9.0 (assuming the fix is in upcoming 22.10.0) segfaults as noted here:

https://github.com/parcel-bundler/parcel/issues/9926
https://github.com/parcel-bundler/parcel/issues/9976

Tracking fix:

https://github.com/nodejs/node/issues/54573

Assuming this lands in Node 22.10.0, we pin the minimum Node 22 version required.