### PR TITLE
Attempt fixes on flaky tests

### DIFF
--- a/client/src/app/BlockingError.test.tsx
+++ b/client/src/app/BlockingError.test.tsx
@@ -2,6 +2,18 @@ import { render } from '~/test/helpers/render.js'
 import { BlockingError } from './BlockingError.js'
 import { ERRORS } from './errors.js'
 
+// Mocking this prevent a frequently flaky test outcome where redux-toolkit
+// tries to run `cancelAnimationFrame` internally, which is no longer defined,
+// and then the test fails.
+vi.mock('../store/services/api.js', async () => {
+  const actual = await vi.importActual('../store/services/api.js')
+
+  return {
+    ...actual,
+    useGetUserQuery: vi.fn(() => ({ data: null })),
+  }
+})
+
 function getInitialState(errorType: number | null): object {
   return {
     errors: {

--- a/client/src/streets/undo_stack.test.ts
+++ b/client/src/streets/undo_stack.test.ts
@@ -2,6 +2,8 @@ import { create } from 'jsondiffpatch'
 
 import { finishUndoOrRedo } from './undo_stack.js'
 
+// Most of the mocks in this suite were set up by Claude, and I'm not
+// that happy with it.
 const {
   updateStreetDataActionMock,
   setIgnoreStreetChangesMock,
@@ -19,6 +21,12 @@ const {
   updateEverythingMock: vi.fn(),
   dispatchMock: vi.fn(),
   getStateMock: vi.fn(),
+}))
+
+// This side effect method uses a `setTimeout`, mocking it prevents
+// async leakage
+vi.mock('../segments/resizing.js', () => ({
+  cancelSegmentResizeTransitions: vi.fn(),
 }))
 
 vi.mock('../store', () => ({
@@ -39,7 +47,7 @@ vi.mock('./data_model.js', () => ({
 }))
 
 describe('finishUndoOrRedo', () => {
-  beforeEach(() => {
+  afterEach(() => {
     vi.clearAllMocks()
   })
 


### PR DESCRIPTION
This should fix intermittently failing tests that appear randomly while running test suites in `undo_stack.test.js` and `BlockingError.test.jsx`, related to async functions that fail in CI because globals are no longer available. Attempts to harden async behavior from redux-toolkit proved unwieldy with little observable benefit. Furthermore, it is possible to resolve the async issue in `undo_stack` by setting up fake timers and running timers during each test, but ultimately it's still a workaround, one which can just as easily be resolved by mocking the import from `resizing.js` which is a side-effect, anyway.

I re-ran this test three times with no failures, which is (anecdotally) a noticeably better hit rate than previous.