### PR TITLE
Fix additional undo/redo bugs

### DIFF
--- a/client/src/info_bubble/PopupControls/VariantSet.tsx
+++ b/client/src/info_bubble/PopupControls/VariantSet.tsx
@@ -44,8 +44,12 @@ export function VariantSet(props: SectionElementTypeAndPosition) {
   if (type === 'boundary') {
     variantSets = Object.keys(VARIANT_ICONS.boundary)
   } else {
+    if (!segment) {
+      return null
+    }
+
     const { variants } = getSegmentInfo(segment.type)
-    variantSets = variants
+    variantSets = variants ?? []
   }
 
   // Remove any empty entries
@@ -79,7 +83,6 @@ export function VariantSet(props: SectionElementTypeAndPosition) {
     if (type === 'boundary') {
       handler = () => {
         dispatch(setBuildingVariant(position, selection))
-        dispatch(segmentsChanged())
       }
     } else {
       handler = () => {

--- a/client/src/palette/UndoRedo.tsx
+++ b/client/src/palette/UndoRedo.tsx
@@ -19,6 +19,7 @@ export function UndoRedo() {
   }
 
   function isRedoAvailable(): boolean {
+    console.log(undoPosition, isOwnedByCurrentUser())
     return (
       undoPosition !== null &&
       undoPosition >= 0 &&

--- a/client/src/palette/UndoRedo.tsx
+++ b/client/src/palette/UndoRedo.tsx
@@ -19,7 +19,6 @@ export function UndoRedo() {
   }
 
   function isRedoAvailable(): boolean {
-    console.log(undoPosition, isOwnedByCurrentUser())
     return (
       undoPosition !== null &&
       undoPosition >= 0 &&

--- a/client/src/palette/UndoRedo.tsx
+++ b/client/src/palette/UndoRedo.tsx
@@ -15,11 +15,12 @@ export function UndoRedo() {
 
   // Don’t allow undo/redo unless you own the street
   function isUndoAvailable(): boolean {
-    return undoPosition > 0 && isOwnedByCurrentUser()
+    return undoPosition !== null && undoPosition > 0 && isOwnedByCurrentUser()
   }
 
   function isRedoAvailable(): boolean {
     return (
+      undoPosition !== null &&
       undoPosition >= 0 &&
       undoPosition < undoStack.length - 1 &&
       isOwnedByCurrentUser()

--- a/client/src/store/actions/history.ts
+++ b/client/src/store/actions/history.ts
@@ -1,7 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { formatMessage } from '../../locales/locale.js'
-import { trimStreetData } from '../../streets/data_model.js'
 import { isOwnedByCurrentUser } from '../../streets/owner.js'
 import { finishUndoOrRedo } from '../../streets/undo_stack.js'
 import { redo, undo } from '../slices/history.js'
@@ -21,13 +20,10 @@ export const handleUndo = createAsyncThunk<
   { state: RootState; dispatch: Dispatch }
 >('history/handleUndo', async (arg, { dispatch, getState }) => {
   const { position } = getState().history
-  const { street } = getState()
 
   // Don't allow undo/redo unless you own the street
-  if (position > 0 && isOwnedByCurrentUser()) {
-    // Before undoing, send a copy of the current street data
-    // to update data at the current position
-    dispatch(undo(trimStreetData(street)))
+  if (position !== null && position > 0 && isOwnedByCurrentUser()) {
+    dispatch(undo())
     finishUndoOrRedo()
   } else {
     dispatch(
@@ -47,7 +43,12 @@ export const handleRedo = createAsyncThunk<
   const { position, stack } = getState().history
 
   // Don't allow undo/redo unless you own the street
-  if (position >= 0 && position < stack.length - 1 && isOwnedByCurrentUser()) {
+  if (
+    position !== null &&
+    position >= 0 &&
+    position < stack.length - 1 &&
+    isOwnedByCurrentUser()
+  ) {
     dispatch(redo())
     finishUndoOrRedo()
   } else {

--- a/client/src/store/actions/history.ts
+++ b/client/src/store/actions/history.ts
@@ -24,7 +24,7 @@ export const handleUndo = createAsyncThunk<
   // Don't allow undo/redo unless you own the street
   if (position !== null && position > 0 && isOwnedByCurrentUser()) {
     dispatch(undo())
-    finishUndoOrRedo()
+    await finishUndoOrRedo()
   } else {
     dispatch(
       addToast({
@@ -50,7 +50,7 @@ export const handleRedo = createAsyncThunk<
     isOwnedByCurrentUser()
   ) {
     dispatch(redo())
-    finishUndoOrRedo()
+    await finishUndoOrRedo()
   } else {
     dispatch(
       addToast({

--- a/client/src/store/slices/history.test.ts
+++ b/client/src/store/slices/history.test.ts
@@ -5,17 +5,17 @@ import reducer, {
   unifyStack,
   undo,
   redo,
-  MAX_UNDO_LIMIT
+  MAX_UNDO_LIMIT,
 } from './history'
 
 describe('undo reducer', () => {
   const initialState = {
     stack: [],
-    position: 0
+    position: null,
   }
 
   it('should handle initial state', () => {
-    expect(reducer(undefined, {})).toEqual(initialState)
+    expect(reducer(undefined, { type: 'test' })).toEqual(initialState)
   })
 
   it('should handle resetUndoStack()', () => {
@@ -23,7 +23,7 @@ describe('undo reducer', () => {
       reducer(
         {
           stack: [{}, {}, {}],
-          position: 1
+          position: 1,
         },
         resetUndoStack()
       )
@@ -34,70 +34,69 @@ describe('undo reducer', () => {
     expect(
       reducer(
         {
-          stack: [1, 2, 3],
-          position: 2
+          stack: [{ name: 'a' }, { name: 'b' }, { name: 'c' }],
+          position: 2,
         },
         replaceUndoStack({
-          stack: [4, 5],
-          position: 2
+          stack: [{ name: 'd' }, { name: 'e' }],
+          position: 2,
         })
       )
     ).toEqual({
-      stack: [4, 5],
+      stack: [{ name: 'd' }, { name: 'e' }],
       // Stack position must actually be within length of new stack
-      position: 1
+      position: 1,
     })
   })
 
   it('should handle createNewUndo()', () => {
-    expect(reducer(initialState, createNewUndo({ foo: 'bar' }))).toEqual({
-      position: 1,
-      stack: [{ foo: 'bar' }]
+    expect(reducer(initialState, createNewUndo({ name: 'bar' }))).toEqual({
+      position: 0,
+      stack: [{ name: 'bar' }],
     })
   })
 
   it('creates a new undo at the top of an existing stack', () => {
-    const item = { foo: 'bar' }
+    const item = { name: 'bar' }
     const state = reducer(
       {
-        position: 10,
-        stack: Array(10).fill({})
+        position: 9,
+        stack: Array(10).fill({}),
       },
       createNewUndo(item)
     )
 
-    expect(state.position).toEqual(11)
+    expect(state.position).toEqual(10)
     expect(state.stack.length).toEqual(11)
     expect(state.stack[state.stack.length - 1]).toMatchObject(item)
   })
 
   it('truncates an undo stack if a new undo state is created at an earlier position', () => {
-    const item = { foo: 'bar' }
+    const item = { name: 'bar' }
     const state = reducer(
       {
         position: 6,
-        stack: Array(10).fill({})
+        stack: Array(10).fill({}),
       },
       createNewUndo(item)
     )
 
-    // Expect the position to have increased by 1
+    // Expect the position to point to the newly added item
     expect(state.position).toEqual(7)
 
-    // Expect the stack to be truncated
-    expect(state.stack.length).toEqual(7)
+    // Expect the stack to be truncated and then appended by one item
+    expect(state.stack.length).toEqual(8)
 
     // Expect the last item on the stack to match what was added
     expect(state.stack[state.stack.length - 1]).toMatchObject(item)
   })
 
   it('trims an undo stack that is too large', () => {
-    const MAX_UNDO_POSITION = MAX_UNDO_LIMIT + 1 // The maximum position can be 1 past the actual stack length
-    const item = { foo: 'bar' }
+    const item = { name: 'bar' }
     const state = reducer(
       {
-        position: MAX_UNDO_POSITION,
-        stack: [{ foo: 'baz' }, ...Array(MAX_UNDO_LIMIT).fill({})]
+        position: MAX_UNDO_LIMIT - 1,
+        stack: [{ name: 'baz' }, ...Array(MAX_UNDO_LIMIT - 1).fill({})],
       },
       createNewUndo(item)
     )
@@ -105,8 +104,8 @@ describe('undo reducer', () => {
     // Stack size should max at MAX_UNDO_LIMIT
     expect(state.stack.length).toEqual(MAX_UNDO_LIMIT)
 
-    // Position should max at MAX_UNDO_POSITION
-    expect(state.position).toEqual(MAX_UNDO_POSITION)
+    // Position should point to the final item in the stack
+    expect(state.position).toEqual(MAX_UNDO_LIMIT - 1)
 
     // Expect the last item on the stack to match what was added
     expect(state.stack[MAX_UNDO_LIMIT - 1]).toMatchObject(item)
@@ -121,18 +120,18 @@ describe('undo reducer', () => {
         position: 9,
         stack: Array(10)
           .fill({})
-          .map((x, i) => ({ id: i }))
+          .map((x, i) => ({ id: `${i}` })),
       },
-      undo({ id: 1000 })
+      undo()
     )
 
     expect(state.position).toEqual(8)
-    expect(state.stack[9]).toMatchObject({ id: 1000 })
+    expect(state.stack[9]).toMatchObject({ id: '9' })
 
     // One more
-    const state2 = reducer(state, undo({ id: 1001 }))
+    const state2 = reducer(state, undo())
     expect(state2.position).toEqual(7)
-    expect(state2.stack[8]).toMatchObject({ id: 1001 })
+    expect(state2.stack[8]).toMatchObject({ id: '8' })
   })
 
   it('increases position by 1 for redo', () => {
@@ -141,7 +140,7 @@ describe('undo reducer', () => {
         position: 2,
         stack: Array(10)
           .fill({})
-          .map((x, i) => ({ id: i }))
+          .map((x, i) => ({ id: `${i}` })),
       },
       redo()
     )
@@ -155,21 +154,22 @@ describe('undo reducer', () => {
 
   it('unifies metadata on an undo stack', () => {
     const item = {
-      id: 1,
+      id: '1',
       name: 'foo',
       namespacedId: 2,
-      creatorId: 3,
-      updatedAt: 'bar'
+      creatorId: '3',
+      updatedAt: 'bar',
     }
     const state = reducer(
       {
+        position: 0,
         stack: Array(10).fill({
-          id: 0,
+          id: '0',
           name: 'bar',
           namespacedId: 1,
-          creatorId: 2,
-          updatedAt: 'baz'
-        })
+          creatorId: '2',
+          updatedAt: 'baz',
+        }),
       },
       unifyStack(item)
     )

--- a/client/src/store/slices/history.ts
+++ b/client/src/store/slices/history.ts
@@ -6,7 +6,7 @@ export const MAX_UNDO_LIMIT = 100
 
 const initialState: HistoryState = {
   stack: [],
-  position: 0,
+  position: null,
 }
 
 /**
@@ -52,14 +52,19 @@ const undoSlice = createSlice({
   initialState,
 
   reducers: {
-    undo(state, action: PayloadAction<Partial<StreetState>>) {
-      const newPosition = state.position - 1
+    undo(state) {
+      if (state.position === null) {
+        return
+      }
 
-      state.stack[state.position] = action.payload
-      state.position = newPosition < 0 ? 0 : newPosition
+      state.position = Math.max(0, state.position - 1)
     },
 
     redo(state) {
+      if (state.position === null) {
+        return
+      }
+
       const newPosition = state.position + 1
       const stackSize = state.stack.length - 1
 
@@ -68,26 +73,31 @@ const undoSlice = createSlice({
 
     resetUndoStack(state) {
       state.stack = []
-      state.position = 0
+      state.position = null
     },
 
     replaceUndoStack(state, action: PayloadAction<HistoryState>) {
       state.stack = action.payload.stack
 
-      // Make sure given position is set to a value within stack length
-      state.position = Math.min(
-        action.payload.position,
-        action.payload.stack.length - 1
-      )
+      // Make sure given position is set to a value within stack length,
+      // and use `null` for an empty stack.
+      if (state.stack.length === 0) {
+        state.position = null
+      } else if (action.payload.position === null) {
+        state.position = state.stack.length - 1
+      } else {
+        state.position = Math.min(
+          Math.max(action.payload.position, 0),
+          state.stack.length - 1
+        )
+      }
     },
 
     createNewUndo(state, action: PayloadAction<Partial<StreetState>>) {
-      const position = state.position
-
-      // Create a shallow copy of the original undo stack up to the current
-      // current position. This removes future undo path in case we undo a
-      // few times and then do something undoable.
-      let stack = state.stack.slice(0, position)
+      // Keep history up to and including the current item, dropping any
+      // redo branch when a new snapshot is recorded after undo.
+      const retainedLength = state.position === null ? 0 : state.position + 1
+      let stack = state.stack.slice(0, retainedLength)
 
       // Add the latest state
       const street = action.payload
@@ -99,7 +109,7 @@ const undoSlice = createSlice({
 
       // Update
       state.stack = stack
-      state.position = Math.min(position, MAX_UNDO_LIMIT) + 1
+      state.position = stack.length > 0 ? stack.length - 1 : null
     },
 
     /**

--- a/client/src/streets/remix.ts
+++ b/client/src/streets/remix.ts
@@ -59,9 +59,10 @@ export function remixStreet() {
 
   const undoStack = getUndoStack()
   const undoPosition = getUndoPosition()
+  const previousPosition = undoPosition === null ? -1 : undoPosition - 1
   if (
-    undoStack[undoPosition - 1] &&
-    undoStack[undoPosition - 1].name !== street.name
+    undoStack[previousPosition] &&
+    undoStack[previousPosition].name !== street.name
   ) {
     // The street was remixed as a result of editing its name. Don’t be
     // a douche and add (remixed) to it then.

--- a/client/src/streets/undo_stack.test.ts
+++ b/client/src/streets/undo_stack.test.ts
@@ -5,6 +5,7 @@ import { finishUndoOrRedo } from './undo_stack'
 const {
   updateStreetDataActionMock,
   cancelSegmentResizeTransitionsMock,
+  setIgnoreStreetChangesMock,
   setUpdateTimeToNowMock,
   updateEverythingMock,
   dispatchMock,
@@ -15,6 +16,7 @@ const {
     payload,
   })),
   cancelSegmentResizeTransitionsMock: vi.fn(),
+  setIgnoreStreetChangesMock: vi.fn(),
   setUpdateTimeToNowMock: vi.fn(),
   updateEverythingMock: vi.fn(),
   dispatchMock: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock('../segments/resizing.js', () => ({
 }))
 
 vi.mock('./data_model.js', () => ({
+  setIgnoreStreetChanges: setIgnoreStreetChangesMock,
   setUpdateTimeToNow: setUpdateTimeToNowMock,
   updateEverything: updateEverythingMock,
 }))
@@ -46,7 +49,7 @@ describe('finishUndoOrRedo', () => {
     vi.clearAllMocks()
   })
 
-  it('seeds missing segment warnings before restoring street data', () => {
+  it('seeds missing segment warnings before restoring street data', async () => {
     getStateMock.mockReturnValue({
       history: {
         position: 0,
@@ -67,7 +70,7 @@ describe('finishUndoOrRedo', () => {
       },
     })
 
-    finishUndoOrRedo()
+    await finishUndoOrRedo()
 
     expect(updateStreetDataActionMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -82,9 +85,11 @@ describe('finishUndoOrRedo', () => {
     expect(cancelSegmentResizeTransitionsMock).toHaveBeenCalledTimes(1)
     expect(setUpdateTimeToNowMock).toHaveBeenCalledTimes(1)
     expect(updateEverythingMock).toHaveBeenCalledWith(true)
+    expect(setIgnoreStreetChangesMock).toHaveBeenNthCalledWith(1, true)
+    expect(setIgnoreStreetChangesMock).toHaveBeenNthCalledWith(2, false)
   })
 
-  it('preserves existing warnings on restored segments', () => {
+  it('preserves existing warnings on restored segments', async () => {
     getStateMock.mockReturnValue({
       history: {
         position: 0,
@@ -106,7 +111,7 @@ describe('finishUndoOrRedo', () => {
       },
     })
 
-    finishUndoOrRedo()
+    await finishUndoOrRedo()
 
     expect(updateStreetDataActionMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/client/src/streets/undo_stack.ts
+++ b/client/src/streets/undo_stack.ts
@@ -4,7 +4,11 @@ import { cancelSegmentResizeTransitions } from '../segments/resizing.js'
 import store from '../store'
 import { updateStreetDataAction } from '../store/actions/street.js'
 import { createNewUndo, unifyStack } from '../store/slices/history.js'
-import { setUpdateTimeToNow, updateEverything } from './data_model.js'
+import {
+  setIgnoreStreetChanges,
+  setUpdateTimeToNow,
+  updateEverything,
+} from './data_model.js'
 
 import type { StreetState } from '@streetmix/types'
 
@@ -16,7 +20,7 @@ export function getUndoPosition() {
   return store.getState().history.position
 }
 
-export function finishUndoOrRedo() {
+export async function finishUndoOrRedo() {
   // set current street to the thing we just updated
   const { position, stack } = store.getState().history
   if (position === null) {
@@ -34,12 +38,15 @@ export function finishUndoOrRedo() {
     }))
   }
 
-  store.dispatch(updateStreetDataAction(restoredStreet))
-  cancelSegmentResizeTransitions()
-
-  setUpdateTimeToNow()
-
-  updateEverything(true)
+  setIgnoreStreetChanges(true)
+  try {
+    await store.dispatch(updateStreetDataAction(restoredStreet))
+    cancelSegmentResizeTransitions()
+    setUpdateTimeToNow()
+    updateEverything(true)
+  } finally {
+    setIgnoreStreetChanges(false)
+  }
 }
 
 export function createNewUndoIfNecessary(

--- a/client/src/streets/undo_stack.ts
+++ b/client/src/streets/undo_stack.ts
@@ -19,6 +19,10 @@ export function getUndoPosition() {
 export function finishUndoOrRedo() {
   // set current street to the thing we just updated
   const { position, stack } = store.getState().history
+  if (position === null) {
+    return
+  }
+
   const restoredStreet = clone(stack[position])
 
   // Undo stack snapshots intentionally omit derived warnings.
@@ -47,7 +51,7 @@ export function createNewUndoIfNecessary(
     return
   }
 
-  store.dispatch(createNewUndo(clone(lastStreet)))
+  store.dispatch(createNewUndo(clone(currentStreet)))
 }
 
 export function unifyUndoStack() {

--- a/client/src/users/localization.js
+++ b/client/src/users/localization.js
@@ -4,7 +4,7 @@ import { normalizeAllSegmentWidths } from '../segments/resizing'
 import { segmentsChanged } from '../segments/view'
 import {
   saveStreetToServerIfNecessary,
-  setIgnoreStreetChanges
+  setIgnoreStreetChanges,
 } from '../streets/data_model'
 import { getUndoStack, getUndoPosition } from '../streets/undo_stack'
 import { normalizeStreetWidth } from '../streets/width'
@@ -13,7 +13,7 @@ import {
   setUnits,
   updateStreetWidth,
   updateStreetData,
-  updateSegments
+  updateSegments,
 } from '../store/slices/street'
 import { setUserUnits } from '../store/slices/settings'
 import { SETTINGS_UNITS_IMPERIAL, SETTINGS_UNITS_METRIC } from './constants'
@@ -22,7 +22,7 @@ const COUNTRIES_IMPERIAL_UNITS = ['US']
 
 let leftHandTraffic = false
 
-export function getLeftHandTraffic () {
+export function getLeftHandTraffic() {
   return leftHandTraffic
 }
 
@@ -101,10 +101,10 @@ const COUNTRIES_LEFT_HAND_TRAFFIC = [
   'VG',
   'VI',
   'ZM',
-  'ZW'
+  'ZW',
 ]
 
-export function updateSettingsFromCountryCode (countryCode) {
+export function updateSettingsFromCountryCode(countryCode) {
   if (COUNTRIES_LEFT_HAND_TRAFFIC.indexOf(countryCode) !== -1) {
     leftHandTraffic = true
   }
@@ -116,7 +116,7 @@ export function updateSettingsFromCountryCode (countryCode) {
   updateUnitSettings(countryCode)
 }
 
-export function updateUnitSettings (countryCode) {
+export function updateUnitSettings(countryCode) {
   const localStorageUnits = store.getState().settings.units
   let unitType
 
@@ -132,7 +132,7 @@ export function updateUnitSettings (countryCode) {
 }
 
 // Only changes the units of the street, not the user.
-export function updateUnits (newUnits) {
+export function updateUnits(newUnits) {
   let fromUndo
   const street = store.getState().street
   if (street.units === newUnits) {
@@ -145,9 +145,10 @@ export function updateUnits (newUnits) {
   // to undo stack instead of double conversion (which could be lossy).
   const undoStack = getUndoStack()
   const undoPosition = getUndoPosition()
+  const previousPosition = undoPosition === null ? -1 : undoPosition - 1
   if (
-    undoStack[undoPosition - 1] &&
-    undoStack[undoPosition - 1].units === newUnits
+    undoStack[previousPosition] &&
+    undoStack[previousPosition].units === newUnits
   ) {
     fromUndo = true
   } else {
@@ -171,7 +172,7 @@ export function updateUnits (newUnits) {
       )
     }
   } else {
-    store.dispatch(updateStreetData(clone(undoStack[undoPosition - 1])))
+    store.dispatch(updateStreetData(clone(undoStack[previousPosition])))
   }
   segmentsChanged()
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -193,7 +193,7 @@ export type FloodDistance = number | null | 'max'
 
 export interface HistoryState {
   stack: Partial<StreetState>[]
-  position: number
+  position: number | null
 }
 
 export type WeatherEffect = 'rain' | 'snow'


### PR DESCRIPTION
Ideally this fixes:

- Unable to undo more than one position. (Position was stuck, and undoing will just swap between previous states forever, with no redo)
- Switching a boundary variant incorrectly triggers an additional push to history stack.
