### PR TITLE
Change buildings data model

### DIFF
--- a/app/lib/streets_export.js
+++ b/app/lib/streets_export.js
@@ -29,11 +29,11 @@ export function streetsToCSV (json) {
     'creatorId',
     'width',
     'widthImperial',
-    'leftBuildingVariant',
-    'leftBuildingHeight',
+    'leftBoundaryVariant',
+    'leftBoundaryFloors',
     SEGMENT_REPLACE_HEADER, // WILL BE REPLACED
-    'rightBuildingVariant',
-    'rightBuildingHeight',
+    'rightBoundaryVariant',
+    'rightBoundaryFloors',
     'editCount',
     'createdAt',
     'url'
@@ -66,10 +66,14 @@ export function streetsToCSV (json) {
         case 'creatorId':
         case 'createdAt':
           return street[header] ?? ''
-        case 'leftBuildingVariant':
-        case 'leftBuildingHeight':
-        case 'rightBuildingVariant':
-        case 'rightBuildingHeight':
+        case 'leftBoundaryVariant':
+          return street.data.boundary.left.variant
+        case 'leftBoundaryFloors':
+          return street.data.boundary.left.floors
+        case 'rightBoundaryVariant':
+          return street.data.boundary.right.variant
+        case 'rightBoundaryFloors':
+          return street.data.boundary.left.floors
         case 'editCount':
           return street.data.street[header] ?? ''
         case 'width':

--- a/app/lib/util.js
+++ b/app/lib/util.js
@@ -16,6 +16,18 @@ export function asStreetJson (street) {
     json.creator = { id: street.creatorId }
   }
 
+  // Add back deprecated building properties for compatibility
+  if (street.data.street.boundary) {
+    json.data.street.leftBuildingVariant =
+      street.data.street.boundary.left.variant
+    json.data.street.leftBuildingHeight =
+      street.data.street.boundary.left.floors
+    json.data.street.rightBuildingVariant =
+      street.data.street.boundary.right.variant
+    json.data.street.rightBuildingHeight =
+      street.data.street.boundary.right.floors
+  }
+
   return json
 }
 

--- a/client/src/gallery/GalleryStreetItem.css
+++ b/client/src/gallery/GalleryStreetItem.css
@@ -157,6 +157,7 @@
   justify-content: center;
   height: 100%;
   color: var(--color-turquoise-800);
+  white-space: normal;
 
   /* Top/bottom padding accounts for street name */
   padding: 20px 1.5em 2px;

--- a/client/src/gallery/GalleryStreetItem.tsx
+++ b/client/src/gallery/GalleryStreetItem.tsx
@@ -63,6 +63,7 @@ function GalleryStreetItem (
         watermark: false
       })
     } catch (error) {
+      console.error(error)
       setError(true)
     }
   }, [thumbnailEl, street, dpi])

--- a/client/src/info_bubble/InfoBubble.test.jsx
+++ b/client/src/info_bubble/InfoBubble.test.jsx
@@ -45,8 +45,14 @@ const initialState = {
         warnings: []
       }
     ],
-    leftBuildingVariant: 'grass',
-    rightBuildingVariant: 'grass'
+    boundary: {
+      left: {
+        variant: 'grass'
+      },
+      right: {
+        variant: 'grass'
+      }
+    }
   },
   system: {},
   locale: {

--- a/client/src/info_bubble/InfoBubbleControls/BuildingHeightControl.tsx
+++ b/client/src/info_bubble/InfoBubbleControls/BuildingHeightControl.tsx
@@ -29,13 +29,13 @@ function BuildingHeightControl ({
   // Get the appropriate building data based on which side of street it's on
   const variant = useSelector((state) =>
     position === BUILDING_LEFT_POSITION
-      ? state.street.leftBuildingVariant
-      : state.street.rightBuildingVariant
+      ? state.street.boundary.left.variant
+      : state.street.boundary.right.variant
   )
   const value = useSelector((state) =>
     position === BUILDING_LEFT_POSITION
-      ? state.street.leftBuildingHeight
-      : state.street.rightBuildingHeight
+      ? state.street.boundary.left.floors
+      : state.street.boundary.right.floors
   )
 
   const dispatch = useDispatch()

--- a/client/src/info_bubble/InfoBubbleControls/Variants.test.tsx
+++ b/client/src/info_bubble/InfoBubbleControls/Variants.test.tsx
@@ -25,8 +25,14 @@ vi.mock('../../segments/variant_icons.json', () => ({
 describe('Variants', () => {
   const initialState = {
     street: {
-      leftBuildingVariant: 'residential',
-      rightBuildingVariant: 'residential',
+      boundary: {
+        left: {
+          variant: 'residential'
+        },
+        right: {
+          variant: 'residential'
+        }
+      },
       segments: [
         {
           variant: {
@@ -84,7 +90,7 @@ describe('Variants', () => {
       )
 
       await userEvent.click(screen.getByTitle('Waterfront'))
-      expect(store.getState().street.leftBuildingVariant).toBe('waterfront')
+      expect(store.getState().street.boundary.left.variant).toBe('waterfront')
     })
 
     it('handles switching right building', async () => {
@@ -94,7 +100,7 @@ describe('Variants', () => {
       )
 
       await userEvent.click(screen.getByTitle('Waterfront'))
-      expect(store.getState().street.rightBuildingVariant).toBe('waterfront')
+      expect(store.getState().street.boundary.right.variant).toBe('waterfront')
     })
   })
 

--- a/client/src/info_bubble/InfoBubbleControls/Variants.tsx
+++ b/client/src/info_bubble/InfoBubbleControls/Variants.tsx
@@ -36,9 +36,9 @@ function Variants (props: VariantsProps): React.ReactElement | null {
   // Get the appropriate variant information
   const variant = useSelector((state) => {
     if (position === BUILDING_LEFT_POSITION) {
-      return state.street.leftBuildingVariant
+      return state.street.boundary.left.variant
     } else if (position === BUILDING_RIGHT_POSITION) {
-      return state.street.rightBuildingVariant
+      return state.street.boundary.right.variant
     } else if (typeof position === 'number') {
       return state.street.segments[position].variantString
     }

--- a/client/src/info_bubble/InfoBubbleHeader/InfoBubbleHeader.tsx
+++ b/client/src/info_bubble/InfoBubbleHeader/InfoBubbleHeader.tsx
@@ -63,7 +63,7 @@ function InfoBubbleHeader (props: InfoBubbleHeaderProps): React.ReactElement {
         break
       }
       case INFO_BUBBLE_TYPE_LEFT_BUILDING: {
-        const key = street.leftBuildingVariant
+        const key = street.boundary.left.variant
 
         id = `buildings.${key}.name`
         defaultMessage = BUILDINGS[key as keyof typeof BUILDINGS].label
@@ -71,7 +71,7 @@ function InfoBubbleHeader (props: InfoBubbleHeaderProps): React.ReactElement {
         break
       }
       case INFO_BUBBLE_TYPE_RIGHT_BUILDING: {
-        const key = street.rightBuildingVariant
+        const key = street.boundary.right.variant
 
         id = `buildings.${key}.name`
         defaultMessage = BUILDINGS[key as keyof typeof BUILDINGS].label

--- a/client/src/segments/Building.jsx
+++ b/client/src/segments/Building.jsx
@@ -38,14 +38,6 @@ class Building extends React.Component {
     super(props)
 
     this.state = {
-      variant:
-        props.position === BUILDING_LEFT_POSITION
-          ? 'leftBuildingVariant'
-          : 'rightBuildingVariant',
-      height:
-        props.position === BUILDING_LEFT_POSITION
-          ? 'leftBuildingHeight'
-          : 'rightBuildingHeight',
       oldBuildingEnter: true,
       newBuildingEnter: false,
       switchBuildings: false,
@@ -77,37 +69,39 @@ class Building extends React.Component {
 
   componentDidUpdate (prevProps, prevState) {
     const { street, position, buildingWidth } = this.props
-    const { variant, height } = this.state
 
     const lastOverflow = prevProps.street.remainingWidth < 0
     const streetOverflow = street.remainingWidth < 0
 
     if (
-      prevProps.street[height] !== street[height] ||
+      prevProps.street.boundary[position].floors !==
+        street.boundary[position].floors ||
       lastOverflow !== streetOverflow ||
-      (street[variant] && prevProps.buildingWidth !== buildingWidth)
+      (street.boundary[position].variant &&
+        prevProps.buildingWidth !== buildingWidth)
     ) {
       createBuilding(
         this.streetSectionBuilding,
-        street[variant],
+        street.boundary[position].variant,
         position,
-        street[height],
+        street.boundary[position].floors,
         streetOverflow
       )
     }
 
     if (
-      prevProps.street[variant] &&
-      prevProps.street[variant] !== street[variant]
+      prevProps.street.boundary[position].variant &&
+      prevProps.street.boundary[position].variant !==
+        street.boundary[position].variant
     ) {
       if (this.shouldBuildingAnimate(prevProps.street, street)) {
         this.handleSwitchBuildings()
       } else {
         createBuilding(
           this.streetSectionBuilding,
-          street[variant],
+          street.boundary[position].variant,
           position,
-          street[height],
+          street.boundary[position].floors,
           streetOverflow
         )
       }
@@ -118,9 +112,9 @@ class Building extends React.Component {
       this.props.updatePerspective(this.streetSectionBuilding)
       createBuilding(
         this.streetSectionBuilding,
-        street[variant],
+        street.boundary[position].variant,
         position,
-        street[height],
+        street.boundary[position].floors,
         streetOverflow
       )
     }
@@ -194,19 +188,11 @@ class Building extends React.Component {
   // Animate if the only changes in street object are:
   // editCount, rightBuildingVariant (or leftBuildingVariant), updatedAt, and clientUpdatedAt
   shouldBuildingAnimate = (oldStreet, newStreet) => {
-    let userUpdated = true
-    for (const key in newStreet) {
-      if (oldStreet[key] !== newStreet[key]) {
-        userUpdated = [
-          'editCount',
-          this.state.variant,
-          'updatedAt',
-          'clientUpdatedAt'
-        ].includes(key)
-        if (!userUpdated) return false
-      }
-    }
-    return userUpdated
+    let shouldAnimate = false
+    if (oldStreet.id !== newStreet.id) return false
+    if (oldStreet.boundary.left.variant !== newStreet.boundary.left.variant) { shouldAnimate = true }
+    if (oldStreet.boundary.right.variant !== newStreet.boundary.right.variant) { shouldAnimate = true }
+    return shouldAnimate
   }
 
   renderBuilding = (building, nodeRef) => {

--- a/client/src/segments/Building.jsx
+++ b/client/src/segments/Building.jsx
@@ -185,13 +185,17 @@ class Building extends React.Component {
     })
   }
 
-  // Animate if the only changes in street object are:
-  // editCount, rightBuildingVariant (or leftBuildingVariant), updatedAt, and clientUpdatedAt
+  // Animate if the only changes in street object are boundary variants.
+  // Absolutely don't animate if we're switchng streets.
   shouldBuildingAnimate = (oldStreet, newStreet) => {
     let shouldAnimate = false
     if (oldStreet.id !== newStreet.id) return false
-    if (oldStreet.boundary.left.variant !== newStreet.boundary.left.variant) { shouldAnimate = true }
-    if (oldStreet.boundary.right.variant !== newStreet.boundary.right.variant) { shouldAnimate = true }
+    if (oldStreet.boundary.left.variant !== newStreet.boundary.left.variant) {
+      shouldAnimate = true
+    }
+    if (oldStreet.boundary.right.variant !== newStreet.boundary.right.variant) {
+      shouldAnimate = true
+    }
     return shouldAnimate
   }
 

--- a/client/src/store/slices/street.test.js
+++ b/client/src/store/slices/street.test.js
@@ -36,10 +36,20 @@ describe('street reducer', () => {
     width: 0,
     name: null,
     segments: [],
-    leftBuildingHeight: 0,
-    rightBuildingHeight: 0,
-    leftBuildingVariant: '',
-    rightBuildingVariant: '',
+    boundary: {
+      left: {
+        id: '',
+        variant: '',
+        floors: 0,
+        elevation: 0
+      },
+      right: {
+        id: '',
+        variant: '',
+        floors: 0,
+        elevation: 0
+      }
+    },
     skybox: 'day',
     location: null,
     showAnalytics: false,
@@ -473,330 +483,264 @@ describe('street reducer', () => {
     describe('addBuildingFloor()', () => {
       it('adds a floor on the left building', () => {
         const existingStreet = {
-          leftBuildingHeight: 1
+          boundary: {
+            left: {
+              floors: 1
+            }
+          }
         }
 
-        expect(street(existingStreet, addBuildingFloor('left'))).toEqual({
-          leftBuildingHeight: 2
-        })
+        const result = street(existingStreet, addBuildingFloor('left'))
+        expect(result.boundary.left.floors).toEqual(2)
       })
 
       it('adds a floor on the right building', () => {
         const existingStreet = {
-          rightBuildingHeight: 19
+          boundary: {
+            right: {
+              floors: 19
+            }
+          }
         }
 
-        expect(street(existingStreet, addBuildingFloor('right'))).toEqual({
-          rightBuildingHeight: 20
-        })
+        const result = street(existingStreet, addBuildingFloor('right'))
+        expect(result.boundary.right.floors).toEqual(20)
       })
 
       it('will not increase a building height past maximum', () => {
         const existingStreet = {
-          rightBuildingHeight: 20
+          boundary: {
+            right: {
+              floors: 20
+            }
+          }
         }
 
-        expect(street(existingStreet, addBuildingFloor('right'))).toEqual({
-          rightBuildingHeight: 20
-        })
-      })
-
-      it('does nothing if position is not provided', () => {
-        const existingStreet = {
-          leftBuildingHeight: 1,
-          rightBuildingHeight: 1
-        }
-
-        expect(street(existingStreet, addBuildingFloor())).toEqual(
-          existingStreet
-        )
-      })
-
-      it('does nothing if an unknown position is provided', () => {
-        const existingStreet = {
-          leftBuildingHeight: 1,
-          rightBuildingHeight: 1
-        }
-
-        expect(street(existingStreet, addBuildingFloor('middle'))).toEqual(
-          existingStreet
-        )
+        const result = street(existingStreet, addBuildingFloor('right'))
+        expect(result.boundary.right.floors).toEqual(20)
       })
     })
 
     describe('removeBuildingFloor()', () => {
       it('removes a floor on the left building', () => {
         const existingStreet = {
-          leftBuildingHeight: 2
+          boundary: {
+            left: {
+              floors: 2
+            }
+          }
         }
 
-        expect(street(existingStreet, removeBuildingFloor('left'))).toEqual({
-          leftBuildingHeight: 1
-        })
+        const result = street(existingStreet, removeBuildingFloor('left'))
+        expect(result.boundary.left.floors).toEqual(1)
       })
 
       it('removes a floor on the right building', () => {
         const existingStreet = {
-          rightBuildingHeight: 19
+          boundary: {
+            right: {
+              floors: 19
+            }
+          }
         }
 
-        expect(street(existingStreet, removeBuildingFloor('right'))).toEqual({
-          rightBuildingHeight: 18
-        })
+        const result = street(existingStreet, removeBuildingFloor('right'))
+        expect(result.boundary.right.floors).toEqual(18)
       })
 
       it('will not decrease a building height past minimum', () => {
         const existingStreet = {
-          leftBuildingHeight: 1
+          boundary: {
+            left: {
+              floors: 1
+            }
+          }
         }
 
-        expect(street(existingStreet, removeBuildingFloor('left'))).toEqual({
-          leftBuildingHeight: 1
-        })
-      })
-
-      it('does nothing if position is not provided', () => {
-        const existingStreet = {
-          leftBuildingHeight: 1,
-          rightBuildingHeight: 1
-        }
-
-        expect(street(existingStreet, removeBuildingFloor())).toEqual(
-          existingStreet
-        )
-      })
-
-      it('does nothing if an unknown position is provided', () => {
-        const existingStreet = {
-          leftBuildingHeight: 1,
-          rightBuildingHeight: 1
-        }
-
-        expect(street(existingStreet, removeBuildingFloor('middle'))).toEqual(
-          existingStreet
-        )
+        const result = street(existingStreet, removeBuildingFloor('left'))
+        expect(result.boundary.left.floors).toEqual(1)
       })
     })
 
     describe('setBuildingFloorValue()', () => {
       it('sets a floor value on the left building', () => {
         const existingStreet = {
-          leftBuildingHeight: 1
+          boundary: {
+            left: {
+              floors: 1
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('left', 3))
-        ).toEqual({
-          leftBuildingHeight: 3
-        })
+        const result = street(existingStreet, setBuildingFloorValue('left', 3))
+        expect(result.boundary.left.floors).toEqual(3)
       })
 
       it('sets a floor value on the right building', () => {
         const existingStreet = {
-          rightBuildingHeight: 1
+          boundary: {
+            right: {
+              floors: 1
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', 1))
-        ).toEqual({
-          rightBuildingHeight: 1
-        })
+        const result = street(existingStreet, setBuildingFloorValue('right', 1))
+        expect(result.boundary.right.floors).toEqual(1)
       })
 
       it('will clamp a value to minimum', () => {
         const existingStreet = {
-          leftBuildingHeight: 20
+          boundary: {
+            left: {
+              floors: 20
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('left', 0))
-        ).toEqual({
-          leftBuildingHeight: 1
-        })
+        const result = street(existingStreet, setBuildingFloorValue('left', 0))
+        expect(result.boundary.left.floors).toEqual(1)
       })
 
       it('will clamp a value to maximum', () => {
         const existingStreet = {
-          rightBuildingHeight: 1
+          boundary: {
+            right: {
+              floors: 1
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', 1000))
-        ).toEqual({
-          rightBuildingHeight: 20
-        })
+        const result = street(
+          existingStreet,
+          setBuildingFloorValue('right', 1000)
+        )
+        expect(result.boundary.right.floors).toEqual(20)
       })
 
       it('refuses to set a value that is NaN', () => {
         const existingStreet = {
-          rightBuildingHeight: 5
+          boundary: {
+            right: {
+              floors: 5
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', NaN))
-        ).toEqual({
-          rightBuildingHeight: 5
-        })
+        const result = street(
+          existingStreet,
+          setBuildingFloorValue('right', NaN)
+        )
+        expect(result.boundary.right.floors).toEqual(5)
       })
 
       it('refuses to set a value that is falsy', () => {
         const existingStreet = {
-          leftBuildingHeight: 5
+          boundary: {
+            left: {
+              floors: 5
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('left', null))
-        ).toEqual({
-          leftBuildingHeight: 5
-        })
-
-        expect(
-          street(existingStreet, setBuildingFloorValue('left', false))
-        ).toEqual({
-          leftBuildingHeight: 5
-        })
-
+        // Only cover the empty string case because all other falsy values are
+        // type errors
         expect(
           street(existingStreet, setBuildingFloorValue('left', ''))
-        ).toEqual({
-          leftBuildingHeight: 5
-        })
-
-        expect(street(existingStreet, setBuildingFloorValue('left'))).toEqual({
-          leftBuildingHeight: 5
-        })
+        ).toEqual(existingStreet)
       })
 
       it('parses integer values from non-integer input', () => {
         const existingStreet = {
-          rightBuildingHeight: 5
+          boundary: {
+            right: {
+              floors: 5
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', 4.5))
-        ).toEqual({
-          rightBuildingHeight: 4
-        })
+        const result1 = street(
+          existingStreet,
+          setBuildingFloorValue('right', 4.5)
+        )
+        expect(result1.boundary.right.floors).toEqual(4)
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', '9'))
-        ).toEqual({
-          rightBuildingHeight: 9
-        })
+        const result2 = street(
+          existingStreet,
+          setBuildingFloorValue('right', '9')
+        )
+        expect(result2.boundary.right.floors).toEqual(9)
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', '6 floors'))
-        ).toEqual({
-          rightBuildingHeight: 6
-        })
+        const result3 = street(
+          existingStreet,
+          setBuildingFloorValue('right', '6 floors')
+        )
+        expect(result3.boundary.right.floors).toEqual(6)
       })
 
       it('does not set a value if integer value cannot be parsed from non-integer input', () => {
         const existingStreet = {
-          leftBuildingHeight: 5
+          boundary: {
+            left: {
+              floors: 5
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingFloorValue('right', 'foo'))
-        ).toEqual({
-          leftBuildingHeight: 5
-        })
-      })
-
-      it('does nothing if position is not provided', () => {
-        const existingStreet = {
-          leftBuildingHeight: 1,
-          rightBuildingHeight: 1
-        }
-
-        expect(street(existingStreet, setBuildingFloorValue())).toEqual(
-          existingStreet
+        const result = street(
+          existingStreet,
+          setBuildingFloorValue('right', 'foo')
         )
-      })
-
-      it('does nothing if an unknown position is provided', () => {
-        const existingStreet = {
-          leftBuildingHeight: 1,
-          rightBuildingHeight: 1
-        }
-
-        expect(street(existingStreet, setBuildingFloorValue('middle'))).toEqual(
-          existingStreet
-        )
+        expect(result.boundary.left.floors).toEqual(5)
       })
     })
 
     describe('setBuildingVariant()', () => {
       it('sets a variant on the left building', () => {
         const existingStreet = {
-          leftBuildingVariant: 'wide'
+          boundary: {
+            left: {
+              variant: 'wide'
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingVariant('left', 'narrow'))
-        ).toEqual({
-          leftBuildingVariant: 'narrow'
-        })
+        const result = street(
+          existingStreet,
+          setBuildingVariant('left', 'narrow')
+        )
+        expect(result.boundary.left.variant).toEqual('narrow')
       })
 
       it('sets a floor value on the right building', () => {
         const existingStreet = {
-          rightBuildingVariant: 'narrow'
+          boundary: {
+            right: {
+              variant: 'narrow'
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingVariant('right', 'wide'))
-        ).toEqual({
-          rightBuildingVariant: 'wide'
-        })
+        const result = street(
+          existingStreet,
+          setBuildingVariant('right', 'wide')
+        )
+        expect(result.boundary.right.variant).toEqual('wide')
       })
 
       it('refuses to set a value that is falsy', () => {
         const existingStreet = {
-          leftBuildingVariant: 'waterfront'
+          boundary: {
+            left: {
+              variant: 'waterfront'
+            }
+          }
         }
 
-        expect(
-          street(existingStreet, setBuildingVariant('left', null))
-        ).toEqual({
-          leftBuildingVariant: 'waterfront'
-        })
-
-        expect(
-          street(existingStreet, setBuildingVariant('left', false))
-        ).toEqual({
-          leftBuildingVariant: 'waterfront'
-        })
-
-        expect(street(existingStreet, setBuildingVariant('left', ''))).toEqual({
-          leftBuildingVariant: 'waterfront'
-        })
-
-        expect(street(existingStreet, setBuildingVariant('left'))).toEqual({
-          leftBuildingVariant: 'waterfront'
-        })
-      })
-
-      it('does nothing if position is not provided', () => {
-        const existingStreet = {
-          leftBuildingVariant: 'fence',
-          rightBuildingVariant: 'parking'
-        }
-
-        expect(street(existingStreet, setBuildingVariant())).toEqual(
-          existingStreet
-        )
-      })
-
-      it('does nothing if an unknown position is provided', () => {
-        const existingStreet = {
-          leftBuildingVariant: 'fence',
-          rightBuildingVariant: 'parking'
-        }
-
-        expect(street(existingStreet, setBuildingVariant('middle'))).toEqual(
-          existingStreet
-        )
+        // Only cover the empty string case because all other falsy values
+        // are type errors
+        const result = street(existingStreet, setBuildingVariant('left', ''))
+        expect(result.boundary.left.variant).toEqual('waterfront')
       })
     })
   })

--- a/client/src/store/slices/street.ts
+++ b/client/src/store/slices/street.ts
@@ -17,10 +17,20 @@ const initialState: StreetState = {
   width: 0,
   name: null,
   segments: [],
-  leftBuildingHeight: 0,
-  rightBuildingHeight: 0,
-  leftBuildingVariant: '',
-  rightBuildingVariant: '',
+  boundary: {
+    left: {
+      id: '',
+      variant: '',
+      floors: 0,
+      elevation: 0
+    },
+    right: {
+      id: '',
+      variant: '',
+      floors: 0,
+      elevation: 0
+    }
+  },
   skybox: DEFAULT_SKYBOX,
   location: null,
   showAnalytics: false,
@@ -318,14 +328,14 @@ const streetSlice = createSlice({
 
       switch (position) {
         case 'left':
-          state.leftBuildingHeight = Math.min(
-            state.leftBuildingHeight + 1,
+          state.boundary.left.floors = Math.min(
+            state.boundary.left.floors + 1,
             MAX_BUILDING_HEIGHT
           )
           break
         case 'right':
-          state.rightBuildingHeight = Math.min(
-            state.rightBuildingHeight + 1,
+          state.boundary.right.floors = Math.min(
+            state.boundary.right.floors + 1,
             MAX_BUILDING_HEIGHT
           )
           break
@@ -337,10 +347,16 @@ const streetSlice = createSlice({
 
       switch (position) {
         case 'left':
-          state.leftBuildingHeight = Math.max(state.leftBuildingHeight - 1, 1)
+          state.boundary.left.floors = Math.max(
+            state.boundary.left.floors - 1,
+            1
+          )
           break
         case 'right':
-          state.rightBuildingHeight = Math.max(state.rightBuildingHeight - 1, 1)
+          state.boundary.right.floors = Math.max(
+            state.boundary.right.floors - 1,
+            1
+          )
           break
       }
     },
@@ -357,13 +373,13 @@ const streetSlice = createSlice({
 
         switch (position) {
           case 'left':
-            state.leftBuildingHeight = Math.min(
+            state.boundary.left.floors = Math.min(
               Math.max(value, 1),
               MAX_BUILDING_HEIGHT
             )
             break
           case 'right':
-            state.rightBuildingHeight = Math.min(
+            state.boundary.right.floors = Math.min(
               Math.max(value, 1),
               MAX_BUILDING_HEIGHT
             )
@@ -388,10 +404,10 @@ const streetSlice = createSlice({
 
         switch (position) {
           case 'left':
-            state.leftBuildingVariant = variant
+            state.boundary.left.variant = variant
             break
           case 'right':
-            state.rightBuildingVariant = variant
+            state.boundary.right.variant = variant
             break
         }
       },

--- a/client/src/streets/__mocks__/street_template.yaml
+++ b/client/src/streets/__mocks__/street_template.yaml
@@ -5,13 +5,15 @@
 ###############################################################################
 
 width: 24
-edges:
+boundary:
   left:
     variant: narrow
-    height: 4
+    floors: 4
+    elevation: 1
   right:
     variant: wide
-    height: 3
+    floors: 3
+    elevation: 1
 slices:
   - type: sidewalk
     variant:

--- a/client/src/streets/data_model.js
+++ b/client/src/streets/data_model.js
@@ -35,7 +35,7 @@ export function setLastStreet () {
 }
 
 // Server is now the source of truth of this value
-const LATEST_SCHEMA_VERSION = 31
+const LATEST_SCHEMA_VERSION = 32
 
 // Do some work to update segment data, although they're not technically
 // part of the schema (yet?) -- carried over after moving bulk of
@@ -111,10 +111,7 @@ export function trimStreetData (street) {
     location: street.location,
     userUpdated: street.userUpdated,
     skybox: street.skybox,
-    leftBuildingHeight: street.leftBuildingHeight,
-    rightBuildingHeight: street.rightBuildingHeight,
-    leftBuildingVariant: street.leftBuildingVariant,
-    rightBuildingVariant: street.rightBuildingVariant,
+    boundary: street.boundary,
     segments: street.segments.map((origSegment) => {
       const segment = {
         id: origSegment.id,
@@ -233,10 +230,6 @@ export function createStreetData (data, units) {
     updatedAt: currentDate,
     clientUpdatedAt: currentDate,
     creatorId,
-    leftBuildingHeight: data.boundary.left.floors,
-    leftBuildingVariant: data.boundary.left.variant,
-    rightBuildingHeight: data.boundary.right.floors,
-    rightBuildingVariant: data.boundary.right.variant,
     ...data
   }
 

--- a/client/src/streets/data_model.js
+++ b/client/src/streets/data_model.js
@@ -233,15 +233,18 @@ export function createStreetData (data, units) {
     updatedAt: currentDate,
     clientUpdatedAt: currentDate,
     creatorId,
-    leftBuildingHeight: data.edges.left.height,
-    leftBuildingVariant: data.edges.left.variant,
-    rightBuildingHeight: data.edges.right.height,
-    rightBuildingVariant: data.edges.right.variant,
+    leftBuildingHeight: data.boundary.left.floors,
+    leftBuildingVariant: data.boundary.left.variant,
+    rightBuildingHeight: data.boundary.right.floors,
+    rightBuildingVariant: data.boundary.right.variant,
     ...data
   }
 
+  // Create boundary ids
+  street.boundary.left.id = nanoid()
+  street.boundary.right.id = nanoid()
+
   // Cleanup
-  delete street.edges
   delete street.slices
 
   if (units === SETTINGS_UNITS_IMPERIAL) {

--- a/client/src/streets/data_model.test.js
+++ b/client/src/streets/data_model.test.js
@@ -12,10 +12,16 @@ function partialStreetDataForSnapshot (data) {
   return {
     units: data.units,
     width: data.width,
-    leftBuildingHeight: data.leftBuildingHeight,
-    leftBuildingVariant: data.leftBuildingVariant,
-    rightBuildingHeight: data.rightBuildingHeight,
-    rightBuildingVariant: data.rightBuildingVariant,
+    boundary: {
+      left: {
+        ...data.boundary.left,
+        id: 'left' // Use non-random ID
+      },
+      right: {
+        ...data.boundary.right,
+        id: 'right' // Use non-random ID
+      }
+    },
     segments: data.segments.map((slice, i) => ({
       id: `segment_${i}`, // Placeholder ID number
       type: slice.type,
@@ -33,10 +39,20 @@ describe('createStreetData()', () => {
     const snapshot = partialStreetDataForSnapshot(data)
     expect(snapshot).toMatchInlineSnapshot(`
       {
-        "leftBuildingHeight": 4,
-        "leftBuildingVariant": "narrow",
-        "rightBuildingHeight": 3,
-        "rightBuildingVariant": "wide",
+        "boundary": {
+          "left": {
+            "elevation": 1,
+            "floors": 4,
+            "id": "left",
+            "variant": "narrow",
+          },
+          "right": {
+            "elevation": 1,
+            "floors": 3,
+            "id": "right",
+            "variant": "wide",
+          },
+        },
         "segments": [
           {
             "elevation": 1,
@@ -138,10 +154,20 @@ describe('createStreetData()', () => {
     // adjusted so they create cleaner conversion to feet and inches.
     expect(snapshot).toMatchInlineSnapshot(`
       {
-        "leftBuildingHeight": 4,
-        "leftBuildingVariant": "narrow",
-        "rightBuildingHeight": 3,
-        "rightBuildingVariant": "wide",
+        "boundary": {
+          "left": {
+            "elevation": 1,
+            "floors": 4,
+            "id": "left",
+            "variant": "narrow",
+          },
+          "right": {
+            "elevation": 1,
+            "floors": 3,
+            "id": "right",
+            "variant": "wide",
+          },
+        },
         "segments": [
           {
             "elevation": 1,
@@ -246,10 +272,20 @@ describe('createStreetData()', () => {
     // and vice versa
     expect(snapshot).toMatchInlineSnapshot(`
       {
-        "leftBuildingHeight": 4,
-        "leftBuildingVariant": "narrow",
-        "rightBuildingHeight": 3,
-        "rightBuildingVariant": "wide",
+        "boundary": {
+          "left": {
+            "elevation": 1,
+            "floors": 4,
+            "id": "left",
+            "variant": "narrow",
+          },
+          "right": {
+            "elevation": 1,
+            "floors": 3,
+            "id": "right",
+            "variant": "wide",
+          },
+        },
         "segments": [
           {
             "elevation": 1,

--- a/client/src/streets/image.js
+++ b/client/src/streets/image.js
@@ -27,14 +27,14 @@ export function getStreetImage (
   const width = TILE_SIZE * street.width + BUILDING_SPACE * 2
 
   const leftHeight = getBuildingImageHeight(
-    street.leftBuildingVariant,
+    street.boundary.left.variant,
     'left',
-    street.leftBuildingHeight
+    street.boundary.left.floors
   )
   const rightHeight = getBuildingImageHeight(
-    street.rightBuildingVariant,
+    street.boundary.right.variant,
     'right',
-    street.rightBuildingHeight
+    street.boundary.right.floors
   )
 
   let height = Math.max(leftHeight, rightHeight)

--- a/client/src/streets/street.js
+++ b/client/src/streets/street.js
@@ -9,10 +9,7 @@ export function initStreetDataChangedListener () {
   // We create a string representation of the values we need to compare
   const select = (state) =>
     JSON.stringify({
-      leftBuildingHeight: state.street.leftBuildingHeight,
-      leftBuildingVariant: state.street.leftBuildingVariant,
-      rightBuildingHeight: state.street.rightBuildingHeight,
-      rightBuildingVariant: state.street.rightBuildingVariant,
+      boundary: state.street.boundary,
       name: state.street.name,
       location: state.street.location,
       skybox: state.street.skybox

--- a/client/src/streets/templates/default.yaml
+++ b/client/src/streets/templates/default.yaml
@@ -9,13 +9,15 @@
 ###############################################################################
 
 width: 24
-edges:
+boundary:
   left:
     variant: narrow
-    height: 4
+    floors: 4
+    elevation: 1
   right:
     variant: wide
-    height: 3
+    floors: 3
+    elevation: 1
 slices:
   - type: sidewalk
     variant:

--- a/client/src/streets/templates/empty.yaml
+++ b/client/src/streets/templates/empty.yaml
@@ -8,11 +8,13 @@
 ###############################################################################
 
 width: 24
-edges:
+boundary:
   left:
     variant: grass
-    height: 1
+    floors: 1
+    elevation: 1
   right:
     variant: grass
-    height: 1
+    floors: 1
+    elevation: 1
 slices: []

--- a/client/src/streets/thumbnail.js
+++ b/client/src/streets/thumbnail.js
@@ -334,15 +334,20 @@ function drawBuildings (
 
   // Left building
   const x1 = width / 2 - (street.width * TILE_SIZE * multiplier) / 2
-  const leftBuilding = BUILDINGS[street.leftBuildingVariant]
+  // Keep deprecated properties here because gallery streets are transmitted
+  // without updating schemas
+  const leftVariant =
+    street.boundary?.left.variant ?? street.leftBuildingVariant
+  const leftFloors = street.boundary?.left.floors ?? street.leftBuildingHeight
+  const leftBuilding = BUILDINGS[leftVariant]
   const leftOverhang =
     typeof leftBuilding.overhangWidth === 'number'
       ? leftBuilding.overhangWidth
       : 0
   drawBuilding(
     ctx,
-    street.leftBuildingVariant,
-    street.leftBuildingHeight,
+    leftVariant,
+    leftFloors,
     'left',
     buildingWidth,
     groundLevel,
@@ -353,15 +358,21 @@ function drawBuildings (
 
   // Right building
   const x2 = width / 2 + (street.width * TILE_SIZE * multiplier) / 2
-  const rightBuilding = BUILDINGS[street.rightBuildingVariant]
+  // Keep deprecated properties here because gallery streets are transmitted
+  // without updating schemas
+  const rightVariant =
+    street.boundary?.right.variant ?? street.rightBuildingVariant
+  const rightFloors =
+    street.boundary?.right.floors ?? street.rightBuildingHeight
+  const rightBuilding = BUILDINGS[rightVariant]
   const rightOverhang =
     typeof rightBuilding.overhangWidth === 'number'
       ? rightBuilding.overhangWidth
       : 0
   drawBuilding(
     ctx,
-    street.rightBuildingVariant,
-    street.rightBuildingHeight,
+    rightVariant,
+    rightFloors,
     'right',
     buildingWidth,
     groundLevel,

--- a/client/src/streets/xhr.js
+++ b/client/src/streets/xhr.js
@@ -1,5 +1,4 @@
 import clone from 'just-clone'
-import { nanoid } from 'nanoid'
 import { showError, ERRORS } from '../app/errors'
 import {
   checkIfEverythingIsLoaded,
@@ -265,24 +264,6 @@ function unpackStreetDataFromServerTransmission (transmission) {
   street.name = transmission.name ?? null
   street.location = transmission.data.street.location ?? null
   street.editCount = transmission.data.street.editCount ?? 0
-
-  // Add boundary object if not present
-  if (street.boundary === undefined) {
-    street.boundary = {
-      left: {
-        id: nanoid(),
-        variant: street.leftBuildingVariant,
-        floors: street.leftBuildingHeight,
-        elevation: 1
-      },
-      right: {
-        id: nanoid(),
-        variant: street.rightBuildingVariant,
-        floors: street.rightBuildingHeight,
-        elevation: 1
-      }
-    }
-  }
 
   // Delete deprecated properties, if present
   delete street.leftBuildingVariant

--- a/client/src/streets/xhr.js
+++ b/client/src/streets/xhr.js
@@ -1,4 +1,5 @@
 import clone from 'just-clone'
+import { nanoid } from 'nanoid'
 import { showError, ERRORS } from '../app/errors'
 import {
   checkIfEverythingIsLoaded,
@@ -264,6 +265,30 @@ function unpackStreetDataFromServerTransmission (transmission) {
   street.name = transmission.name ?? null
   street.location = transmission.data.street.location ?? null
   street.editCount = transmission.data.street.editCount ?? 0
+
+  // Add boundary object if not present
+  if (street.boundary === undefined) {
+    street.boundary = {
+      left: {
+        id: nanoid(),
+        variant: street.leftBuildingVariant,
+        floors: street.leftBuildingHeight,
+        elevation: 1
+      },
+      right: {
+        id: nanoid(),
+        variant: street.rightBuildingVariant,
+        floors: street.rightBuildingHeight,
+        elevation: 1
+      }
+    }
+  }
+
+  // Delete deprecated properties, if present
+  delete street.leftBuildingVariant
+  delete street.leftBuildingHeight
+  delete street.rightBuildingVariant
+  delete street.rightBuildingHeight
 
   return street
 }

--- a/client/test/fixtures/street.json
+++ b/client/test/fixtures/street.json
@@ -19,10 +19,18 @@
       },
       "userUpdated": false,
       "skybox": "day",
-      "leftBuildingHeight": 3,
-      "rightBuildingHeight": 2,
-      "leftBuildingVariant": "narrow",
-      "rightBuildingVariant": "wide",
+      "boundary": {
+        "left": {
+          "variant": "narrow",
+          "floors": 3,
+          "elevation": 1
+        },
+        "right": {
+          "variant": "wide",
+          "floors": 2,
+          "elevation": 1
+        }
+      },
       "segments": ["Object", "Object"],
       "editCount": 33
     }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -19,6 +19,13 @@ export interface Segment {
 }
 export type SliceItem = Segment // Alias for future use
 
+export interface StreetBoundary {
+  id: string
+  variant: string
+  floors: number
+  elevation: number
+}
+
 export interface StreetJson {
   id: string
   namespacedId: number
@@ -26,10 +33,14 @@ export interface StreetJson {
   units: UnitsSetting
   width: number
   segments: Segment[]
-  leftBuildingHeight: number
-  rightBuildingHeight: number
-  leftBuildingVariant: string
-  rightBuildingVariant: string
+  leftBuildingHeight: number // Deprecated
+  rightBuildingHeight: number // Deprecated
+  leftBuildingVariant: string // Deprecated
+  rightBuildingVariant: string // Deprecated
+  boundary: {
+    left: StreetBoundary
+    right: StreetBoundary
+  }
   skybox: string
   location: StreetLocation | null
   showAnalytics: boolean
@@ -86,10 +97,14 @@ export interface StreetState extends StreetJsonExtra {
   width: number
   name: string | null
   segments: Segment[]
-  leftBuildingHeight: number
-  rightBuildingHeight: number
-  leftBuildingVariant: string
-  rightBuildingVariant: string
+  leftBuildingHeight: number // Deprecated
+  rightBuildingHeight: number // Deprecated
+  leftBuildingVariant: string // Deprecated
+  rightBuildingVariant: string // Deprecated
+  boundary: {
+    left: StreetBoundary
+    right: StreetBoundary
+  }
   skybox: string
   location: StreetLocation | null
   showAnalytics: boolean

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -33,10 +33,10 @@ export interface StreetJson {
   units: UnitsSetting
   width: number
   segments: Segment[]
-  leftBuildingHeight: number // Deprecated
-  rightBuildingHeight: number // Deprecated
-  leftBuildingVariant: string // Deprecated
-  rightBuildingVariant: string // Deprecated
+  leftBuildingHeight?: number // Deprecated
+  rightBuildingHeight?: number // Deprecated
+  leftBuildingVariant?: string // Deprecated
+  rightBuildingVariant?: string // Deprecated
   boundary: {
     left: StreetBoundary
     right: StreetBoundary
@@ -97,10 +97,6 @@ export interface StreetState extends StreetJsonExtra {
   width: number
   name: string | null
   segments: Segment[]
-  leftBuildingHeight: number // Deprecated
-  rightBuildingHeight: number // Deprecated
-  leftBuildingVariant: string // Deprecated
-  rightBuildingVariant: string // Deprecated
   boundary: {
     left: StreetBoundary
     right: StreetBoundary


### PR DESCRIPTION
This replaces the properties `leftBuildingVariant`, `leftBuildingHeight`, `rightBuildingVariant` and `rightBuildingHeight` with a new object `boundary`. The boundary object contains two child objects, `left` and `right`, which hold properties related to the sides of the street section.

With this change, the terminology `building` is replaced with `boundary` because not all street sections are bounded by buildings. The "building height" terminology is also replaced by `floors` which more accurately describes what that value is.

Behavior should remain the same, e.g. not all boundary variants handle `floors` as an input.

By moving to this data format, new properties for different boundary variants are more scalable. Two new properties are included here (though are currently unused for any purpose): `id`, which (similarly to segments/slices), is a randomly-generated string that can assist with random seeding, and `elevation`, which (in the future) can allow for boundaries to be rendered at arbitrary heights.

For compatibility purposes, the four legacy properties will continue to be exposed when reading streets via API. Note that the legacy properties will not be exposed through the gallery endpoint, and streets that have not been accessed directly through the street API will not be updated to the latest schema.