### PR TITLE
a11y: Add focus trapping on dialogs to improve keyboard/screen reader navigation

### DIFF
--- a/client/src/dialogs/About/AboutDialog.tsx
+++ b/client/src/dialogs/About/AboutDialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useRef } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import logo from 'url:~/images/logo_horizontal.svg'
@@ -15,9 +15,10 @@ import './AboutDialog.css'
 export function AboutDialog() {
   const offline = useSelector((state) => state.system.offline)
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="about-dialog">
           <header>
@@ -26,7 +27,7 @@ export function AboutDialog() {
               alt="Streetmix (logo)"
               className="about-dialog-logo"
             />
-            <h1 id={dialogTitleId}>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="dialogs.about.heading"
                 defaultMessage="About Streetmix."

--- a/client/src/dialogs/About/AboutDialog.tsx
+++ b/client/src/dialogs/About/AboutDialog.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import logo from 'url:~/images/logo_horizontal.svg'
@@ -13,9 +14,10 @@ import './AboutDialog.css'
 
 export function AboutDialog() {
   const offline = useSelector((state) => state.system.offline)
+  const dialogTitleId = useId()
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="about-dialog">
           <header>
@@ -24,7 +26,7 @@ export function AboutDialog() {
               alt="Streetmix (logo)"
               className="about-dialog-logo"
             />
-            <h1>
+            <h1 id={dialogTitleId}>
               <FormattedMessage
                 id="dialogs.about.heading"
                 defaultMessage="About Streetmix."

--- a/client/src/dialogs/About/__snapshots__/AboutDialog.test.tsx.snap
+++ b/client/src/dialogs/About/__snapshots__/AboutDialog.test.tsx.snap
@@ -37,6 +37,7 @@ exports[`AboutDialog > renders snapshot 1`] = `
             />
             <h1
               id="_r_0_"
+              tabindex="-1"
             >
               About Streetmix.
             </h1>

--- a/client/src/dialogs/About/__snapshots__/AboutDialog.test.tsx.snap
+++ b/client/src/dialogs/About/__snapshots__/AboutDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`AboutDialog > renders snapshot 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-labelledby="_r_0_"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"
@@ -32,7 +35,9 @@ exports[`AboutDialog > renders snapshot 1`] = `
               class="about-dialog-logo"
               src="test-file-stub"
             />
-            <h1>
+            <h1
+              id="_r_0_"
+            >
               About Streetmix.
             </h1>
           </header>

--- a/client/src/dialogs/Analytics/AnalyticsDialog.tsx
+++ b/client/src/dialogs/Analytics/AnalyticsDialog.tsx
@@ -28,6 +28,7 @@ export function AnalyticsDialog() {
   const dispatch = useDispatch()
   const intl = useIntl()
   const max = useRef(0)
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
   const dialogTitleId = useId()
 
   const [isVisible, setVisible] = useState(street.showAnalytics)
@@ -103,11 +104,11 @@ export function AnalyticsDialog() {
   }
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="analytics-dialog">
           <header>
-            <h1 id={dialogTitleId}>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="dialogs.analytics.heading"
                 defaultMessage="Analytics"

--- a/client/src/dialogs/Analytics/AnalyticsDialog.tsx
+++ b/client/src/dialogs/Analytics/AnalyticsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useId } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 
 import { useSelector, useDispatch } from '~/src/store/hooks.js'
@@ -28,6 +28,7 @@ export function AnalyticsDialog() {
   const dispatch = useDispatch()
   const intl = useIntl()
   const max = useRef(0)
+  const dialogTitleId = useId()
 
   const [isVisible, setVisible] = useState(street.showAnalytics)
   const toggleVisible = () => {
@@ -102,11 +103,11 @@ export function AnalyticsDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="analytics-dialog">
           <header>
-            <h1>
+            <h1 id={dialogTitleId}>
               <FormattedMessage
                 id="dialogs.analytics.heading"
                 defaultMessage="Analytics"

--- a/client/src/dialogs/Analytics/__snapshots__/AnalyticsDialog.test.tsx.snap
+++ b/client/src/dialogs/Analytics/__snapshots__/AnalyticsDialog.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`AnalyticsDialog > renders snapshot 1`] = `
           <header>
             <h1
               id="_r_0_"
+              tabindex="-1"
             >
               Analytics
             </h1>

--- a/client/src/dialogs/Analytics/__snapshots__/AnalyticsDialog.test.tsx.snap
+++ b/client/src/dialogs/Analytics/__snapshots__/AnalyticsDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`AnalyticsDialog > renders snapshot 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-labelledby="_r_0_"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"
@@ -27,7 +30,9 @@ exports[`AnalyticsDialog > renders snapshot 1`] = `
           class="analytics-dialog"
         >
           <header>
-            <h1>
+            <h1
+              id="_r_0_"
+            >
               Analytics
             </h1>
           </header>
@@ -172,11 +177,11 @@ exports[`AnalyticsDialog > renders snapshot 1`] = `
                 class="checkbox-item"
               >
                 <input
-                  id="_r_0_"
+                  id="_r_1_"
                   type="checkbox"
                 />
                 <label
-                  for="_r_0_"
+                  for="_r_1_"
                 >
                   Show capacity counts in segment labels
                 </label>

--- a/client/src/dialogs/CoastmixTutorial.tsx
+++ b/client/src/dialogs/CoastmixTutorial.tsx
@@ -1,15 +1,18 @@
+import { useId } from 'react'
 import { CoastmixPracticeTour } from '~/src/ui/Tours/CoastmixPractice.js'
 import { Button } from '~/src/ui/Button.js'
 import { Dialog } from './Dialog.js'
 import './CoastmixTutorial.css'
 
 export function CoastmixTutorialComplete() {
+  const dialogTitleId = useId()
+
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="dialog-coastmix-tutorial-complete">
           <header>
-            <h2>Tutorial complete!</h2>
+            <h2 id={dialogTitleId}>Tutorial complete!</h2>
           </header>
 
           <div className="dialog-content">

--- a/client/src/dialogs/CoastmixTutorial.tsx
+++ b/client/src/dialogs/CoastmixTutorial.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useRef } from 'react'
 import { CoastmixPracticeTour } from '~/src/ui/Tours/CoastmixPractice.js'
 import { Button } from '~/src/ui/Button.js'
 import { Dialog } from './Dialog.js'
@@ -6,13 +6,16 @@ import './CoastmixTutorial.css'
 
 export function CoastmixTutorialComplete() {
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="dialog-coastmix-tutorial-complete">
           <header>
-            <h2 id={dialogTitleId}>Tutorial complete!</h2>
+            <h2 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
+              Tutorial complete!
+            </h2>
           </header>
 
           <div className="dialog-content">

--- a/client/src/dialogs/Dialog.test.tsx
+++ b/client/src/dialogs/Dialog.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react'
 import { fireEvent, within } from '@testing-library/react'
 import { render } from '~/test/helpers/render.js'
 import { Dialog } from './Dialog.js'
@@ -24,6 +25,7 @@ describe('Dialog', () => {
 
     expect(dialog).toHaveAttribute('aria-modal', 'true')
     expect(dialog).toHaveAttribute('tabindex', '-1')
+    expect(dialog).toHaveFocus()
   })
 
   it('accepts accessible name props', () => {
@@ -38,13 +40,39 @@ describe('Dialog', () => {
     expect(dialog).toHaveAttribute('aria-label', 'Fallback label')
   })
 
+  it('focuses the provided initial focus element on open', () => {
+    const titleRef = createRef<HTMLHeadingElement>()
+    const { getByRole, getByText } = render(
+      <Dialog initialFocusRef={titleRef}>
+        {() => (
+          <>
+            <h1 ref={titleRef} tabIndex={-1}>
+              Dialog heading
+            </h1>
+            <button>First</button>
+          </>
+        )}
+      </Dialog>
+    )
+
+    const dialog = getByRole('dialog')
+    const [closeButton] = within(dialog).getAllByRole('button')
+
+    expect(dialog).not.toHaveFocus()
+    expect(getByText('Dialog heading')).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(closeButton).toHaveFocus()
+  })
+
   it('traps focus when tabbing from the last focusable element', () => {
     const { getByRole } = render(<Dialog>{() => <FocusableContents />}</Dialog>)
     const dialog = getByRole('dialog')
     const [closeButton, firstButton, lastButton] =
       within(dialog).getAllByRole('button')
 
-    expect(closeButton).toHaveFocus()
+    expect(dialog).toHaveFocus()
     firstButton.focus()
     expect(firstButton).toHaveFocus()
 
@@ -61,6 +89,7 @@ describe('Dialog', () => {
     const closeButton = buttons[0]
     const lastButton = buttons[2]
 
+    closeButton.focus()
     expect(closeButton).toHaveFocus()
 
     fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })

--- a/client/src/dialogs/Dialog.test.tsx
+++ b/client/src/dialogs/Dialog.test.tsx
@@ -1,13 +1,85 @@
+import { fireEvent, within } from '@testing-library/react'
 import { render } from '~/test/helpers/render.js'
 import { Dialog } from './Dialog.js'
 
 const Contents = () => <>foo</>
+const FocusableContents = () => (
+  <>
+    <button>First</button>
+    <button>Last</button>
+  </>
+)
+const LabeledContents = () => <h1 id="dialog-test-title">Dialog heading</h1>
 
 describe('Dialog', () => {
   it('renders', () => {
     const { getByRole } = render(<Dialog>{() => <Contents />}</Dialog>)
 
     expect(getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('sets modal semantics and a focus target', () => {
+    const { getByRole } = render(<Dialog>{() => <Contents />}</Dialog>)
+    const dialog = getByRole('dialog')
+
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('accepts accessible name props', () => {
+    const { getByRole } = render(
+      <Dialog ariaLabelledBy="dialog-test-title" ariaLabel="Fallback label">
+        {() => <LabeledContents />}
+      </Dialog>
+    )
+    const dialog = getByRole('dialog')
+
+    expect(dialog).toHaveAttribute('aria-labelledby', 'dialog-test-title')
+    expect(dialog).toHaveAttribute('aria-label', 'Fallback label')
+  })
+
+  it('traps focus when tabbing from the last focusable element', () => {
+    const { getByRole } = render(<Dialog>{() => <FocusableContents />}</Dialog>)
+    const dialog = getByRole('dialog')
+    const [closeButton, firstButton, lastButton] =
+      within(dialog).getAllByRole('button')
+
+    expect(closeButton).toHaveFocus()
+    firstButton.focus()
+    expect(firstButton).toHaveFocus()
+
+    lastButton.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+
+    expect(closeButton).toHaveFocus()
+  })
+
+  it('traps focus when shift-tabbing from the first focusable element', () => {
+    const { getByRole } = render(<Dialog>{() => <FocusableContents />}</Dialog>)
+    const dialog = getByRole('dialog')
+    const buttons = within(dialog).getAllByRole('button')
+    const closeButton = buttons[0]
+    const lastButton = buttons[2]
+
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+
+    expect(lastButton).toHaveFocus()
+  })
+
+  it('returns focus to the previously focused element on unmount', () => {
+    const opener = document.createElement('button')
+    opener.textContent = 'Open dialog'
+    document.body.append(opener)
+    opener.focus()
+
+    const { unmount } = render(<Dialog>{() => <Contents />}</Dialog>)
+
+    unmount()
+    expect(opener).toHaveFocus()
+
+    opener.remove()
   })
 
   // These can't be tested right now because it CSSTransition is mocked

--- a/client/src/dialogs/Dialog.tsx
+++ b/client/src/dialogs/Dialog.tsx
@@ -28,6 +28,7 @@ interface DialogProps {
   children: (arg: CloseFunction) => React.ReactElement
   ariaLabelledBy?: string
   ariaLabel?: string
+  initialFocusRef?: React.RefObject<HTMLElement | null>
 }
 
 const FOCUSABLE_SELECTORS = [
@@ -39,7 +40,12 @@ const FOCUSABLE_SELECTORS = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(', ')
 
-export function Dialog({ children, ariaLabelledBy, ariaLabel }: DialogProps) {
+export function Dialog({
+  children,
+  ariaLabelledBy,
+  ariaLabel,
+  initialFocusRef,
+}: DialogProps) {
   // Appear state controls transition in/out
   const dialogEl = useRef<HTMLDivElement>(null)
   const nodeRef = useRef(null)
@@ -97,17 +103,16 @@ export function Dialog({ children, ariaLabelledBy, ariaLabel }: DialogProps) {
       })
     }
 
-    const focusFirstElement = () => {
-      const focusableElements = getFocusableElements()
-      const firstElement = focusableElements[0] ?? dialogEl.current
-      firstElement?.focus()
+    const focusDialog = () => {
+      const initialFocusElement = initialFocusRef?.current ?? dialogEl.current
+      initialFocusElement?.focus()
     }
 
     previousActiveElementRef.current =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null
-    focusFirstElement()
+    focusDialog()
 
     const handleDialogTab = (event: KeyboardEvent) => {
       if (event.key !== 'Tab' || !dialogEl.current) return
@@ -124,7 +129,17 @@ export function Dialog({ children, ariaLabelledBy, ariaLabel }: DialogProps) {
       const lastElement = focusableElements[focusableElements.length - 1]
       const activeElement = document.activeElement
 
-      if (!event.shiftKey && activeElement === lastElement) {
+      if (
+        activeElement instanceof HTMLElement &&
+        !focusableElements.includes(activeElement)
+      ) {
+        event.preventDefault()
+        if (event.shiftKey) {
+          lastElement.focus()
+        } else {
+          firstElement.focus()
+        }
+      } else if (!event.shiftKey && activeElement === lastElement) {
         event.preventDefault()
         firstElement.focus()
       } else if (event.shiftKey && activeElement === firstElement) {

--- a/client/src/dialogs/Dialog.tsx
+++ b/client/src/dialogs/Dialog.tsx
@@ -26,12 +26,24 @@ import './Dialog.css'
 type CloseFunction = () => void
 interface DialogProps {
   children: (arg: CloseFunction) => React.ReactElement
+  ariaLabelledBy?: string
+  ariaLabel?: string
 }
 
-export function Dialog({ children }: DialogProps) {
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+export function Dialog({ children, ariaLabelledBy, ariaLabel }: DialogProps) {
   // Appear state controls transition in/out
   const dialogEl = useRef<HTMLDivElement>(null)
   const nodeRef = useRef(null)
+  const previousActiveElementRef = useRef<HTMLElement | null>(null)
   const [appear, setAppear] = useState(true)
   const dispatch = useDispatch()
 
@@ -57,6 +69,92 @@ export function Dialog({ children }: DialogProps) {
     dispatch(clearDialogs())
   }
 
+  useEffect(() => {
+    const getFocusableElements = (): HTMLElement[] => {
+      if (!dialogEl.current) return []
+
+      return Array.from(
+        dialogEl.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+      ).filter((element) => {
+        if (element.hasAttribute('disabled')) return false
+        if (element.hasAttribute('hidden')) return false
+        if (element.getAttribute('aria-hidden') === 'true') return false
+        if (element.getAttribute('aria-disabled') === 'true') return false
+        if (
+          element instanceof HTMLInputElement &&
+          element.getAttribute('type') === 'hidden'
+        ) {
+          return false
+        }
+        const computedStyles = window.getComputedStyle(element)
+        if (
+          computedStyles.display === 'none' ||
+          computedStyles.visibility === 'hidden'
+        ) {
+          return false
+        }
+        return true
+      })
+    }
+
+    const focusFirstElement = () => {
+      const focusableElements = getFocusableElements()
+      const firstElement = focusableElements[0] ?? dialogEl.current
+      firstElement?.focus()
+    }
+
+    previousActiveElementRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    focusFirstElement()
+
+    const handleDialogTab = (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || !dialogEl.current) return
+
+      const focusableElements = getFocusableElements()
+
+      if (focusableElements.length === 0) {
+        event.preventDefault()
+        dialogEl.current.focus()
+        return
+      }
+
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
+      const activeElement = document.activeElement
+
+      if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault()
+        firstElement.focus()
+      } else if (event.shiftKey && activeElement === firstElement) {
+        event.preventDefault()
+        lastElement.focus()
+      } else if (
+        activeElement instanceof Node &&
+        !dialogEl.current.contains(activeElement)
+      ) {
+        event.preventDefault()
+        firstElement.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleDialogTab)
+
+    return () => {
+      document.removeEventListener('keydown', handleDialogTab)
+
+      if (
+        previousActiveElementRef.current &&
+        document.contains(previousActiveElementRef.current)
+      ) {
+        previousActiveElementRef.current.focus()
+      } else {
+        document.body.focus()
+      }
+    }
+  }, [])
+
   return (
     <CSSTransition
       appear
@@ -69,7 +167,15 @@ export function Dialog({ children }: DialogProps) {
       <div className="dialog-box-container" ref={nodeRef}>
         <div className="dialog-box-backdrop" />
         <div className="dialog-box-display-area">
-          <div className="dialog-box" role="dialog" ref={dialogEl}>
+          <div
+            className="dialog-box"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={ariaLabelledBy}
+            aria-label={ariaLabel}
+            tabIndex={-1}
+            ref={dialogEl}
+          >
             <CloseButton onClick={handleClose} />
             {children(handleClose)}
           </div>

--- a/client/src/dialogs/ErrorDialog.tsx
+++ b/client/src/dialogs/ErrorDialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useRef } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import { ExternalLink } from '../ui/ExternalLink.js'
@@ -13,13 +13,14 @@ import './ErrorDialog.css'
  */
 export function ErrorDialog() {
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="dialog-error">
           <header>
-            <h1 id={dialogTitleId}>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="dialogs.error.heading"
                 defaultMessage="Oops!"

--- a/client/src/dialogs/ErrorDialog.tsx
+++ b/client/src/dialogs/ErrorDialog.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import { ExternalLink } from '../ui/ExternalLink.js'
@@ -11,12 +12,14 @@ import './ErrorDialog.css'
  * If _this_ component throws an error, the universe blows up.
  */
 export function ErrorDialog() {
+  const dialogTitleId = useId()
+
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="dialog-error">
           <header>
-            <h1>
+            <h1 id={dialogTitleId}>
               <FormattedMessage
                 id="dialogs.error.heading"
                 defaultMessage="Oops!"

--- a/client/src/dialogs/FeatureFlag/FeatureFlagDialog.tsx
+++ b/client/src/dialogs/FeatureFlag/FeatureFlagDialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useRef } from 'react'
 
 import { useSelector, useDispatch } from '~/src/store/hooks.js'
 import { setFeatureFlag } from '~/src/store/slices/flags.js'
@@ -10,6 +10,7 @@ export function FeatureFlagDialog() {
   const flags = useSelector((state) => state.flags)
   const dispatch = useDispatch()
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   function renderFlagList(): React.ReactElement[] {
     return Object.entries(flags).map(([key, flag]) => {
@@ -39,11 +40,13 @@ export function FeatureFlagDialog() {
   }
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="feature-flag-dialog" dir="ltr">
           <header>
-            <h1 id={dialogTitleId}>Feature flags</h1>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
+              Feature flags
+            </h1>
           </header>
           <div className="dialog-content">
             <ul>{renderFlagList()}</ul>

--- a/client/src/dialogs/FeatureFlag/FeatureFlagDialog.tsx
+++ b/client/src/dialogs/FeatureFlag/FeatureFlagDialog.tsx
@@ -1,3 +1,5 @@
+import { useId } from 'react'
+
 import { useSelector, useDispatch } from '~/src/store/hooks.js'
 import { setFeatureFlag } from '~/src/store/slices/flags.js'
 import { Checkbox } from '~/src/ui/Checkbox.js'
@@ -7,6 +9,7 @@ import './FeatureFlagDialog.css'
 export function FeatureFlagDialog() {
   const flags = useSelector((state) => state.flags)
   const dispatch = useDispatch()
+  const dialogTitleId = useId()
 
   function renderFlagList(): React.ReactElement[] {
     return Object.entries(flags).map(([key, flag]) => {
@@ -36,11 +39,11 @@ export function FeatureFlagDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="feature-flag-dialog" dir="ltr">
           <header>
-            <h1>Feature flags</h1>
+            <h1 id={dialogTitleId}>Feature flags</h1>
           </header>
           <div className="dialog-content">
             <ul>{renderFlagList()}</ul>

--- a/client/src/dialogs/FeatureFlag/__snapshots__/FeatureFlagDialog.test.tsx.snap
+++ b/client/src/dialogs/FeatureFlag/__snapshots__/FeatureFlagDialog.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`FeatureFlagDialog > renders 1`] = `
           <header>
             <h1
               id="_r_0_"
+              tabindex="-1"
             >
               Feature flags
             </h1>

--- a/client/src/dialogs/FeatureFlag/__snapshots__/FeatureFlagDialog.test.tsx.snap
+++ b/client/src/dialogs/FeatureFlag/__snapshots__/FeatureFlagDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`FeatureFlagDialog > renders 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-labelledby="_r_0_"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"
@@ -28,7 +31,9 @@ exports[`FeatureFlagDialog > renders 1`] = `
           dir="ltr"
         >
           <header>
-            <h1>
+            <h1
+              id="_r_0_"
+            >
               Feature flags
             </h1>
           </header>
@@ -42,11 +47,11 @@ exports[`FeatureFlagDialog > renders 1`] = `
                 >
                   <input
                     checked=""
-                    id="_r_0_"
+                    id="_r_1_"
                     type="checkbox"
                   />
                   <label
-                    for="_r_0_"
+                    for="_r_1_"
                   >
                     <span
                       class=""
@@ -64,11 +69,11 @@ exports[`FeatureFlagDialog > renders 1`] = `
                   class="checkbox-item"
                 >
                   <input
-                    id="_r_1_"
+                    id="_r_2_"
                     type="checkbox"
                   />
                   <label
-                    for="_r_1_"
+                    for="_r_2_"
                   >
                     <span
                       class="feature-flag-label-modified"
@@ -87,11 +92,11 @@ exports[`FeatureFlagDialog > renders 1`] = `
                 >
                   <input
                     checked=""
-                    id="_r_2_"
+                    id="_r_3_"
                     type="checkbox"
                   />
                   <label
-                    for="_r_2_"
+                    for="_r_3_"
                   >
                     <span
                       class=""
@@ -110,11 +115,11 @@ exports[`FeatureFlagDialog > renders 1`] = `
                 >
                   <input
                     disabled=""
-                    id="_r_3_"
+                    id="_r_4_"
                     type="checkbox"
                   />
                   <label
-                    for="_r_3_"
+                    for="_r_4_"
                   >
                     <span
                       class="feature-flag-label-modified"

--- a/client/src/dialogs/Geotag/GeotagDialog.tsx
+++ b/client/src/dialogs/Geotag/GeotagDialog.tsx
@@ -141,6 +141,10 @@ export function GeotagDialog() {
 
   const dispatch = useDispatch()
   const intl = useIntl()
+  const geotagDialogLabel = intl.formatMessage({
+    id: 'dialogs.geotag.dialog-title',
+    defaultMessage: 'Location',
+  })
 
   const geocodeAvailable = !!PELIAS_API_KEY && !!PELIAS_HOST_NAME && !offline
 
@@ -299,7 +303,7 @@ export function GeotagDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabel={geotagDialogLabel}>
       {(closeDialog) => (
         <div className="geotag-dialog">
           {geocodeAvailable ? (

--- a/client/src/dialogs/Geotag/__snapshots__/GeotagDialog.test.tsx.snap
+++ b/client/src/dialogs/Geotag/__snapshots__/GeotagDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`GeotagDialog > renders 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-label="Location"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"

--- a/client/src/dialogs/Newsletter/NewsletterDialog.tsx
+++ b/client/src/dialogs/Newsletter/NewsletterDialog.tsx
@@ -38,6 +38,7 @@ export function NewsletterDialog() {
   })
   const [submitState, setSubmitState] = useState('DEFAULT')
   const emailInputId = useId()
+  const dialogTitleId = useId()
 
   useEffect(() => {
     // Wrapping `setFocus()` in a `setTimeout` of 0 allows it to find the
@@ -79,12 +80,12 @@ export function NewsletterDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => {
         return (
           <div className="newsletter-dialog">
             <header>
-              <h1>
+              <h1 id={dialogTitleId}>
                 <FormattedMessage
                   id="dialogs.newsletter.heading"
                   defaultMessage="Subscribe to our newsletter"

--- a/client/src/dialogs/Newsletter/__snapshots__/NewsletterDialog.test.tsx.snap
+++ b/client/src/dialogs/Newsletter/__snapshots__/NewsletterDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`NewsletterDialog > renders snapshot 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-labelledby="_r_1_"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"
@@ -27,7 +30,9 @@ exports[`NewsletterDialog > renders snapshot 1`] = `
           class="newsletter-dialog"
         >
           <header>
-            <h1>
+            <h1
+              id="_r_1_"
+            >
               Subscribe to our newsletter
             </h1>
           </header>

--- a/client/src/dialogs/SaveAsImage/SaveAsImageDialog.tsx
+++ b/client/src/dialogs/SaveAsImage/SaveAsImageDialog.tsx
@@ -20,6 +20,7 @@ const DEFAULT_IMAGE_DPI = 2
 
 export function SaveAsImageDialog() {
   const imageCanvas = useRef<HTMLCanvasElement>(null)
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
   const [scale, setScale] = useState(1)
   const [isLoading, setIsLoading] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
@@ -238,11 +239,11 @@ export function SaveAsImageDialog() {
   }
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {() => (
         <div className="save-as-image-dialog">
           <header>
-            <h1 id={dialogTitleId}>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="dialogs.save.heading"
                 defaultMessage="Save as image"

--- a/client/src/dialogs/SaveAsImage/SaveAsImageDialog.tsx
+++ b/client/src/dialogs/SaveAsImage/SaveAsImageDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useId } from 'react'
 import { FormattedMessage, useIntl } from 'react-intl'
 import { saveAs } from 'file-saver'
 
@@ -26,6 +26,7 @@ export function SaveAsImageDialog() {
   const [errorMessage, setErrorMessage] = useState<string>()
   const [errorMessage2, setErrorMessage2] = useState<boolean>(false)
   const [downloadDataUrl, setDownloadDataUrl] = useState<string>()
+  const dialogTitleId = useId()
   const [baseDimensions, setBaseDimensions] = useState({})
   const locale = useSelector((state) => state.locale.locale)
   const {
@@ -237,11 +238,11 @@ export function SaveAsImageDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {() => (
         <div className="save-as-image-dialog">
           <header>
-            <h1>
+            <h1 id={dialogTitleId}>
               <FormattedMessage
                 id="dialogs.save.heading"
                 defaultMessage="Save as image"

--- a/client/src/dialogs/SaveAsImage/__snapshots__/SaveAsImageDialog.test.tsx.snap
+++ b/client/src/dialogs/SaveAsImage/__snapshots__/SaveAsImageDialog.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
           <header>
             <h1
               id="_r_0_"
+              tabindex="-1"
             >
               Save as image
             </h1>

--- a/client/src/dialogs/SaveAsImage/__snapshots__/SaveAsImageDialog.test.tsx.snap
+++ b/client/src/dialogs/SaveAsImage/__snapshots__/SaveAsImageDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-labelledby="_r_0_"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"
@@ -27,7 +30,9 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
           class="save-as-image-dialog"
         >
           <header>
-            <h1>
+            <h1
+              id="_r_0_"
+            >
               Save as image
             </h1>
           </header>
@@ -41,29 +46,13 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
                 class="checkbox-item"
               >
                 <input
-                  id="_r_0_"
-                  type="checkbox"
-                />
-                <label
-                  for="_r_0_"
-                >
-                  Segment names and widths
-                </label>
-                <svg
-                  data-icon="check"
-                />
-              </div>
-              <div
-                class="checkbox-item"
-              >
-                <input
                   id="_r_1_"
                   type="checkbox"
                 />
                 <label
                   for="_r_1_"
                 >
-                  Street name
+                  Segment names and widths
                 </label>
                 <svg
                   data-icon="check"
@@ -79,6 +68,22 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
                 <label
                   for="_r_2_"
                 >
+                  Street name
+                </label>
+                <svg
+                  data-icon="check"
+                />
+              </div>
+              <div
+                class="checkbox-item"
+              >
+                <input
+                  id="_r_3_"
+                  type="checkbox"
+                />
+                <label
+                  for="_r_3_"
+                >
                   Transparent sky
                 </label>
                 <svg
@@ -91,11 +96,11 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
                 <input
                   checked=""
                   disabled=""
-                  id="_r_6_"
+                  id="_r_7_"
                   type="checkbox"
                 />
                 <label
-                  for="_r_6_"
+                  for="_r_7_"
                 >
                   Watermark 
                   <svg
@@ -132,7 +137,7 @@ exports[`SaveAsImageDialog > renders snapshot 1`] = `
                   class="custom-scale-popover"
                 >
                   <button
-                    aria-controls="radix-_r_7_"
+                    aria-controls="radix-_r_8_"
                     aria-expanded="false"
                     aria-haspopup="dialog"
                     class="popover-trigger"

--- a/client/src/dialogs/SentimentSurvey/SentimentSurveyDialog.tsx
+++ b/client/src/dialogs/SentimentSurvey/SentimentSurveyDialog.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react'
+import { useId, useRef } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import { ExternalLink } from '~/src/ui/ExternalLink.js'
@@ -7,13 +7,14 @@ import './SentimentSurveyDialog.css'
 
 export function SentimentSurveyDialog() {
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="sentiment-survey-about-dialog">
           <div className="dialog-content">
-            <h3 id={dialogTitleId}>
+            <h3 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="sentiment.about-header"
                 defaultMessage="We want to understand how people feel about streets"

--- a/client/src/dialogs/SentimentSurvey/SentimentSurveyDialog.tsx
+++ b/client/src/dialogs/SentimentSurvey/SentimentSurveyDialog.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import { ExternalLink } from '~/src/ui/ExternalLink.js'
@@ -5,12 +6,14 @@ import { Dialog } from '../Dialog.js'
 import './SentimentSurveyDialog.css'
 
 export function SentimentSurveyDialog() {
+  const dialogTitleId = useId()
+
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="sentiment-survey-about-dialog">
           <div className="dialog-content">
-            <h3>
+            <h3 id={dialogTitleId}>
               <FormattedMessage
                 id="sentiment.about-header"
                 defaultMessage="We want to understand how people feel about streets"

--- a/client/src/dialogs/Settings/SettingsDialog.tsx
+++ b/client/src/dialogs/Settings/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useId } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import type { UserProfile } from '~/src/types/index.js'
@@ -28,6 +28,7 @@ export function SettingsDialog({ category = 'profile' }: SettingsDialogProps) {
     (state) => state.user?.signInData?.details ?? {}
   )
   const [activeCategory, setActiveCategory] = useState(category)
+  const dialogTitleId = useId()
 
   // `user` is allowed to initialize as an empty object, and in that case
   // make `roles` initialize as an empty array.
@@ -61,11 +62,11 @@ export function SettingsDialog({ category = 'profile' }: SettingsDialogProps) {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="settings-dialog">
           <header>
-            <h1>
+            <h1 id={dialogTitleId}>
               <FormattedMessage
                 id="settings.heading"
                 defaultMessage="Settings"

--- a/client/src/dialogs/Settings/SettingsDialog.tsx
+++ b/client/src/dialogs/Settings/SettingsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useId } from 'react'
+import { useState, useId, useRef } from 'react'
 import { FormattedMessage } from 'react-intl'
 
 import type { UserProfile } from '~/src/types/index.js'
@@ -29,6 +29,7 @@ export function SettingsDialog({ category = 'profile' }: SettingsDialogProps) {
   )
   const [activeCategory, setActiveCategory] = useState(category)
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   // `user` is allowed to initialize as an empty object, and in that case
   // make `roles` initialize as an empty array.
@@ -62,11 +63,11 @@ export function SettingsDialog({ category = 'profile' }: SettingsDialogProps) {
   }
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="settings-dialog">
           <header>
-            <h1 id={dialogTitleId}>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="settings.heading"
                 defaultMessage="Settings"

--- a/client/src/dialogs/SignIn/SignInDialog.tsx
+++ b/client/src/dialogs/SignIn/SignInDialog.tsx
@@ -21,6 +21,8 @@ export function SignInDialog() {
   const [signingIn, setSigningIng] = useState(false)
 
   const emailInputEl = useRef<HTMLInputElement>(null)
+  const waitingDialogTitleRef = useRef<HTMLHeadingElement>(null)
+  const emailSentDialogTitleRef = useRef<HTMLHeadingElement>(null)
   const id = useId()
   const emailInputId = `${id}-email`
   const dialogTitleId = `${id}-title`
@@ -95,11 +97,18 @@ export function SignInDialog() {
 
   function SignInWaiting(): React.ReactElement {
     return (
-      <Dialog ariaLabelledBy={waitingDialogTitleId}>
+      <Dialog
+        ariaLabelledBy={waitingDialogTitleId}
+        initialFocusRef={waitingDialogTitleRef}
+      >
         {() => (
           <div className="sign-in-dialog">
             <header>
-              <h1 id={waitingDialogTitleId}>
+              <h1
+                id={waitingDialogTitleId}
+                ref={waitingDialogTitleRef}
+                tabIndex={-1}
+              >
                 <FormattedMessage
                   id="dialogs.sign-in.loading-message"
                   defaultMessage="Signing you in…"
@@ -121,11 +130,18 @@ export function SignInDialog() {
 
   function EmailSent(): React.ReactElement {
     return (
-      <Dialog ariaLabelledBy={emailSentDialogTitleId}>
+      <Dialog
+        ariaLabelledBy={emailSentDialogTitleId}
+        initialFocusRef={emailSentDialogTitleRef}
+      >
         {() => (
           <div className="sign-in-dialog">
             <header>
-              <h1 id={emailSentDialogTitleId}>
+              <h1
+                id={emailSentDialogTitleId}
+                ref={emailSentDialogTitleRef}
+                tabIndex={-1}
+              >
                 <FormattedMessage
                   id="dialogs.sign-in.loading-message"
                   defaultMessage="Signing you in…"

--- a/client/src/dialogs/SignIn/SignInDialog.tsx
+++ b/client/src/dialogs/SignIn/SignInDialog.tsx
@@ -21,7 +21,11 @@ export function SignInDialog() {
   const [signingIn, setSigningIng] = useState(false)
 
   const emailInputEl = useRef<HTMLInputElement>(null)
-  const emailInputId = useId()
+  const id = useId()
+  const emailInputId = `${id}-email`
+  const dialogTitleId = `${id}-title`
+  const waitingDialogTitleId = `${id}-waiting-title`
+  const emailSentDialogTitleId = `${id}-email-sent-title`
 
   useEffect(() => {
     emailInputEl.current?.focus()
@@ -91,11 +95,11 @@ export function SignInDialog() {
 
   function SignInWaiting(): React.ReactElement {
     return (
-      <Dialog>
+      <Dialog ariaLabelledBy={waitingDialogTitleId}>
         {() => (
           <div className="sign-in-dialog">
             <header>
-              <h1>
+              <h1 id={waitingDialogTitleId}>
                 <FormattedMessage
                   id="dialogs.sign-in.loading-message"
                   defaultMessage="Signing you in…"
@@ -117,11 +121,11 @@ export function SignInDialog() {
 
   function EmailSent(): React.ReactElement {
     return (
-      <Dialog>
+      <Dialog ariaLabelledBy={emailSentDialogTitleId}>
         {() => (
           <div className="sign-in-dialog">
             <header>
-              <h1>
+              <h1 id={emailSentDialogTitleId}>
                 <FormattedMessage
                   id="dialogs.sign-in.loading-message"
                   defaultMessage="Signing you in…"
@@ -165,12 +169,12 @@ export function SignInDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {
         (/* closeDialog */) => (
           <div className="sign-in-dialog">
             <header>
-              <h1>
+              <h1 id={dialogTitleId}>
                 <FormattedMessage
                   id="dialogs.sign-in.heading"
                   defaultMessage="Sign in / Sign up"

--- a/client/src/dialogs/SignIn/__snapshots__/SignInDialog.test.tsx.snap
+++ b/client/src/dialogs/SignIn/__snapshots__/SignInDialog.test.tsx.snap
@@ -12,8 +12,11 @@ exports[`SignInDialog > renders 1`] = `
       class="dialog-box-display-area"
     >
       <div
+        aria-labelledby="_r_0_-title"
+        aria-modal="true"
         class="dialog-box"
         role="dialog"
+        tabindex="-1"
       >
         <button
           class="close"
@@ -27,7 +30,9 @@ exports[`SignInDialog > renders 1`] = `
           class="sign-in-dialog"
         >
           <header>
-            <h1>
+            <h1
+              id="_r_0_-title"
+            >
               Sign in / Sign up
             </h1>
           </header>
@@ -40,13 +45,13 @@ exports[`SignInDialog > renders 1`] = `
             <form>
               <label
                 class="sign-in-email-label"
-                for="_r_0_"
+                for="_r_0_-email"
               >
                 Email
               </label>
               <input
                 class="sign-in-input "
-                id="_r_0_"
+                id="_r_0_-email"
                 name="email"
                 placeholder="test@test.com"
                 required=""

--- a/client/src/dialogs/Upgrade/UpgradeDialog.tsx
+++ b/client/src/dialogs/Upgrade/UpgradeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useId } from 'react'
+import { useState, useId, useRef } from 'react'
 import { FormattedMessage } from 'react-intl'
 import axios from 'axios'
 
@@ -19,6 +19,7 @@ export function UpgradeDialog() {
   const [error, setError] = useState<unknown>()
   const [data, setData] = useState<unknown>()
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   const hasTier1 = roles.includes(userRoles.SUBSCRIBER_1.value)
 
@@ -82,12 +83,12 @@ export function UpgradeDialog() {
   }
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {
         (/* closeDialog */) => (
           <div className="upgrade-dialog" dir="ltr">
             <header>
-              <h1 id={dialogTitleId}>
+              <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
                 <FormattedMessage id="upgrade.title" defaultMessage="Upgrade" />
               </h1>
             </header>

--- a/client/src/dialogs/Upgrade/UpgradeDialog.tsx
+++ b/client/src/dialogs/Upgrade/UpgradeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useId } from 'react'
 import { FormattedMessage } from 'react-intl'
 import axios from 'axios'
 
@@ -18,6 +18,7 @@ export function UpgradeDialog() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<unknown>()
   const [data, setData] = useState<unknown>()
+  const dialogTitleId = useId()
 
   const hasTier1 = roles.includes(userRoles.SUBSCRIBER_1.value)
 
@@ -81,12 +82,12 @@ export function UpgradeDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {
         (/* closeDialog */) => (
           <div className="upgrade-dialog" dir="ltr">
             <header>
-              <h1>
+              <h1 id={dialogTitleId}>
                 <FormattedMessage id="upgrade.title" defaultMessage="Upgrade" />
               </h1>
             </header>

--- a/client/src/dialogs/WhatsNew/WhatsNewDialog.tsx
+++ b/client/src/dialogs/WhatsNew/WhatsNewDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useId } from 'react'
 import { FormattedMessage } from 'react-intl'
 import ReactMarkdown from 'react-markdown'
 import rehypeExternalLinks from 'rehype-external-links'
@@ -14,6 +14,7 @@ export const WhatsNewDialog = () => {
   const [state, setSubmitState] = useState('LOADING')
   const [content, setContent] = useState('')
   const [scrollShade, setScrollShade] = useState(false)
+  const dialogTitleId = useId()
 
   useEffect(() => {
     getContent()
@@ -43,11 +44,11 @@ export const WhatsNewDialog = () => {
   }
 
   return (
-    <Dialog>
+    <Dialog ariaLabelledBy={dialogTitleId}>
       {(closeDialog) => (
         <div className="whats-new-dialog">
           <header>
-            <h1>
+            <h1 id={dialogTitleId}>
               <FormattedMessage
                 id="dialogs.whatsnew.heading"
                 defaultMessage="What’s new in Streetmix?&lrm;"

--- a/client/src/dialogs/WhatsNew/WhatsNewDialog.tsx
+++ b/client/src/dialogs/WhatsNew/WhatsNewDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useId } from 'react'
+import { useState, useEffect, useId, useRef } from 'react'
 import { FormattedMessage } from 'react-intl'
 import ReactMarkdown from 'react-markdown'
 import rehypeExternalLinks from 'rehype-external-links'
@@ -15,6 +15,7 @@ export const WhatsNewDialog = () => {
   const [content, setContent] = useState('')
   const [scrollShade, setScrollShade] = useState(false)
   const dialogTitleId = useId()
+  const dialogTitleRef = useRef<HTMLHeadingElement>(null)
 
   useEffect(() => {
     getContent()
@@ -44,11 +45,11 @@ export const WhatsNewDialog = () => {
   }
 
   return (
-    <Dialog ariaLabelledBy={dialogTitleId}>
+    <Dialog ariaLabelledBy={dialogTitleId} initialFocusRef={dialogTitleRef}>
       {(closeDialog) => (
         <div className="whats-new-dialog">
           <header>
-            <h1 id={dialogTitleId}>
+            <h1 id={dialogTitleId} ref={dialogTitleRef} tabIndex={-1}>
               <FormattedMessage
                 id="dialogs.whatsnew.heading"
                 defaultMessage="What’s new in Streetmix?&lrm;"


### PR DESCRIPTION
### Summary                                                                                  
  Add focus trapping, focus restoration, and ARIA semantics to the shared Dialog component.   
                                                                                              
  - Trap Tab/Shift+Tab within open dialogs                                                    
  - Restore focus to the previously focused element on close                                  
  - Add `aria-modal`, `aria-labelledby`, and `tabIndex={-1}` to the dialog container          
  - Wire up all dialog consumers with `useId()` to link headings as accessible names
                                                                                              
 ### Test plan                                                                                
  - [x] Open and close dialogs — focus returns to the trigger element                         
  - [x] Tab through a dialog — focus wraps from last to first element                         
  - [x] Shift+Tab — focus wraps from first to last element                                    
  - [x] Screen reader announces dialog heading on open (excluding Newsletter & Signup)