### PR TITLE
feat(db): update street id to UUID datatype

### DIFF
--- a/app/db/migrations/20241031205836-update-street-id-uuid-datatype.cjs
+++ b/app/db/migrations/20241031205836-update-street-id-uuid-datatype.cjs
@@ -1,0 +1,30 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    return queryInterface.sequelize.query(`
+      ALTER TABLE "Streets"
+      ALTER COLUMN id
+      TYPE uuid USING id::uuid
+    `)
+    // Sequelize will refuse to run the `changeColumn` command because, and
+    // I quote, `ERROR: column "id" is in a primary key`. So we just run the
+    // bare query above instead.
+    // return queryInterface.changeColumn('Streets', 'id', {
+    //   type: Sequelize.DataTypes.UUID
+    // })
+  },
+
+  async down (queryInterface, Sequelize) {
+    return queryInterface.sequelize.query(`
+      ALTER TABLE "Streets"
+      ALTER COLUMN id
+      TYPE varchar(255)
+    `)
+    // Sequelize will refuse to run the `changeColumn` command -- see above.
+    // return queryInterface.changeColumn('Streets', 'id', {
+    //   type: Sequelize.DataTypes.STRING
+    // })
+  }
+}

--- a/app/db/models/street.js
+++ b/app/db/models/street.js
@@ -5,7 +5,7 @@ export default (sequelize, DataTypes) => {
       id: {
         allowNull: false,
         primaryKey: true,
-        type: DataTypes.STRING
+        type: DataTypes.UUID
       },
       namespacedId: {
         type: DataTypes.INTEGER,


### PR DESCRIPTION
Currently in the `Street` table the `id` field is specified as `VARCHAR(255)`, even though it is only holding text strings that are UUIDs. (There is some chatter about how UUIDs are not more performant than sequential IDs, we are not really at a scale where this matters so much that it's worth converting, although there is a potential future where the upgrade is to make a sequential ID column that is a primary key alongside the UUIDs to expose as outward-facing, non-sequential ids. Also: a future where we opt for ULIDs over UUIDs.)

It turns out that there is an actual UUID data type in PostgreSQL: https://www.postgresql.org/docs/current/datatype-uuid.html

I like specifying the UUID datatype hopefully to save space, and also for validation benefits, and also, hopefully, whatever indexing/performance benefits that PostgreSQL might provide knowing that the type is a UUID.

See here:
https://dzone.com/articles/performance-of-ulid-and-uuid-in-postgres-database (on this person's test, there is a slight improvement of the UUID data type over a VARCHAR field of the same length.)