### PR TITLE
Add email autofill hints inputs for a11y

### DIFF
--- a/client/src/dialogs/Newsletter/NewsletterDialog.tsx
+++ b/client/src/dialogs/Newsletter/NewsletterDialog.tsx
@@ -110,7 +110,6 @@ export function NewsletterDialog() {
                   id={emailInputId}
                   placeholder="test@example.com"
                   autoComplete="email"
-                  inputMode="email"
                   spellCheck={false}
                   {...register('email', { required: true })}
                 />

--- a/client/src/dialogs/Newsletter/NewsletterDialog.tsx
+++ b/client/src/dialogs/Newsletter/NewsletterDialog.tsx
@@ -109,6 +109,9 @@ export function NewsletterDialog() {
                   type="email"
                   id={emailInputId}
                   placeholder="test@example.com"
+                  autoComplete="email"
+                  inputMode="email"
+                  spellCheck={false}
                   {...register('email', { required: true })}
                 />
                 <input type="hidden" value="via app" {...register('tag')} />

--- a/client/src/dialogs/Newsletter/__snapshots__/NewsletterDialog.test.tsx.snap
+++ b/client/src/dialogs/Newsletter/__snapshots__/NewsletterDialog.test.tsx.snap
@@ -46,7 +46,6 @@ exports[`NewsletterDialog > renders snapshot 1`] = `
               <input
                 autocomplete="email"
                 id="_r_0_"
-                inputmode="email"
                 name="email"
                 placeholder="test@example.com"
                 required=""

--- a/client/src/dialogs/Newsletter/__snapshots__/NewsletterDialog.test.tsx.snap
+++ b/client/src/dialogs/Newsletter/__snapshots__/NewsletterDialog.test.tsx.snap
@@ -44,10 +44,13 @@ exports[`NewsletterDialog > renders snapshot 1`] = `
                 Enter your email
               </label>
               <input
+                autocomplete="email"
                 id="_r_0_"
+                inputmode="email"
                 name="email"
                 placeholder="test@example.com"
                 required=""
+                spellcheck="false"
                 type="email"
               />
               <input

--- a/client/src/dialogs/SignIn/SignInDialog.tsx
+++ b/client/src/dialogs/SignIn/SignInDialog.tsx
@@ -203,7 +203,6 @@ export function SignInDialog() {
                   }
                   name="email"
                   autoComplete="email"
-                  inputMode="email"
                   spellCheck={false}
                   onChange={handleChange}
                   placeholder="test@test.com"

--- a/client/src/dialogs/SignIn/SignInDialog.tsx
+++ b/client/src/dialogs/SignIn/SignInDialog.tsx
@@ -202,6 +202,9 @@ export function SignInDialog() {
                     'sign-in-input ' + (error ? 'sign-in-input-error' : '')
                   }
                   name="email"
+                  autoComplete="email"
+                  inputMode="email"
+                  spellCheck={false}
                   onChange={handleChange}
                   placeholder="test@test.com"
                   required

--- a/client/src/dialogs/SignIn/__snapshots__/SignInDialog.test.tsx.snap
+++ b/client/src/dialogs/SignIn/__snapshots__/SignInDialog.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`SignInDialog > renders 1`] = `
                 autocomplete="email"
                 class="sign-in-input "
                 id="_r_0_"
-                inputmode="email"
                 name="email"
                 placeholder="test@test.com"
                 required=""

--- a/client/src/dialogs/SignIn/__snapshots__/SignInDialog.test.tsx.snap
+++ b/client/src/dialogs/SignIn/__snapshots__/SignInDialog.test.tsx.snap
@@ -45,11 +45,14 @@ exports[`SignInDialog > renders 1`] = `
                 Email
               </label>
               <input
+                autocomplete="email"
                 class="sign-in-input "
                 id="_r_0_"
+                inputmode="email"
                 name="email"
                 placeholder="test@test.com"
                 required=""
+                spellcheck="false"
                 type="email"
                 value=""
               />


### PR DESCRIPTION
## Summary
Add email autofill hints to email inputs in the sign-in and newsletter dialogs.

  - Satisfies WCAG 1.3.5 (Identify Input Purpose)
  - Ensures mobile keyboards show email layout, prevents spellcheck squiggles on email addresses

## Test plan
  - [x] Two email fields work, have new attributes
  - [x] Linter & Tests pass