### PR TITLE
Upgrade http links to https and fix broken URLs (round 1)

### DIFF
--- a/client/src/app/keypress.ts
+++ b/client/src/app/keypress.ts
@@ -4,7 +4,7 @@
  * Handles registration, removal, and processing of keyboard inputs.
  * Some inspiration:
  *    - Mousetrap.js (https://craig.is/killing/mice)
- *    - Keypress.js (http://dmauro.github.io/Keypress/)
+ *    - Keypress.js (https://dmauro.github.io/Keypress/)
  *    - keymaster.js (https://github.com/madrobby/keymaster)
  */
 import { isFocusOnBody } from '../util/focus.js'

--- a/client/src/dialogs/About/credits.json
+++ b/client/src/dialogs/About/credits.json
@@ -41,7 +41,7 @@
       "name": "Ezra Spier",
       "title": "engineer, marketing",
       "mugshotFile": "ezra.jpg",
-      "url": "http://ahhrrr.com",
+      "url": "https://yesezra.com/",
       "active": false,
       "original": true
     },

--- a/docs/docs/contributing/code/local-setup.md
+++ b/docs/docs/contributing/code/local-setup.md
@@ -14,7 +14,7 @@ You may already have some of these prerequisites installed. Skip or update the p
 
 1. Install **[XCode Developer Tools](https://itunes.apple.com/us/app/xcode/id497799835?mt=12)**.
 
-2. (Optional) Install the **[Homebrew](http://brew.sh/) package manager**. This makes installing other software packages easier, but you can use any other package installation method you wish. In this example and in the following steps, we will use Homebrew on the command line to set up your development environment.
+2. (Optional) Install the **[Homebrew](https://brew.sh/) package manager**. This makes installing other software packages easier, but you can use any other package installation method you wish. In this example and in the following steps, we will use Homebrew on the command line to set up your development environment.
 
 ```shell-session
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -62,9 +62,9 @@ Streetmix was not developed on a Windows platform, and testing is limited. These
 
 You may already have some of these prerequisites installed. Skip or update the packages that already exist.
 
-1. Install [a modern browser](http://browsehappy.com/). We recommend **Firefox** or **Chrome**. [Internet Explorer is not supported](/user-guide/support/faq#internet-explorer).
-2. Install **[Git](http://git-scm.com/download/win)**. You may want to consider following Microsoft's guide to [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-git), which helps us provide similar command line instructions to Mac OSX and Linux environments.
-3. Install **[Node.js](http://nodejs.org/)**. The site should detect your Windows system and provide you with the correct install executable, or you can choose to download [a specific package or installer](http://nodejs.org/en/download/). In production, Streetmix uses the latest "Active LTS" release. Locally, you should be able to use any version of Node.js in the "Current" or "Active" state.
+1. Install [a modern browser](https://browsehappy.com/). We recommend **Firefox** or **Chrome**. [Internet Explorer is not supported](/user-guide/support/faq#internet-explorer).
+2. Install **[Git](https://git-scm.com/install/windows)**. You may want to consider following Microsoft's guide to [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-git), which helps us provide similar command line instructions to Mac OSX and Linux environments.
+3. Install **[Node.js](https://nodejs.org/)**. The site should detect your Windows system and provide you with the correct install executable, or you can choose to download [a specific package or installer](https://nodejs.org/en/download). In production, Streetmix uses the latest "Active LTS" release. Locally, you should be able to use any version of Node.js in the "Current" or "Active" state.
 4. Install **PostgreSQL**. You can [download a Windows package here](https://www.postgresql.org/download/windows/).
 5. Install **PostGIS**. You can [download a Windows package here](https://postgis.net/windows_downloads/).
 

--- a/docs/docs/contributing/code/reference/helpers.md
+++ b/docs/docs/contributing/code/reference/helpers.md
@@ -50,7 +50,7 @@ In the above example, we call `seedrandom()` twice, with the same `seed`, so tha
 
 **References**
 
-- [Random Seeds, Coded Hints, and Quintillions](http://davidbau.com/archives/2010/01/30/random_seeds_coded_hints_and_quintillions.html) [David Bau]
+- [Random Seeds, Coded Hints, and Quintillions](https://davidbau.com/archives/2010/01/30/random_seeds_coded_hints_and_quintillions.html) [David Bau]
 - [seedrandom.js](https://github.com/davidbau/seedrandom) [GitHub]
 
 ## axios

--- a/docs/docs/contributing/code/styleguide.md
+++ b/docs/docs/contributing/code/styleguide.md
@@ -34,7 +34,7 @@ We may investigate adopting CSS Modules. However, we would strongly prefer solut
 
 Avoid styling elements using `id` attribute selectors. Instead, use class names (alongside pseudo-selectors and attribute selectors, if necessary). Namespace all classnames. If there's a component called `palette`, a good class name could be `palette-container`. Avoid writing generic class names like `large`. Styles are not scoped, so generic class names without namespaces will inevitably cause collisions.
 
-We do not use a strict BEM framework/naming convention for class names. Some good resources which have generally informed our approach to CSS organization (but have not dictated it) include [Scalable and Modular Architecture for CSS (SMACSS)](http://smacss.com/) and parts of the [Reasonable System for CSS Stylesheet Structure (rscss)](https://rscss.io/).
+We do not use a strict BEM framework/naming convention for class names. Some good resources which have generally informed our approach to CSS organization (but have not dictated it) include [Scalable and Modular Architecture for CSS (SMACSS)](https://smacss.com/) and parts of the [Reasonable System for CSS Stylesheet Structure (rscss)](https://rscss.io/).
 
 ## JavaScript
 

--- a/docs/docs/contributing/design/icons.md
+++ b/docs/docs/contributing/design/icons.md
@@ -34,4 +34,4 @@ Here are some tips when exporting from Affinity Designer (which can also be rele
 
 ### Other resources
 
-- [SVG `symbol` a Good Choice for Icons](http://css-tricks.com/svg-symbol-good-choice-icons/) [CSS Tricks]
+- [SVG `symbol` a Good Choice for Icons](https://css-tricks.com/svg-symbol-good-choice-icons/) [CSS Tricks]

--- a/docs/docs/contributing/translations/new-translator-guide.md
+++ b/docs/docs/contributing/translations/new-translator-guide.md
@@ -136,7 +136,7 @@ Sometimes there will be updates to the English strings. Transifex will detect th
 
 ## Need more help?
 
-Refer to the [Transifex documentation](http://docs.transifex.com/) if you need more help. A good place to start is the [Transifex web editor tutorial](http://docs.transifex.com/tutorials/txeditor/).
+Refer to the [Transifex documentation](https://help.transifex.com/) if you need more help. A good place to start is the [Transifex web editor tutorial](https://help.transifex.com/en/articles/6318216-translating-with-the-web-editor).
 
 ### FAQ & Discord chat
 

--- a/docs/docs/user-guide/changelog.md
+++ b/docs/docs/user-guide/changelog.md
@@ -581,7 +581,7 @@ We’ve upgraded our sign-in authentication system behind the scenes. As a side 
 ### ✨ New features
 
 - **Added an outbound autonomous vehicle illustration.** When you hate to see them go, but you love to watch them drive away. (Note: only available for signed-in users.)
-- **Added a motorcycle with sidecar to the drive lane.** And introducing a cameo by [Junebug and Johnny](http://kentuckyroutezero.com/). (Note: only available for signed-in users.)
+- **Added a motorcycle with sidecar to the drive lane.** And introducing a cameo by [Junebug and Johnny](https://kentuckyroutezero.com/). (Note: only available for signed-in users.)
 - **Added languages: Italian, Korean, and Latin American Spanish.** _Cin cin!_ _건배!_ _¡Salud!_ The latter is especially important, as we can now support a much larger community of Spanish speakers throughout all of Latin America. Many thanks to our translators, Enrico Ferreguti, Sunha Park, and Lina Marcela Quiñones, with reviewers Marco Scarselli, Hanbyul Jo, and Carlos Pardo.
 
 ### 🎮 UI improvements

--- a/docs/docs/user-guide/street-design-elements.md
+++ b/docs/docs/user-guide/street-design-elements.md
@@ -24,9 +24,9 @@ Notes on segments, which are the elements that comprise a street section. [See I
 - **Maximum width:** 12 ft (3.6m)
 - **References:**
   - [AASHTO 2001 Green Book - Chapter 4 - Lane Widths](https://gist.github.com/louh/9ed5e8585878db8034c6) (pp 315-316)
-  - [NCHRP Report 500, Volume 10: A Guide for Reducing Collisions Involving Pedestrians](http://onlinepubs.trb.org/onlinepubs/nchrp/nchrp_rpt_500v10.pdf)
+  - [NCHRP Report 500, Volume 10: A Guide for Reducing Collisions Involving Pedestrians](https://www.nationalacademies.org/publications/23425)
     - section V-48
-  - [ITE Designing Walkable Urban Thoroughfares](http://www.ite.org/emodules/scriptcontent/orders/ProductDetail.cfm?pc=RP-036A-E) (2010)
+  - [ITE Designing Walkable Urban Thoroughfares](https://www.ite.org/pub/?id=E1CFF43C-2354-D714-51D9-D82B39D4DBAD) (2010)
   - [Walkable City](https://gist.github.com/louh/921ca2e36cf2a7e5df49/raw/c720c5170bd6534a07d4b7b73ac588b3dc56d4fa/Walkable+City+-+Multilane+roads%2C+road+diets) by Jeff Speck (2012) - Step 5: "Protect the Pedestrian"
 
 Lane widths typically fall between 2.7m (9ft) and 3.6m (12ft). For urban contexts where Streetmix is most useful, the 3.0m (10ft) lane width is most ideal. Some guides allow for 3.3m (11ft) lanes, but we will follow Jeff Speck's lead (and other progressive planners) in setting 10ft widths as typical.
@@ -122,7 +122,7 @@ Bicycles are a desirable alternate form of transportation to the automobile beca
 
 Sharrows are a strategy where additional road space is available, and you want to get a bike lane in there somehow, but you can't really stripe it without giving both the drive lane and bike lane less than the standard width, so it is combined. This is a "shared lane" scenario.
 
-In [a California study](https://usa.streetsblog.org/2013/06/13/in-california-cities-drivers-want-more-bike-lanes-heres-why), researchers found that drivers tend to prefer real bike lanes to keep bikers separate from the cars, and dislike sharrows. Bikers, on the other hand, prefer sharrows to nothing at all. (Source: [Do All Roadway Users Want the Same Things? Results from a Roadway Design Survey of Pedestrians, Drivers, Bicyclists, and Transit Users in the Bay Area](http://safetrec.berkeley.edu/trb2013/13-4475.pdf) by Rebecca L. Sanders and Jill Cooper, 2013)
+In [a California study](https://usa.streetsblog.org/2013/06/13/in-california-cities-drivers-want-more-bike-lanes-heres-why), researchers found that drivers tend to prefer real bike lanes to keep bikers separate from the cars, and dislike sharrows. Bikers, on the other hand, prefer sharrows to nothing at all. (Source: [Do All Roadway Users Want the Same Things? Results from a Roadway Design Survey of Pedestrians, Drivers, Bicyclists, and Transit Users in the Bay Area](https://its.berkeley.edu/publications/do-all-roadway-users-want-same-things) by Rebecca L. Sanders and Jill Cooper, 2013)
 
 ### Cycletrack (bike lane + median or buffer)
 
@@ -184,7 +184,7 @@ Not presently planned for Streetmix.
 - **Subtypes:** Different car types; inbound, outbound; separated infrastructure or in drive lane
 - **Default width:** 10 ft (same as drive lane)
 - **Minimum width:** 10 ft
-  - According to [streetcar.org](http://streetcar.org/), the widths of most streetcars are between 8'-0" to 9'-0". In the absence (so far) of guidelines defining streetcar width, we can assume that 10' should be the minimum and can remain the default.
+  - According to [streetcar.org](https://www.streetcar.org/), the widths of most streetcars are between 8'-0" to 9'-0". In the absence (so far) of guidelines defining streetcar width, we can assume that 10' should be the minimum and can remain the default.
 - **Maximum width:** none
 
 ### Buses


### PR DESCRIPTION
## Summary
Inspired by https://github.com/streetmix/streetmix/pull/3677, cleaned up a bunch of the old http links.  

Most of these are straight swaps but a few suffered from link rot so I found what I believe to be the closest thing to replace them.  

(Round 2 will be in the translated docs, once I read up on that work flow.)

