### PR TITLE
Update flood distance checking

### DIFF
--- a/client/src/plugins/coastmix/sea_level.test.ts
+++ b/client/src/plugins/coastmix/sea_level.test.ts
@@ -1,5 +1,5 @@
 import { createStreetState } from '~/test/factories/street.js'
-import { calculateSeaLevelRise } from './sea_level.js'
+import { calculateSeaLevelRise, checkSeaLevel } from './sea_level.js'
 
 describe('sea level rise', () => {
   describe('calculateSeaLevelRise', () => {
@@ -53,6 +53,146 @@ describe('sea level rise', () => {
 
       const result9 = calculateSeaLevelRise(2070, false, street)
       expect(result9).toBe(2.372)
+    })
+  })
+
+  describe('checkSeaLevel', () => {
+    it('treats a slope with a higher far edge as blocking floodwater from the left', () => {
+      const street = createStreetState({
+        boundary: {
+          left: {
+            variant: 'beach',
+            elevation: 0,
+          },
+          right: {
+            variant: 'grass',
+            elevation: 0,
+          },
+        },
+        segments: [
+          {
+            width: 4,
+            type: 'path',
+            elevation: 0,
+            slope: {
+              on: true,
+              values: [0.2, 0.7],
+            },
+          },
+          {
+            width: 4,
+            type: 'path',
+            elevation: 0.1,
+            slope: {
+              on: false,
+              values: [],
+            },
+          },
+        ],
+      })
+
+      const streetEl = document.createElement('div')
+      const leftSlopeEl = document.createElement('div')
+      leftSlopeEl.dataset.sliceIndex = '0'
+      leftSlopeEl.dataset.sliceLeft = '0'
+      Object.defineProperty(leftSlopeEl, 'offsetWidth', {
+        configurable: true,
+        value: 40,
+      })
+      streetEl.appendChild(leftSlopeEl)
+
+      const lowerFlatEl = document.createElement('div')
+      lowerFlatEl.dataset.sliceIndex = '1'
+      lowerFlatEl.dataset.sliceLeft = '40'
+      Object.defineProperty(lowerFlatEl, 'offsetWidth', {
+        configurable: true,
+        value: 40,
+      })
+      streetEl.appendChild(lowerFlatEl)
+
+      const canvasEl = document.createElement('div')
+
+      const [leftFloodDistance, rightFloodDistance] = checkSeaLevel(
+        street,
+        streetEl,
+        canvasEl,
+        2030,
+        false
+      )
+
+      expect(leftFloodDistance).toBeCloseTo(20.56, 2)
+      expect(rightFloodDistance).toBeNull()
+    })
+
+    it('treats a slope with a higher far edge as blocking floodwater from the right', () => {
+      const street = createStreetState({
+        boundary: {
+          left: {
+            variant: 'grass',
+            elevation: 0,
+          },
+          right: {
+            variant: 'beach',
+            elevation: 0,
+          },
+        },
+        segments: [
+          {
+            width: 4,
+            type: 'path',
+            elevation: 0.1,
+            slope: {
+              on: false,
+              values: [],
+            },
+          },
+          {
+            width: 4,
+            type: 'path',
+            elevation: 0,
+            slope: {
+              on: true,
+              values: [0.7, 0.2],
+            },
+          },
+        ],
+      })
+
+      const streetEl = document.createElement('div')
+      const lowerFlatEl = document.createElement('div')
+      lowerFlatEl.dataset.sliceIndex = '0'
+      lowerFlatEl.dataset.sliceLeft = '0'
+      Object.defineProperty(lowerFlatEl, 'offsetWidth', {
+        configurable: true,
+        value: 40,
+      })
+      streetEl.appendChild(lowerFlatEl)
+
+      const rightSlopeEl = document.createElement('div')
+      rightSlopeEl.dataset.sliceIndex = '1'
+      rightSlopeEl.dataset.sliceLeft = '40'
+      Object.defineProperty(rightSlopeEl, 'offsetWidth', {
+        configurable: true,
+        value: 40,
+      })
+      streetEl.appendChild(rightSlopeEl)
+
+      const canvasEl = document.createElement('div')
+      Object.defineProperty(canvasEl, 'offsetWidth', {
+        configurable: true,
+        value: 80,
+      })
+
+      const [leftFloodDistance, rightFloodDistance] = checkSeaLevel(
+        street,
+        streetEl,
+        canvasEl,
+        2030,
+        false
+      )
+
+      expect(leftFloodDistance).toBeNull()
+      expect(rightFloodDistance).toBeCloseTo(20.56, 2)
     })
   })
 })

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -68,13 +68,10 @@ function calculateFloodDistance(
 
     // Slices can block a flood based on its elevation.
     // First, see if this slice is sloped.
-    // Compare the flood height with the slope value facing the flood direction
+    // If sloped, a slice blocks a blood if any of its endpoints are higher
+    // than the height.
     if (slice.slope.on) {
-      if (fromLeft) {
-        compareElevation = slice.slope.values[0] ?? slice.elevation
-      } else {
-        compareElevation = slice.slope.values[1] ?? slice.elevation
-      }
+      compareElevation = Math.max(slice.slope.values[0], slice.slope.values[1])
     } else {
       // If not sloped, we look at the slice's flat elevation.
       compareElevation = slice.elevation
@@ -113,7 +110,20 @@ function calculateFloodDistance(
 
   if (fromLeft) {
     const distance = Number(sliceEl?.dataset.sliceLeft)
-    return distance
+
+    // If sloped, how far does flood go before it hits the slope?
+    const slice = slices[slicePosition]
+    let extraDistance = 0
+    if (slice.slope.on) {
+      const rise = slice.slope.values[1] - slice.slope.values[0]
+      if (rise > 0) {
+        const run = sliceEl?.offsetWidth ?? 0 // This is the width of item
+        // This is a rise/run formula
+        extraDistance = (run / rise) * (slice.slope.values[0] - height)
+      }
+    }
+
+    return distance - extraDistance
   } else {
     // There are some extra steps for calculating the right-hand distance
     // which is based on the width of the on-screen canvasEl element.
@@ -126,7 +136,19 @@ function calculateFloodDistance(
     const offsetLeftPlusWidth =
       Number(sliceEl?.dataset.sliceLeft) + (sliceEl?.offsetWidth ?? 0)
 
-    const distance = parentWidth - offsetLeftPlusWidth
+    // If sloped, how far does flood go before it hits the slope?
+    const slice = slices[slicePosition]
+    let extraDistance = 0
+    if (slice.slope.on) {
+      const rise = slice.slope.values[0] - slice.slope.values[1]
+      if (rise > 0) {
+        const run = sliceEl?.offsetWidth ?? 0 // This is the width of item
+        // This is a rise/run formula
+        extraDistance = -(run / rise) * (height - slice.slope.values[1])
+      }
+    }
+
+    const distance = parentWidth - offsetLeftPlusWidth - extraDistance
     return distance
   }
 }


### PR DESCRIPTION
- Fixes a bug where the far side of a slope doesn't block a flood if it's higher than the sea level, but the adjacent element behind it is not.
- Flood distance now stops along a slope.
- AI-written test coverage.