### PR TITLE
fix: remove sensitive token and signature logging

### DIFF
--- a/app/resources/services/integrations/coil.ts
+++ b/app/resources/services/integrations/coil.ts
@@ -180,7 +180,6 @@ export async function BTPTokenCheck(
   req.session.btpToken = btpToken
   // ..but it dosen't work unless we do this:
   res.cookie('btpToken', btpToken)
-  console.log(btpToken)
   return next()
 }
 

--- a/app/resources/services/integrations/patreon.ts
+++ b/app/resources/services/integrations/patreon.ts
@@ -157,9 +157,5 @@ export function webhook(req: Request, res: Response, _next: NextFunction) {
     return
   }
 
-  console.log(JSON.stringify(req.body))
-  console.log(req.headers['x-patreon-event'])
-  console.log(req.headers['x-patreon-signature'])
-
   res.status(204).end()
 }


### PR DESCRIPTION
Both the Coil and Patreon integrations write secrets to the server console log on every request.

- coil.ts logged the BTP token right after setting it as a session cookie. This token is a bearer credential for Coil's payment provisioning API, so it should not be written to logs.
- patreon.ts logged the full webhook request body plus the x-patreon-event and x-patreon-signature headers on every valid webhook call. The signature header is the HMAC computed from the webhook's shared secret, and the body can contain subscriber data from Patreon.

Removing these debug statements does not change behavior; they were leftover from the original 2021 implementations and are not read anywhere else in the codebase.