### PR TITLE
fix(undo_stack): crash on missing warnings

### DIFF
--- a/client/src/info_bubble/PopupLower/Warnings.test.tsx
+++ b/client/src/info_bubble/PopupLower/Warnings.test.tsx
@@ -72,4 +72,15 @@ describe('Warnings', () => {
     expect(container).not.toHaveTextContent('This may be too wide.')
     expect(container).not.toHaveTextContent('This may not be wide enough.')
   })
+
+  it('renders nothing if segment warnings is undefined', () => {
+    const segment = {}
+    const { container } = render(<Warnings segment={segment} />)
+
+    expect(container).not.toHaveTextContent(
+      'This doesn’t fit within the street.'
+    )
+    expect(container).not.toHaveTextContent('This may be too wide.')
+    expect(container).not.toHaveTextContent('This may not be wide enough.')
+  })
 })

--- a/client/src/info_bubble/PopupLower/Warnings.tsx
+++ b/client/src/info_bubble/PopupLower/Warnings.tsx
@@ -24,8 +24,9 @@ export function Warnings(props: WarningsProps) {
   const messages = []
 
   if (segment === undefined) return null
+  const warnings = segment.warnings ?? [false]
 
-  if (segment.warnings[SLICE_WARNING_DANGEROUS_EXISTING]) {
+  if (warnings[SLICE_WARNING_DANGEROUS_EXISTING]) {
     messages.push({
       type: 'alert',
       message: (
@@ -36,7 +37,7 @@ export function Warnings(props: WarningsProps) {
       ),
     })
   }
-  if (segment.warnings[SLICE_WARNING_OUTSIDE]) {
+  if (warnings[SLICE_WARNING_OUTSIDE]) {
     messages.push({
       type: 'error',
       message: (
@@ -47,7 +48,7 @@ export function Warnings(props: WarningsProps) {
       ),
     })
   }
-  if (segment.warnings[SLICE_WARNING_WIDTH_TOO_SMALL]) {
+  if (warnings[SLICE_WARNING_WIDTH_TOO_SMALL]) {
     messages.push({
       type: 'error',
       message: (
@@ -58,7 +59,7 @@ export function Warnings(props: WarningsProps) {
       ),
     })
   }
-  if (segment.warnings[SLICE_WARNING_WIDTH_TOO_LARGE]) {
+  if (warnings[SLICE_WARNING_WIDTH_TOO_LARGE]) {
     messages.push({
       type: 'error',
       message: (
@@ -70,8 +71,8 @@ export function Warnings(props: WarningsProps) {
     })
   }
   if (
-    segment.warnings[SLICE_WARNING_SLOPE_EXCEEDED_BERM] ||
-    segment.warnings[SLICE_WARNING_SLOPE_EXCEEDED_PATH]
+    warnings[SLICE_WARNING_SLOPE_EXCEEDED_BERM] ||
+    warnings[SLICE_WARNING_SLOPE_EXCEEDED_PATH]
   ) {
     messages.push({
       type: 'error',

--- a/client/src/segments/Segment.tsx
+++ b/client/src/segments/Segment.tsx
@@ -251,6 +251,7 @@ export function Segment(props: SliceProps) {
   }
 
   const classNames = ['segment']
+  const warnings = segment.warnings ?? [false]
 
   if (isDragging) {
     classNames.push('dragged-out')
@@ -260,15 +261,15 @@ export function Segment(props: SliceProps) {
 
   // Warnings
   if (
-    segment.warnings[SLICE_WARNING_OUTSIDE] ||
-    segment.warnings[SLICE_WARNING_WIDTH_TOO_SMALL] ||
-    segment.warnings[SLICE_WARNING_WIDTH_TOO_LARGE] ||
-    segment.warnings[SLICE_WARNING_SLOPE_EXCEEDED_BERM] ||
-    segment.warnings[SLICE_WARNING_SLOPE_EXCEEDED_PATH]
+    warnings[SLICE_WARNING_OUTSIDE] ||
+    warnings[SLICE_WARNING_WIDTH_TOO_SMALL] ||
+    warnings[SLICE_WARNING_WIDTH_TOO_LARGE] ||
+    warnings[SLICE_WARNING_SLOPE_EXCEEDED_BERM] ||
+    warnings[SLICE_WARNING_SLOPE_EXCEEDED_PATH]
   ) {
     classNames.push('warning')
   }
-  if (segment.warnings[SLICE_WARNING_OUTSIDE]) {
+  if (warnings[SLICE_WARNING_OUTSIDE]) {
     classNames.push('outside')
   }
 

--- a/client/src/segments/capacity.ts
+++ b/client/src/segments/capacity.ts
@@ -126,6 +126,7 @@ export function getSegmentCapacity(
   segment: Segment,
   source: string = DEFAULT_CAPACITY_SOURCE
 ): CapacityForDisplay | undefined {
+  const warnings = segment.warnings ?? [false]
   let capacity = getCapacityData(source).segments[segment.type]
 
   // Returns undefined value if capacity is not defined
@@ -146,8 +147,8 @@ export function getSegmentCapacity(
   // If a segment has capacity data, but something makes it zero capacity,
   // return modified values here.
   if (
-    segment.warnings[SLICE_WARNING_OUTSIDE] ||
-    segment.warnings[SLICE_WARNING_WIDTH_TOO_SMALL]
+    warnings[SLICE_WARNING_OUTSIDE] ||
+    warnings[SLICE_WARNING_WIDTH_TOO_SMALL]
   ) {
     return {
       average: 0,

--- a/client/src/streets/undo_stack.test.ts
+++ b/client/src/streets/undo_stack.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { finishUndoOrRedo } from './undo_stack'
+
+const {
+  updateStreetDataActionMock,
+  cancelSegmentResizeTransitionsMock,
+  setUpdateTimeToNowMock,
+  updateEverythingMock,
+  dispatchMock,
+  getStateMock,
+} = vi.hoisted(() => ({
+  updateStreetDataActionMock: vi.fn((payload) => ({
+    type: 'street/updateStreetDataAction',
+    payload,
+  })),
+  cancelSegmentResizeTransitionsMock: vi.fn(),
+  setUpdateTimeToNowMock: vi.fn(),
+  updateEverythingMock: vi.fn(),
+  dispatchMock: vi.fn(),
+  getStateMock: vi.fn(),
+}))
+
+vi.mock('../store', () => ({
+  default: {
+    dispatch: dispatchMock,
+    getState: getStateMock,
+  },
+}))
+
+vi.mock('../store/actions/street.js', () => ({
+  updateStreetDataAction: updateStreetDataActionMock,
+}))
+
+vi.mock('../segments/resizing.js', () => ({
+  cancelSegmentResizeTransitions: cancelSegmentResizeTransitionsMock,
+}))
+
+vi.mock('./data_model.js', () => ({
+  setUpdateTimeToNow: setUpdateTimeToNowMock,
+  updateEverything: updateEverythingMock,
+}))
+
+describe('finishUndoOrRedo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('seeds missing segment warnings before restoring street data', () => {
+    getStateMock.mockReturnValue({
+      history: {
+        position: 0,
+        stack: [
+          {
+            segments: [
+              {
+                id: '1',
+                type: 'sidewalk',
+                variantString: 'default',
+                width: 3,
+                elevation: 0,
+                slope: { on: false, values: [] },
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    finishUndoOrRedo()
+
+    expect(updateStreetDataActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        segments: [
+          expect.objectContaining({
+            warnings: [false],
+          }),
+        ],
+      })
+    )
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(cancelSegmentResizeTransitionsMock).toHaveBeenCalledTimes(1)
+    expect(setUpdateTimeToNowMock).toHaveBeenCalledTimes(1)
+    expect(updateEverythingMock).toHaveBeenCalledWith(true)
+  })
+
+  it('preserves existing warnings on restored segments', () => {
+    getStateMock.mockReturnValue({
+      history: {
+        position: 0,
+        stack: [
+          {
+            segments: [
+              {
+                id: '2',
+                type: 'drive-lane',
+                variantString: 'default',
+                width: 3,
+                elevation: 0,
+                slope: { on: false, values: [] },
+                warnings: [false, true],
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    finishUndoOrRedo()
+
+    expect(updateStreetDataActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        segments: [
+          expect.objectContaining({
+            warnings: [false, true],
+          }),
+        ],
+      })
+    )
+  })
+})

--- a/client/src/streets/undo_stack.ts
+++ b/client/src/streets/undo_stack.ts
@@ -19,8 +19,18 @@ export function getUndoPosition() {
 export function finishUndoOrRedo() {
   // set current street to the thing we just updated
   const { position, stack } = store.getState().history
+  const restoredStreet = clone(stack[position])
 
-  store.dispatch(updateStreetDataAction(clone(stack[position])))
+  // Undo stack snapshots intentionally omit derived warnings.
+  // Seed defaults so render paths never read `undefined` before recomputation.
+  if (Array.isArray(restoredStreet?.segments)) {
+    restoredStreet.segments = restoredStreet.segments.map((segment) => ({
+      ...segment,
+      warnings: segment.warnings ?? [false],
+    }))
+  }
+
+  store.dispatch(updateStreetDataAction(restoredStreet))
   cancelSegmentResizeTransitions()
 
   setUpdateTimeToNow()


### PR DESCRIPTION
Fix undo actions crashing Streetmix.

Undo is still buggy:
- segment positions do not properly update
- stack still switches between two states instead of properly going back in the stack
- Coastmix mode will send a history state on load

Merging this as just a single bug fix to prevent crashes.