### PR TITLE
Node 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       # Use the current LTS version of Node.js
-      - name: Use Node.js 22
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
       - run: npm ci
       - run: npm run lint
 
   test:
     name: Unit and integration tests
     runs-on: ubuntu-latest
-    container: node:24-bookworm # EOL 2026-06-10
+    container: node:26-trixie
     strategy:
       # Use current active LTS and later versions of Node.js if present
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,11 @@ jobs:
     name: Unit and integration tests
     runs-on: ubuntu-latest
     container: node:26-trixie
+    # Allow latest version of Node to fail without blocking
+    continue-on-error: ${{ matrix.node-version == '26.x' }}
     strategy:
+      # Do not pre-emptively cancel all tests if one branch fails
+      fail-fast: false
       # Use current active LTS and later versions of Node.js if present
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,18 @@ jobs:
     runs-on: ubuntu-latest
     container: node:26-trixie
     # Allow latest version of Node to fail without blocking
-    continue-on-error: ${{ matrix.node-version == '26.x' }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       # Do not pre-emptively cancel all tests if one branch fails
       fail-fast: false
       # Use current active LTS and later versions of Node.js if present
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x]
+        experimental: [false]
+        include:
+          - node-version: 26.x
+            experimental: true
     env:
       NODE_ENV: test
       HUSKY: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
   test:
     name: Unit and integration tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    container: node:26-trixie
     # Allow latest version of Node to fail without blocking
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -71,6 +70,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - run: npm ci
       - name: Seed test database
         run: npm run db:migrate
@@ -82,6 +82,8 @@ jobs:
       - name: Run tests
         run: npm run vitest:ci
       - name: Report code coverage
+        # As a time-save, only report coverage for main branch of testing
+        if: ${{ matrix.node-version == '24.x' }}
         uses: codecov/codecov-action@v6
 
   cypress:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: npm run lint
 
   test:
-    name: Unit and integration tests
+    name: Unit and integration tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     container: node:26-trixie
     # Allow latest version of Node to fail without blocking
@@ -34,9 +34,11 @@ jobs:
       # Use current active LTS and later versions of Node.js if present
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       matrix:
-        node-version: [22.x, 24.x]
-        experimental: [false]
         include:
+          - node-version: 22.x
+            experimental: false
+          - node-version: 24.x
+            experimental: false
           - node-version: 26.x
             experimental: true
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   test:
     name: Unit and integration tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    # container: node:26-trixie
     # Allow latest version of Node to fail without blocking
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -44,22 +45,22 @@ jobs:
       NODE_ENV: test
       HUSKY: "0"
       CYPRESS_INSTALL_BINARY: "0"
-      PGHOST: postgres
-      PGUSER: postgres
-      PGPASSWORD: postgres
-      PGDATABASE: streetmix_test
-    services:
-      postgres:
-        image: postgis/postgis
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: streetmix_test
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+      # PGHOST: postgres
+      # PGUSER: postgres
+      # PGPASSWORD: postgres
+      # PGDATABASE: streetmix_test
+    # services:
+    #   postgres:
+    #     image: postgis/postgis
+    #     env:
+    #       POSTGRES_PASSWORD: postgres
+    #       POSTGRES_DB: streetmix_test
+    #     # Set health checks to wait until postgres has started
+    #     options: >-
+    #       --health-cmd pg_isready
+    #       --health-interval 10s
+    #       --health-timeout 5s
+    #       --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -72,8 +73,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
-      - name: Seed test database
-        run: npm run db:migrate
+      # - name: Seed test database
+      #   run: npm run db:migrate
       - name: Build files (e.g. TypeScript)
         run: npm run build
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       # Use current active LTS and later versions of Node.js if present
       # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
       matrix:
-        node-version: [22.x, 24.x]
+        node-version: [22.x, 24.x, 26.x]
     env:
       NODE_ENV: test
       HUSKY: "0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,10 @@ jobs:
   test:
     name: Unit and integration tests (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    # Disable this container because we were only needed it for the database
+    # Right now these tests don't use the database (and maybe they never should)
+    # This is a ~40s time save on tests. Remove this config once server tests
+    # are re-implemented and we definitely do not need a real database
     # container: node:26-trixie
     # Allow latest version of Node to fail without blocking
     continue-on-error: ${{ matrix.experimental }}
@@ -83,7 +87,7 @@ jobs:
       - name: Run tests
         run: npm run vitest:ci
       - name: Report code coverage
-        # As a time-save, only report coverage for main branch of testing
+        # As a small time-save, only report coverage for main branch of testing
         if: ${{ matrix.node-version == '24.x' }}
         uses: codecov/codecov-action@v6
 

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,8 +1,8 @@
-const path = require('node:path')
+import path from 'node:path'
 
-module.exports = {
+export default {
   'config': path.resolve('app', 'db', 'config', 'config.ts'),
   'models-path': path.resolve('app', 'db', 'models'),
   'seeders-path': path.resolve('app', 'db', 'seeders'),
-  'migrations-path': path.resolve('app', 'db', 'migrations')
+  'migrations-path': path.resolve('app', 'db', 'migrations'),
 }

--- a/.sequelizerc
+++ b/.sequelizerc
@@ -1,8 +1,6 @@
 import path from 'node:path'
 
-export default {
-  'config': path.resolve('app', 'db', 'config', 'config.ts'),
-  'models-path': path.resolve('app', 'db', 'models'),
-  'seeders-path': path.resolve('app', 'db', 'seeders'),
-  'migrations-path': path.resolve('app', 'db', 'migrations'),
-}
+export const config = path.resolve('app', 'db', 'config', 'config.ts')
+export const modelsPath = path.resolve('app', 'db', 'models')
+export const seedersPath = path.resolve('app', 'db', 'seeders')
+export const migrationsPath = path.resolve('app', 'db', 'migrations')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "AGPL-3.0-or-later",
   "engines": {
-    "node": "^22.18.0 || ^24.0.0",
+    "node": "^22.18.0 || ^24.0.0 || ^26.0.0",
     "npm": ">=11.x"
   },
   "type": "module",


### PR DESCRIPTION
Adds Node 26 to the unit test matrix and make it non-blocking. Note that it will still show as a test failure but it should not block merges, etc.

Node 26 is failing because of changes in how localStorage is handled. Not sure yet if this is intentional, or a bug. And not sure if it's worth solving or waiting for this behavior to change on Node's side.

We keep Node 26 here to track how it works with Streetmix and its dependencies until it becomes LTS.

Also in this PR, we remove the database from unit and integration tests (currently do not need it) for a 40-second time save on performing tests.