### PR TITLE
Menu refactoring

### DIFF
--- a/client/src/menubar/InstanceBadge.css
+++ b/client/src/menubar/InstanceBadge.css
@@ -2,8 +2,8 @@
   z-index: var(--z-02-menu-bar);
   display: none;
   position: absolute;
-  left: 9px;
-  bottom: -14px;
+  inset-inline-start: 9px;
+  inset-block-end: -14px;
   padding: 0.25em 1em;
   text-transform: uppercase;
   font-size: 0.75rem;
@@ -30,12 +30,5 @@
   &.instance-label-demo {
     display: inline-block;
     background-color: rgb(28 189 209);
-  }
-}
-
-[dir="rtl"] {
-  .instance-badge {
-    right: 9px;
-    left: auto;
   }
 }

--- a/client/src/menubar/MenuBar.css
+++ b/client/src/menubar/MenuBar.css
@@ -10,11 +10,10 @@
   justify-content: space-between;
   flex-wrap: wrap;
   position: absolute;
-  left: var(--menu-side-inset);
-  right: var(--menu-side-inset);
-  top: 0;
-  border-bottom-left-radius: var(--menu-bar-border-radius);
-  border-bottom-right-radius: var(--menu-bar-border-radius);
+  inset-inline: var(--menu-side-inset);
+  inset-block-start: 0;
+  border-end-start-radius: var(--menu-bar-border-radius);
+  border-end-end-radius: var(--menu-bar-border-radius);
   background: var(--menu-bar-background);
   background-clip: padding-box;
   box-shadow: var(--menu-bar-box-shadow);
@@ -38,7 +37,7 @@
   ul {
     display: flex;
     list-style: none;
-    padding: 3px 1em;
+    padding: 0.25em;
     margin: 0;
     line-height: 32px;
     color: var(--menu-bar-text-color);
@@ -92,12 +91,7 @@
 
     /* Dropdown carat style */
     svg {
-      margin-left: 0.25em;
-
-      [dir="rtl"] & {
-        margin-right: 0.25em;
-        margin-left: 0;
-      }
+      margin-inline-start: 0.25em;
     }
 
     &:active {
@@ -120,46 +114,26 @@
 }
 
 .menu-bar-left {
-  padding-right: 0.25em !important;
-  padding-left: 0.25em !important;
-
   /* First button gets special hover treatment */
   li:nth-child(2) button.menu-attached:hover::after {
     width: calc(100% + 4px);
-    left: 0;
-
-    [dir="rtl"] & {
-      left: auto;
-      right: 0;
-    }
+    inset-inline-start: 0;
   }
 }
 
 .menu-bar-right {
-  padding-right: 0.25em !important;
-  padding-left: 0.25em !important;
-
   /* Last button gets special hover treatment */
   li:last-child button.menu-attached:hover::after {
     width: calc(100% + 4px);
-
-    [dir="rtl"] & {
-      left: 0;
-    }
+    inset-inline-end: 0;
   }
 }
 
 .menu-bar-title {
-  margin-right: 0.25em;
-  margin-left: 0.45em;
+  margin-inline: 0.45em 0.25em;
   display: flex !important;
   justify-content: center;
   align-items: center;
-
-  [dir="rtl"] & {
-    margin-left: 0.25em;
-    margin-right: 0.45em;
-  }
 
   h1 {
     font-size: 100%;
@@ -174,22 +148,10 @@
 }
 
 .menu-external-link {
-  margin-left: 0.25em;
-  margin-right: -0.2em;
+  margin-inline: 0.25em -0.2em;
   transform: scale(0.8);
-
-  [dir="rtl"] & {
-    margin-left: -0.2em;
-    margin-right: 0.25em;
-  }
 }
 
 .menu-carat-down {
-  margin-left: 0.25em;
-  margin-right: -0.25em;
-
-  [dir="rtl"] & {
-    margin-left: -0.25em;
-    margin-right: 0.25em;
-  }
+  margin-inline: 0.25em -0.25em;
 }

--- a/client/src/menubar/SignInButton.css
+++ b/client/src/menubar/SignInButton.css
@@ -1,10 +1,4 @@
 .menu-bar .menu-sign-in {
-  margin-left: 0.5em;
-  margin-right: 0.1em;
+  margin-inline: 0.5em 0.1em;
   padding: 0.5em 1em;
-
-  [dir="rtl"] & {
-    margin-left: 0.1em;
-    margin-right: 0.5em;
-  }
 }

--- a/client/src/menubar/UpgradeButton.css
+++ b/client/src/menubar/UpgradeButton.css
@@ -1,22 +1,10 @@
 .menu-bar .menu-upgrade {
   display: flex;
   align-items: center;
-  margin-left: 0.75em;
-  margin-right: 0;
+  margin-inline: 0.75em 0;
   padding: 0.5em 1em;
 
-  [dir="rtl"] & {
-    margin-left: 0;
-    margin-right: 0.75em;
-  }
-
   img {
-    margin-left: 0;
-    margin-right: 0.5em;
-
-    [dir="rtl"] & {
-      margin-left: 0.5em;
-      margin-right: 0;
-    }
+    margin-inline: 0 0.5em;
   }
 }

--- a/client/src/menubar/menus/ContactMenu.tsx
+++ b/client/src/menubar/menus/ContactMenu.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl'
 
 import { useDispatch } from '~/src/store/hooks'
 import { showDialog } from '~/src/store/slices/dialogs'
-import ExternalLink from '~/src/ui/ExternalLink'
 import Icon from '~/src/ui/Icon'
 import Menu, { type MenuProps } from './Menu'
 import MenuItem from './MenuItem'
@@ -13,22 +12,22 @@ function ContactMenu (props: MenuProps): React.ReactElement {
 
   return (
     <Menu {...props}>
-      <ExternalLink href="https://strt.mx/discord" icon={true}>
+      <MenuItem href="https://strt.mx/discord">
         <Icon name="discord" className="menu-item-icon" />
         <FormattedMessage
           id="menu.contact.discord"
           defaultMessage="Join Discord chat"
         />
-      </ExternalLink>
-      <ExternalLink href="https://github.com/streetmix/streetmix/" icon={true}>
+      </MenuItem>
+      <MenuItem href="https://github.com/streetmix/streetmix/">
         <Icon name="github" className="menu-item-icon" />
         <FormattedMessage
           id="menu.contact.github"
           defaultMessage="View source code on GitHub"
         />
-      </ExternalLink>
+      </MenuItem>
       <MenuItem
-        onClick={(e) => {
+        onClick={() => {
           dispatch(showDialog('NEWSLETTER'))
         }}
       >

--- a/client/src/menubar/menus/HelpMenu.tsx
+++ b/client/src/menubar/menus/HelpMenu.tsx
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl'
 
 import { useSelector, useDispatch } from '~/src/store/hooks'
 import { showDialog } from '~/src/store/slices/dialogs'
-import ExternalLink from '~/src/ui/ExternalLink'
 import Icon from '~/src/ui/Icon'
 import { registerKeypress, deregisterKeypress } from '~/src/app/keypress'
 import Menu, { type MenuProps } from './Menu'
@@ -44,24 +43,18 @@ function HelpMenu (props: MenuProps): React.ReactElement {
       </MenuItem>
       {!offline && (
         <>
-          <ExternalLink
-            href="https://docs.streetmix.net/user-guide/intro"
-            icon={true}
-          >
+          <MenuItem href="https://docs.streetmix.net/user-guide/intro">
             <Icon name="trail-sign" className="menu-item-icon" />
             <FormattedMessage
               id="menu.help.guidebook-link"
               defaultMessage="Guidebook"
             />
-          </ExternalLink>
+          </MenuItem>
           <MenuSeparator />
-          <ExternalLink
-            href="https://cottonbureau.com/people/streetmix"
-            icon={true}
-          >
+          <MenuItem href="https://cottonbureau.com/people/streetmix">
             <Icon name="cart" className="menu-item-icon" />
             <FormattedMessage id="menu.item.store" defaultMessage="Store" />
-          </ExternalLink>
+          </MenuItem>
         </>
       )}
       <MenuSeparator />

--- a/client/src/menubar/menus/IdentityMenu.css
+++ b/client/src/menubar/menus/IdentityMenu.css
@@ -19,12 +19,7 @@
   align-items: center;
   width: 40px;
   height: 40px;
-  margin-right: 0.5em;
-
-  [dir="rtl"] & {
-    margin-left: 0.5em;
-    margin-right: 0;
-  }
+  margin-inline-end: 0.5em;
 
   .avatar {
     width: 36px;
@@ -63,15 +58,10 @@
     align-items: center;
     border-radius: var(--border-radius-medium);
     padding: 0.3em 0.6em;
-    margin-right: 0.35em;
-    margin-bottom: 0.35em;
+    margin-inline-end: 0.35em;
+    margin-block-end: 0.35em;
     font-size: 0.9em;
     font-weight: 550;
-
-    [dir="rtl"] & {
-      margin-left: 0.35em;
-      margin-right: 0;
-    }
   }
 
   .role-badge-generic {
@@ -85,12 +75,7 @@
 
     img {
       height: 1em;
-      margin-right: 0.35em;
-
-      [dir="rtl"] & {
-        margin-left: 0.35em;
-        margin-right: auto;
-      }
+      margin-inline-end: 0.35em;
     }
   }
 

--- a/client/src/menubar/menus/IdentityMenu.tsx
+++ b/client/src/menubar/menus/IdentityMenu.tsx
@@ -24,6 +24,8 @@ function IdentityMenu (props: MenuProps): React.ReactElement {
   const handleClickMyStreets = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault()
+      const myStreetsLink = user?.id !== undefined ? `/${user.id}` : ''
+      window.history.pushState({}, '', myStreetsLink)
       void dispatch(openGallery({ userId: user.id }))
     },
     [user?.id, dispatch]
@@ -31,7 +33,6 @@ function IdentityMenu (props: MenuProps): React.ReactElement {
 
   const isAdmin: boolean =
     user?.roles?.includes(USER_ROLES.ADMIN.value) ?? false
-  const myStreetsLink = user?.id !== undefined ? `/${user.id}` : ''
 
   return (
     <Menu {...props} className="identity-menu">
@@ -74,13 +75,13 @@ function IdentityMenu (props: MenuProps): React.ReactElement {
             </div>
           </div>
           <MenuSeparator />
-          <a href={myStreetsLink} onClick={handleClickMyStreets}>
+          <MenuItem onClick={handleClickMyStreets}>
             <Icon name="star" className="menu-item-icon" />
             <FormattedMessage
               id="menu.item.my-streets"
               defaultMessage="My streets"
             />
-          </a>
+          </MenuItem>
         </>
       )}
       <MenuItem onClick={() => dispatch(showDialog('SETTINGS'))}>

--- a/client/src/menubar/menus/IdentityMenu.tsx
+++ b/client/src/menubar/menus/IdentityMenu.tsx
@@ -23,7 +23,6 @@ function IdentityMenu (props: MenuProps): React.ReactElement {
   const dispatch = useDispatch()
   const handleClickMyStreets = useCallback(
     (event: React.MouseEvent) => {
-      event.preventDefault()
       const myStreetsLink = user?.id !== undefined ? `/${user.id}` : ''
       window.history.pushState({}, '', myStreetsLink)
       void dispatch(openGallery({ userId: user.id }))

--- a/client/src/menubar/menus/KeyboardShortcuts.css
+++ b/client/src/menubar/menus/KeyboardShortcuts.css
@@ -1,19 +1,15 @@
 .keyboard-shortcuts {
-  padding: 0.8em 1em 1em 2.5em;
+  padding-block: 0.8em 1em;
+  padding-inline: 2.5em 1em;
   max-width: 360px;
   position: relative;
 
-  [dir="rtl"] & {
-    padding-left: 1em;
-    padding-right: 2.5em;
-  }
-
   p:first-child {
-    margin-top: 0;
+    margin-block-start: 0;
   }
 
   table {
-    margin-top: 0.5em;
+    margin-block-start: 0.5em;
     border-collapse: collapse;
 
     td {
@@ -23,12 +19,7 @@
 
     td:first-child {
       min-width: 60px;
-      padding-left: 0;
-
-      [dir="rtl"] & {
-        padding-left: 0.25em;
-        padding-right: 0;
-      }
+      padding-inline-start: 0;
     }
   }
 

--- a/client/src/menubar/menus/KeyboardShortcuts.tsx
+++ b/client/src/menubar/menus/KeyboardShortcuts.tsx
@@ -44,7 +44,7 @@ function KeyboardShortcuts (): React.ReactElement {
             </td>
           </tr>
           <tr>
-            <td dir="ltr">
+            <td>
               {/*
                 <FormattedMessage> is used with a render prop because we need
                 to pass a string child to <KeyboardKey /> when the `icon`
@@ -72,20 +72,26 @@ function KeyboardShortcuts (): React.ReactElement {
             </td>
           </tr>
           <tr>
-            <td dir="ltr">
-              <FormattedMessage id="key.left-arrow" defaultMessage="Left arrow">
-                {(label) => (
-                  <KeyboardKey icon="arrow-left">{label}</KeyboardKey>
-                )}
-              </FormattedMessage>
-              <FormattedMessage
-                id="key.right-arrow"
-                defaultMessage="Right arrow"
-              >
-                {(label) => (
-                  <KeyboardKey icon="arrow-right">{label}</KeyboardKey>
-                )}
-              </FormattedMessage>
+            <td>
+              {/* Keep arrows in the same order in all language directions */}
+              <span dir="ltr">
+                <FormattedMessage
+                  id="key.left-arrow"
+                  defaultMessage="Left arrow"
+                >
+                  {(label) => (
+                    <KeyboardKey icon="arrow-left">{label}</KeyboardKey>
+                  )}
+                </FormattedMessage>
+                <FormattedMessage
+                  id="key.right-arrow"
+                  defaultMessage="Right arrow"
+                >
+                  {(label) => (
+                    <KeyboardKey icon="arrow-right">{label}</KeyboardKey>
+                  )}
+                </FormattedMessage>
+              </span>
             </td>
             <td>
               <FormattedMessage

--- a/client/src/menubar/menus/Menu.css
+++ b/client/src/menubar/menus/Menu.css
@@ -3,7 +3,7 @@
   --menu-box-shadow: var(--medium-box-shadow);
 
   position: absolute;
-  margin-top: 7px;
+  margin-block-start: 7px;
   padding: 5px;
   touch-action: none;
   opacity: 0;
@@ -33,32 +33,6 @@
     opacity: 0;
   }
 
-  > a,
-  > button.menu-item {
-    display: block;
-    position: relative;
-    padding: 0.5em 1em 0.5em 2.5em;
-    text-decoration: none;
-    color: black;
-    border-radius: var(--border-radius);
-
-    /* Specifically for button */
-    width: 100%;
-
-    &:hover {
-      background-color: var(--interactive-element-hover-color);
-    }
-
-    &:active {
-      color: var(--interactive-text-active-color);
-    }
-
-    [dir="rtl"] & {
-      padding-right: 2.5em;
-      padding-left: 1em;
-    }
-  }
-
   input {
     appearance: none;
     background: var(--form-element-background);
@@ -67,21 +41,13 @@
   }
 
   [data-icon="external-link"] {
-    vertical-align: middle;
-    margin-left: 0.25em;
-    margin-top: -2px;
-    height: 12px;
+    margin-inline-start: 0.25em;
     color: var(--color-midnight-600);
 
     /* Reset icon-source styling */
     position: relative;
     left: auto;
-    top: auto;
-
-    [dir="rtl"] & {
-      margin-left: auto;
-      margin-right: 0.25em;
-    }
+    top: 1px;
   }
 }
 
@@ -97,9 +63,17 @@ body.safari .menu {
 .menu-item {
   display: block;
   position: relative;
-  padding: 0.5em 2em;
-  cursor: pointer;
+  padding-block: 0.5em;
+  padding-inline: 2.5em 1em;
+  color: black;
   border-radius: var(--border-radius);
+
+  /* Specifically for anchors */
+  text-decoration: none;
+
+  /* Specifically for button */
+  cursor: pointer;
+  width: 100%;
 
   &:hover {
     background-color: var(--interactive-element-hover-color);
@@ -109,67 +83,38 @@ body.safari .menu {
     color: var(--interactive-text-active-color);
   }
 
-  &.menu-item-selected [data-icon="check"] {
-    display: inline-block;
-  }
-
+  /* Used in locale menu */
   .loading-spinner {
     position: absolute;
-    left: 8px;
-    top: 8px;
-
-    [dir="rtl"] & {
-      left: auto;
-      right: 8px;
-    }
+    inset-block-start: 0.65em;
+    inset-inline-start: 1em;
+    color: var(--color-turquoise-500);
   }
 }
 
 .menu-item-icon {
   position: absolute;
-  top: 0.5em;
-  left: 0.8em;
+  inset-block-start: 0.5em;
+  inset-inline-start: 0.8em;
   width: 16px;
   height: 16px;
   color: var(--color-midnight-800);
 
-  [dir="rtl"] & {
-    left: auto;
-    right: 0.8em;
-  }
-
   &[data-icon-source="io5"] {
-    top: 0.55em;
-    left: 0.75em;
-
-    [dir="rtl"] & {
-      left: auto;
-      right: 0.75em;
-    }
+    inset-block-start: 0.55em;
+    inset-inline-start: 0.75em;
   }
 
   /* Radix icons are optimized for 15px */
   &[data-icon-source="radix"] {
-    top: 0.6em;
+    inset-block-start: 0.6em;
     width: 15px;
     height: 15px;
-
-    [dir="rtl"] & {
-      left: auto;
-      right: 0.8em;
-    }
   }
 
   &[data-icon="check"] {
-    display: none;
-    left: 0.5em;
-    margin-top: 1px;
+    inset-block-start: 0.55em;
     color: var(--color-turquoise-500);
-
-    [dir="rtl"] & {
-      left: auto;
-      right: 0.5em;
-    }
   }
 
   &[data-icon="discord"] {
@@ -197,10 +142,4 @@ body.safari .menu {
   display: block;
   color: rgb(128 128 128);
   font-size: 0.8em;
-}
-
-.menu-separator {
-  height: 1px;
-  background-color: var(--color-turquoise-300);
-  margin: 5px 0;
 }

--- a/client/src/menubar/menus/MenuItem.tsx
+++ b/client/src/menubar/menus/MenuItem.tsx
@@ -1,18 +1,37 @@
-import React, { type ButtonHTMLAttributes } from 'react'
+import React from 'react'
 
-interface MenuItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+import ExternalLink from '~/src/ui/ExternalLink'
+
+// TODO: fix broken types, `href` means render `a`, otherwise render `button`
+type MenuItemProps<T extends 'button' | 'a'> = {
+  href?: string
   children: React.ReactNode
-}
+} & React.JSX.IntrinsicElements[T]
 
-function MenuItem ({
-  children,
+function MenuItem<T extends 'button' | 'a'> ({
+  href,
   className,
+  children,
   ...props
-}: MenuItemProps): React.ReactElement {
+}: MenuItemProps<T>): React.ReactElement {
   // Merge classnames
   const classNames = ['menu-item']
   if (typeof className === 'string') {
     classNames.push(className)
+  }
+
+  if (href !== undefined) {
+    return (
+      <ExternalLink
+        href={href}
+        icon={true}
+        className={classNames.join(' ')}
+        role="menuitem"
+        {...props}
+      >
+        {children}
+      </ExternalLink>
+    )
   }
 
   return (

--- a/client/src/menubar/menus/MenuSeparator.css
+++ b/client/src/menubar/menus/MenuSeparator.css
@@ -1,0 +1,5 @@
+.menu-separator {
+  height: 1px;
+  margin-block: 0.35em;
+  background-color: var(--color-turquoise-300);
+}

--- a/client/src/menubar/menus/MenuSeparator.tsx
+++ b/client/src/menubar/menus/MenuSeparator.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import './MenuSeparator.css'
+
 function MenuSeparator (): React.ReactElement {
   return (
     <div

--- a/client/src/menubar/menus/ShareMenu/Export3DStreet.tsx
+++ b/client/src/menubar/menus/ShareMenu/Export3DStreet.tsx
@@ -1,21 +1,18 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
-import ExternalLink from '~/src/ui/ExternalLink'
 import Icon from '~/src/ui/Icon'
+import MenuItem from '../MenuItem'
 
 function Export3DStreet (): React.ReactElement {
   return (
-    <ExternalLink
-      href={`https://3dstreet.app/#${window.location.href}`}
-      icon={true}
-    >
+    <MenuItem href={`https://3dstreet.app/#${window.location.href}`}>
       <Icon name="cube" className="menu-item-icon" />
       <FormattedMessage
         id="menu.share.3dstreet"
         defaultMessage="Open in 3DStreet"
       />
-    </ExternalLink>
+    </MenuItem>
   )
 }
 

--- a/client/src/menubar/menus/ShareMenu/ExportStreetmeter.tsx
+++ b/client/src/menubar/menus/ShareMenu/ExportStreetmeter.tsx
@@ -1,13 +1,10 @@
 import React from 'react'
 
-import ExternalLink from '~/src/ui/ExternalLink'
+import MenuItem from '../MenuItem'
 
 function ExportStreetmeter (): React.ReactElement {
   return (
-    <ExternalLink
-      href={`https://streetmeter.net/#${window.location.href}`}
-      icon={true}
-    >
+    <MenuItem href={`https://streetmeter.net/#${window.location.href}`}>
       Open in Streetmeter
       <span
         style={{
@@ -22,7 +19,7 @@ function ExportStreetmeter (): React.ReactElement {
       >
         BETA
       </span>
-    </ExternalLink>
+    </MenuItem>
   )
 }
 

--- a/client/src/menubar/menus/ShareMenu/PostOnFacebook.tsx
+++ b/client/src/menubar/menus/ShareMenu/PostOnFacebook.tsx
@@ -3,9 +3,9 @@ import { FormattedMessage } from 'react-intl'
 
 import { useSelector } from '~/src/store/hooks'
 import Icon from '~/src/ui/Icon'
-import ExternalLink from '~/src/ui/ExternalLink'
 import { FACEBOOK_APP_ID } from '~/src/app/config'
 import { getPageTitle } from '~/src/app/page_title'
+import MenuItem from '../MenuItem'
 import type { SocialShareProps } from './helpers'
 
 function PostOnFacebook ({
@@ -28,13 +28,13 @@ function PostOnFacebook ({
     encodeURIComponent(shareText)
 
   return (
-    <ExternalLink href={facebookLink} icon={true}>
+    <MenuItem href={facebookLink}>
       <Icon name="facebook" className="menu-item-icon" />
       <FormattedMessage
         id="menu.share.facebook"
         defaultMessage="Share using Facebook"
       />
-    </ExternalLink>
+    </MenuItem>
   )
 }
 

--- a/client/src/menubar/menus/ShareMenu/PostOnTwitter.tsx
+++ b/client/src/menubar/menus/ShareMenu/PostOnTwitter.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import Icon from '~/src/ui/Icon'
-import ExternalLink from '~/src/ui/ExternalLink'
+import MenuItem from '../MenuItem'
 import type { SocialShareProps } from './helpers'
 
 function PostOnTwitter ({
@@ -17,13 +17,13 @@ function PostOnTwitter ({
     encodeURIComponent(shareUrl)
 
   return (
-    <ExternalLink href={twitterLink} icon={true}>
+    <MenuItem href={twitterLink}>
       <Icon name="twitter" className="menu-item-icon" />
       <FormattedMessage
         id="menu.share.twitter"
         defaultMessage="Share using Twitter"
       />
-    </ExternalLink>
+    </MenuItem>
   )
 }
 

--- a/client/src/menubar/menus/ShareMenu/ShareMenu.css
+++ b/client/src/menubar/menus/ShareMenu/ShareMenu.css
@@ -43,11 +43,6 @@
 
 .share-via-link {
   line-height: 18px;
-  margin-right: 0.5em;
+  margin-inline-end: 0.5em;
   outline: none;
-
-  [dir="rtl"] & {
-    margin-right: auto;
-    margin-left: 0.5em;
-  }
 }

--- a/client/src/menubar/menus/ShareMenu/SignInPromo.css
+++ b/client/src/menubar/menus/ShareMenu/SignInPromo.css
@@ -1,8 +1,8 @@
 .share-sign-in-promo {
   text-align: center;
   background-color: var(--alert-background);
-  border-bottom: var(--alert-border);
-  border-bottom-width: 3px;
+  border-block-end: var(--alert-border);
+  border-block-end-width: 3px;
   padding: 1em 2.5em;
 
   /* Override parent padding */

--- a/client/src/menubar/menus/ShareMenu/__snapshots__/ShareMenu.test.tsx.snap
+++ b/client/src/menubar/menus/ShareMenu/__snapshots__/ShareMenu.test.tsx.snap
@@ -103,8 +103,10 @@ exports[`ShareMenu > renders (user not signed in, anonymous user’s street, no 
       />
     </button>
     <a
+      class="menu-item"
       href="https://twitter.com/intent/tweet?text=Check%20out%20this%20street%20on%20Streetmix!&url=http%3A%2F%2Flocalhost%3A3000%2F"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -119,8 +121,10 @@ exports[`ShareMenu > renders (user not signed in, anonymous user’s street, no 
       />
     </a>
     <a
+      class="menu-item"
       href="https://www.facebook.com/dialog/feed?app_id=&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&link=http%3A%2F%2Flocalhost%3A3000%2F&name=Unnamed%20St%20%E2%80%93%20Streetmix&description=Check%20out%20this%20street%20on%20Streetmix!"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -140,8 +144,10 @@ exports[`ShareMenu > renders (user not signed in, anonymous user’s street, no 
       role="separator"
     />
     <a
+      class="menu-item"
       href="https://3dstreet.app/#http://localhost:3000/"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -249,8 +255,10 @@ exports[`ShareMenu > renders (user signed in, own street, with name) 1`] = `
       />
     </button>
     <a
+      class="menu-item"
       href="https://twitter.com/intent/tweet?text=Check%20out%20my%20street%2C%20bar%2C%20on%20Streetmix!&url=http%3A%2F%2Flocalhost%3A3000%2F"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -265,8 +273,10 @@ exports[`ShareMenu > renders (user signed in, own street, with name) 1`] = `
       />
     </a>
     <a
+      class="menu-item"
       href="https://www.facebook.com/dialog/feed?app_id=&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2F&link=http%3A%2F%2Flocalhost%3A3000%2F&name=bar%20%E2%80%93%20Streetmix&description=Check%20out%20my%20street%2C%20bar%2C%20on%20Streetmix!"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -286,8 +296,10 @@ exports[`ShareMenu > renders (user signed in, own street, with name) 1`] = `
       role="separator"
     />
     <a
+      class="menu-item"
       href="https://3dstreet.app/#http://localhost:3000/"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg

--- a/client/src/menubar/menus/__snapshots__/ContactMenu.test.tsx.snap
+++ b/client/src/menubar/menus/__snapshots__/ContactMenu.test.tsx.snap
@@ -7,8 +7,10 @@ exports[`ContactMenu > renders 1`] = `
     role="menu"
   >
     <a
+      class="menu-item"
       href="https://strt.mx/discord"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -23,8 +25,10 @@ exports[`ContactMenu > renders 1`] = `
       />
     </a>
     <a
+      class="menu-item"
       href="https://github.com/streetmix/streetmix/"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg

--- a/client/src/menubar/menus/__snapshots__/HelpMenu.test.tsx.snap
+++ b/client/src/menubar/menus/__snapshots__/HelpMenu.test.tsx.snap
@@ -29,8 +29,10 @@ exports[`HelpMenu > renders 1`] = `
       What’s new?‎
     </button>
     <a
+      class="menu-item"
       href="https://docs.streetmix.net/user-guide/intro"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -50,8 +52,10 @@ exports[`HelpMenu > renders 1`] = `
       role="separator"
     />
     <a
+      class="menu-item"
       href="https://cottonbureau.com/people/streetmix"
       rel="noopener noreferrer"
+      role="menuitem"
       target="_blank"
     >
       <svg
@@ -102,9 +106,7 @@ exports[`HelpMenu > renders 1`] = `
             </td>
           </tr>
           <tr>
-            <td
-              dir="ltr"
-            >
+            <td>
               <kbd
                 class="key key-icon"
                 title="Minus"
@@ -137,27 +139,29 @@ exports[`HelpMenu > renders 1`] = `
             </td>
           </tr>
           <tr>
-            <td
-              dir="ltr"
-            >
-              <kbd
-                class="key key-icon"
-                title="Left arrow"
+            <td>
+              <span
+                dir="ltr"
               >
-                <svg
-                  data-icon="arrow-left"
-                  data-icon-source="test"
-                />
-              </kbd>
-              <kbd
-                class="key key-icon"
-                title="Right arrow"
-              >
-                <svg
-                  data-icon="arrow-right"
-                  data-icon-source="test"
-                />
-              </kbd>
+                <kbd
+                  class="key key-icon"
+                  title="Left arrow"
+                >
+                  <svg
+                    data-icon="arrow-left"
+                    data-icon-source="test"
+                  />
+                </kbd>
+                <kbd
+                  class="key key-icon"
+                  title="Right arrow"
+                >
+                  <svg
+                    data-icon="arrow-right"
+                    data-icon-source="test"
+                  />
+                </kbd>
+              </span>
             </td>
             <td>
               Move around the street

--- a/client/src/menubar/menus/__snapshots__/IdentityMenu.test.tsx.snap
+++ b/client/src/menubar/menus/__snapshots__/IdentityMenu.test.tsx.snap
@@ -55,8 +55,9 @@ exports[`IdentityMenu > renders 1`] = `
       class="menu-separator"
       role="separator"
     />
-    <a
-      href="/foo"
+    <button
+      class="menu-item"
+      role="menuitem"
     >
       <svg
         class="menu-item-icon"
@@ -64,7 +65,7 @@ exports[`IdentityMenu > renders 1`] = `
         data-icon-source="test"
       />
       My streets
-    </a>
+    </button>
     <button
       class="menu-item"
       role="menuitem"

--- a/client/src/ui/Toasts/Toast.css
+++ b/client/src/ui/Toasts/Toast.css
@@ -53,6 +53,7 @@
   width: 100%;
   min-height: 32px;
   font-weight: 550;
+  text-align: center;
   background-color: transparent;
   color: var(--color-copper-800);
   cursor: pointer;


### PR DESCRIPTION
- Add ARIA `role="menuitem"` to link-type menu items
- Refactor link and button-type menu items to use the same `<MenuItem />` component
- Replace physical CSS properties with logical properties, removing `[dir="rtl"]` selector overrides
- Consolidate separate `.menu-item` styling of links and buttons
- "My streets" is no longer a link, but does a History `pushState` to maintain original behavior
- Fix keyboard buttons in the Help menu being misaligned in Arabic
- Adjust icon positioning in locale menu now that menu item styles are consolidated
- Fix text alignment of Toast buttons