### PR TITLE
Rebuild flood checking functionality

### DIFF
--- a/client/src/app/StreetEditable.test.tsx
+++ b/client/src/app/StreetEditable.test.tsx
@@ -35,6 +35,10 @@ describe('StreetEditable', () => {
             DEBUG_SLICE_SLOPE: { value: false },
           },
           street: createStreetState({
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [segment],
             width: 120,
             remainingWidth: 120,

--- a/client/src/app/StreetView.tsx
+++ b/client/src/app/StreetView.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { useDispatch, useSelector } from '~/src/store/hooks.js'
+import { useSelector } from '~/src/store/hooks.js'
 import { usePrevious } from '~/src/util/usePrevious.js'
 import { Boundary } from '~/src/boundary/index.js'
 import { PopupContainerGroup } from '~/src/info_bubble/PopupContainer.js'
 import { SeaLevel } from '~/src/plugins/coastmix/index.js'
-import { checkSeaLevel } from '~/src/plugins/coastmix/sea_level.js'
-import { setFloodDetails } from '~/src/store/slices/coastmix.js'
 import { ResizeGuides } from '../segments/ResizeGuides.js'
 import { EmptySegmentContainer } from '../segments/EmptySegmentContainer.js'
 import { animate, getElAbsolutePos } from '../util/helpers.js'
@@ -95,12 +93,9 @@ export function StreetView() {
 
   const street = useSelector((state) => state.street)
   const draggingType = useSelector((state) => state.ui.draggingType)
-  const { seaLevelRise, stormSurge } = useSelector((state) => state.coastmix)
   const coastmixMode = useSelector(
     (state) => state.flags.COASTMIX_MODE.value ?? false
   )
-
-  const dispatch = useDispatch()
 
   // Keep previous state for comparisons (ported from legacy behavior)
   const prevState = usePrevious({
@@ -124,15 +119,8 @@ export function StreetView() {
     sectionCanvasEl.current.style.width = streetWidth + 'px'
     sectionCanvasEl.current.style.left = streetSectionCanvasLeft + 'px'
 
-    // Since flooding relies on sectionCanvasEl width being set, calculate
-    // flood distance here. This can change if we start calculating
-    // distance in actual distance values rather than on screen pixel values.
-    // TODO: we now no longer need sectionCanvasEl so consider moving this
-    const floodDetails = checkSeaLevel(street, seaLevelRise, stormSurge)
-    dispatch(setFloodDetails(floodDetails))
-
     return STREETVIEW_RESIZED
-  }, [street, dispatch, seaLevelRise, stormSurge])
+  }, [street.width])
 
   const handleStreetResize = useCallback(() => {
     // Place all scroll-based positioning effects inside of a "raf"

--- a/client/src/app/StreetView.tsx
+++ b/client/src/app/StreetView.tsx
@@ -6,7 +6,10 @@ import { Boundary } from '~/src/boundary/index.js'
 import { PopupContainerGroup } from '~/src/info_bubble/PopupContainer.js'
 import { SeaLevel } from '~/src/plugins/coastmix/index.js'
 import { checkSeaLevel } from '~/src/plugins/coastmix/sea_level.js'
-import { setFloodDistance } from '~/src/store/slices/coastmix.js'
+import {
+  setFloodDistance,
+  setFloodDetails,
+} from '~/src/store/slices/coastmix.js'
 import { ResizeGuides } from '../segments/ResizeGuides.js'
 import { EmptySegmentContainer } from '../segments/EmptySegmentContainer.js'
 import { animate, getElAbsolutePos } from '../util/helpers.js'
@@ -134,8 +137,8 @@ export function StreetView() {
       seaLevelRise,
       stormSurge
     )
-    console.log(floodDetails)
     dispatch(setFloodDistance(floodDistance))
+    dispatch(setFloodDetails(floodDetails))
 
     return STREETVIEW_RESIZED
   }, [street, dispatch, seaLevelRise, stormSurge])

--- a/client/src/app/StreetView.tsx
+++ b/client/src/app/StreetView.tsx
@@ -127,13 +127,14 @@ export function StreetView() {
     // Since flooding relies on sectionCanvasEl width being set, calculate
     // flood distance here. This can change if we start calculating
     // distance in actual distance values rather than on screen pixel values.
-    const floodDistance = checkSeaLevel(
+    const { floodDistance, floodDetails } = checkSeaLevel(
       street,
       slicesEl.current,
       sectionCanvasEl.current,
       seaLevelRise,
       stormSurge
     )
+    console.log(floodDetails)
     dispatch(setFloodDistance(floodDistance))
 
     return STREETVIEW_RESIZED

--- a/client/src/app/StreetView.tsx
+++ b/client/src/app/StreetView.tsx
@@ -6,10 +6,7 @@ import { Boundary } from '~/src/boundary/index.js'
 import { PopupContainerGroup } from '~/src/info_bubble/PopupContainer.js'
 import { SeaLevel } from '~/src/plugins/coastmix/index.js'
 import { checkSeaLevel } from '~/src/plugins/coastmix/sea_level.js'
-import {
-  setFloodDistance,
-  setFloodDetails,
-} from '~/src/store/slices/coastmix.js'
+import { setFloodDetails } from '~/src/store/slices/coastmix.js'
 import { ResizeGuides } from '../segments/ResizeGuides.js'
 import { EmptySegmentContainer } from '../segments/EmptySegmentContainer.js'
 import { animate, getElAbsolutePos } from '../util/helpers.js'
@@ -130,14 +127,8 @@ export function StreetView() {
     // Since flooding relies on sectionCanvasEl width being set, calculate
     // flood distance here. This can change if we start calculating
     // distance in actual distance values rather than on screen pixel values.
-    const { floodDistance, floodDetails } = checkSeaLevel(
-      street,
-      slicesEl.current,
-      sectionCanvasEl.current,
-      seaLevelRise,
-      stormSurge
-    )
-    dispatch(setFloodDistance(floodDistance))
+    // TODO: we now no longer need sectionCanvasEl so consider moving this
+    const floodDetails = checkSeaLevel(street, seaLevelRise, stormSurge)
     dispatch(setFloodDetails(floodDetails))
 
     return STREETVIEW_RESIZED

--- a/client/src/gallery/index.ts
+++ b/client/src/gallery/index.ts
@@ -1,18 +1,21 @@
-import { hideBlockingShield, showBlockingShield } from '../app/blocking_shield'
-import { ERRORS, showError } from '../app/errors'
-import { getMode, MODES, processMode, setMode } from '../app/mode'
+import {
+  hideBlockingShield,
+  showBlockingShield,
+} from '../app/blocking_shield.js'
+import { ERRORS, showError } from '../app/errors.js'
+import { getMode, MODES, processMode, setMode } from '../app/mode.js'
 import store from '../store'
 import { segmentsChanged } from '../store/actions/street.js'
-import { hideError } from '../store/slices/errors'
-import { resetMapState } from '../store/slices/map'
-import { setIgnoreStreetChanges, setLastStreet } from '../streets/data_model'
-import { SAVE_THUMBNAIL_EVENTS, saveStreetThumbnail } from '../streets/image'
-import { unpackServerStreetData } from '../streets/xhr'
+import { hideError } from '../store/slices/errors.js'
+import { resetMapState } from '../store/slices/map.js'
+import { setIgnoreStreetChanges, setLastStreet } from '../streets/data_model.js'
+import { SAVE_THUMBNAIL_EVENTS, saveStreetThumbnail } from '../streets/image.js'
+import { unpackServerStreetData } from '../streets/xhr.js'
 import {
   getGalleryForAllStreets,
   getGalleryForUser,
   getStreet,
-} from '../util/api'
+} from '../util/api.js'
 
 import type { StreetAPIResponse } from '@streetmix/types'
 

--- a/client/src/info_bubble/PopupControls/CoastmixControls.test.tsx
+++ b/client/src/info_bubble/PopupControls/CoastmixControls.test.tsx
@@ -6,9 +6,13 @@ import { render } from '~/test/helpers/render.js'
 import { toggleSliceSlope } from '~/src/store/slices/street.js'
 import { CoastmixControls } from './CoastmixControls.js'
 
-vi.mock('@streetmix/parts', () => ({
-  getSegmentVariantInfo: vi.fn((_type) => ({})),
-}))
+vi.mock('@streetmix/parts', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, () => unknown>>()
+  return {
+    ...actual,
+    getSegmentVariantInfo: vi.fn((_type) => ({})),
+  }
+})
 vi.mock('~/src/store/slices/street.js', async (importOriginal) => {
   const actual = await importOriginal<Record<string, () => unknown>>()
   return {

--- a/client/src/info_bubble/PopupControls/CoastmixControls.test.tsx
+++ b/client/src/info_bubble/PopupControls/CoastmixControls.test.tsx
@@ -24,6 +24,10 @@ vi.mock('~/src/store/slices/street.js', async (importOriginal) => {
 const initialState = {
   street: {
     width: 10,
+    boundary: {
+      left: { variant: 'wide', elevation: 0 },
+      right: { variant: 'wide', elevation: 0 },
+    },
     segments: [
       // Slice `0` is not sloped
       {

--- a/client/src/info_bubble/PopupControls/VariantSet.tsx
+++ b/client/src/info_bubble/PopupControls/VariantSet.tsx
@@ -82,6 +82,7 @@ export function VariantSet(props: SectionElementTypeAndPosition) {
     if (type === 'boundary') {
       handler = () => {
         dispatch(setBuildingVariant(position, selection))
+        dispatch(segmentsChanged())
       }
     } else {
       handler = () => {

--- a/client/src/info_bubble/PopupControls/WidthControl.test.tsx
+++ b/client/src/info_bubble/PopupControls/WidthControl.test.tsx
@@ -8,7 +8,10 @@ describe('WidthControl', () => {
   const activeElement = 0
   const initialState = {
     street: {
-      boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+      boundary: {
+        left: { variant: 'wide', elevation: 0 },
+        right: { variant: 'wide', elevation: 0 },
+      },
       segments: [
         {
           type: 'streetcar',

--- a/client/src/plugins/coastmix/CoastalFloodingPanel.tsx
+++ b/client/src/plugins/coastmix/CoastalFloodingPanel.tsx
@@ -19,7 +19,7 @@ export function CoastalFloodingPanel() {
   const dispatch = useDispatch()
   const intl = useIntl()
 
-  const { controlsVisible, seaLevelRise, floodDistance, stormSurge } = coastmix
+  const { controlsVisible, seaLevelRise, floodDetails, stormSurge } = coastmix
 
   function handleClose(): void {
     dispatch(hideCoastalFloodingPanel())
@@ -42,10 +42,10 @@ export function CoastalFloodingPanel() {
   const messageClassNames = ['flood-controls-message']
   if (seaLevelRise === 0 && stormSurge === false) {
     message = `👉 ${intl.formatMessage({ id: 'tools.flooding.messages.start', defaultMessage: 'Select a sea level rise target to visualize flooding.' })}`
-  } else if (floodDistance[0] === null && floodDistance[1] === null) {
+  } else if (floodDetails[0] === null && floodDetails[1] === null) {
     message = `👉 ${intl.formatMessage({ id: 'tools.flooding.messages.need-waterfront', defaultMessage: 'Add a waterfront boundary to visualize flooding.' })}`
   } else {
-    if (floodDistance.includes('max')) {
+    if (floodDetails[0]?.flooded || floodDetails[1]?.flooded) {
       message = `❌ ${intl.formatMessage({ id: 'tools.flooding.messages.fail', defaultMessage: 'This configuration does not address sea level rise!' })}`
       messageClassNames.push('flood-controls-warning')
     } else {

--- a/client/src/plugins/coastmix/CoastmixUI.tsx
+++ b/client/src/plugins/coastmix/CoastmixUI.tsx
@@ -1,5 +1,6 @@
 import { CoastalFloodingPanel } from '~/src/plugins/coastmix'
 import { useSelector } from '~/src/store/hooks.js'
+import { FloodingDebugOverlay } from './FloodingDebugOverlay.js'
 import './CoastmixUI.css'
 
 export function CoastmixUI() {
@@ -7,5 +8,10 @@ export function CoastmixUI() {
 
   if (!coastmixMode) return null
 
-  return <CoastalFloodingPanel />
+  return (
+    <>
+      <FloodingDebugOverlay />
+      <CoastalFloodingPanel />
+    </>
+  )
 }

--- a/client/src/plugins/coastmix/FloodingDebugOverlay.css
+++ b/client/src/plugins/coastmix/FloodingDebugOverlay.css
@@ -1,0 +1,19 @@
+.flooding-debug-overlay {
+  position: absolute;
+  top: 60px;
+  left: 20px;
+  width: 300px;
+  background-color: rgb(0 0 0 / 20%);
+  color: white;
+  font-family: "Courier New", Courier, monospace;
+  font-weight: bold;
+  padding: 1em;
+  padding-bottom: 0.5em;
+  pointer-events: none;
+  z-index: 990;
+
+  h2 {
+    font-family: "Courier New", Courier, monospace;
+    margin-top: 0;
+  }
+}

--- a/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
+++ b/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
@@ -1,0 +1,80 @@
+import { convertMetricMeasurementToImperial } from '@streetmix/utils'
+import { SliceTypes } from '@streetmix/parts'
+import type { FloodDetails } from '@streetmix/types'
+
+import { useSelector } from '~src/store/hooks.js'
+import './FloodingDebugOverlay.css'
+
+const disallowFlooding = [
+  SliceTypes.CAR,
+  SliceTypes.BIKE,
+  SliceTypes.TRANSIT,
+  SliceTypes.BIKE,
+  // Maybe okay to flood, if we're lax about it!
+  // SliceTypes.FURNITURE,
+  // SliceTypes.FLEX,
+  SliceTypes.UTILITY,
+]
+
+function Details({ details }: { details: FloodDetails }) {
+  if (details === null) return
+
+  const distance = details.distance ?? 0
+  const distanceDisplay =
+    typeof distance === 'number' && distance !== Infinity
+      ? `${convertMetricMeasurementToImperial(distance)} ft`
+      : 'max'
+
+  const styledTypes = []
+  if (details.floodedTypes.length > 0) {
+    for (let i = 0; i < details.floodedTypes.length; i++) {
+      const type = details.floodedTypes[i]
+      if (disallowFlooding.includes(type)) {
+        styledTypes.push(<span style={{ color: 'red' }}>{type}</span>)
+      } else {
+        styledTypes.push(<span style={{ color: 'lightgreen' }}>{type}</span>)
+      }
+    }
+  } else {
+    styledTypes.push(<span>none</span>)
+  }
+
+  return (
+    <>
+      Distance flooded: {distanceDisplay}
+      <br />
+      Flooded areas:{' '}
+      <span style={{ textTransform: 'lowercase' }}>
+        {styledTypes.map((el, i) => [i > 0 && ', ', el])}
+      </span>
+      <br />
+      Bad?{' '}
+      {details.flooded ? (
+        <span style={{ color: 'red' }}>yes</span>
+      ) : (
+        <span style={{ color: 'lightgreen' }}>no</span>
+      )}
+    </>
+  )
+}
+
+export function FloodingDebugOverlay() {
+  const { floodDetails } = useSelector((state) => state.coastmix)
+  const [left, right] = floodDetails
+
+  return (
+    <div className="flooding-debug-overlay">
+      <h2>Flooding debug</h2>
+      <p>
+        Left:
+        <br />
+        {left === null ? 'Not a waterfront' : <Details details={left} />}
+      </p>
+      <p>
+        Right:
+        <br />
+        {right === null ? 'Not a waterfront' : <Details details={right} />}
+      </p>
+    </div>
+  )
+}

--- a/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
+++ b/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
@@ -16,10 +16,19 @@ const disallowFlooding = [
   SliceTypes.UTILITY,
 ]
 
-function Details({ details }: { details: FloodDetails }) {
+function Details({
+  details,
+  remainingWidth,
+}: {
+  details: FloodDetails
+  remainingWidth: number
+}) {
   if (details === null) return
 
-  const distance = details.distance ?? 0
+  const distance =
+    typeof details.distance === 'number'
+      ? details.distance + remainingWidth / 2
+      : details.distance
   const distanceDisplay =
     typeof distance === 'number'
       ? `${convertMetricMeasurementToImperial(distance)} ft`
@@ -67,6 +76,7 @@ function Details({ details }: { details: FloodDetails }) {
 }
 
 export function FloodingDebugOverlay() {
+  const { remainingWidth } = useSelector((state) => state.street)
   const { floodDetails } = useSelector((state) => state.coastmix)
   const [left, right] = floodDetails
 
@@ -76,12 +86,20 @@ export function FloodingDebugOverlay() {
       <p>
         Left:
         <br />
-        {left === null ? 'Not a waterfront' : <Details details={left} />}
+        {left === null ? (
+          'Not a waterfront'
+        ) : (
+          <Details details={left} remainingWidth={remainingWidth} />
+        )}
       </p>
       <p>
         Right:
         <br />
-        {right === null ? 'Not a waterfront' : <Details details={right} />}
+        {right === null ? (
+          'Not a waterfront'
+        ) : (
+          <Details details={right} remainingWidth={remainingWidth} />
+        )}
       </p>
     </div>
   )

--- a/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
+++ b/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
@@ -21,9 +21,9 @@ function Details({ details }: { details: FloodDetails }) {
 
   const distance = details.distance ?? 0
   const distanceDisplay =
-    typeof distance === 'number' && distance !== Infinity
+    typeof distance === 'number'
       ? `${convertMetricMeasurementToImperial(distance)} ft`
-      : 'max'
+      : distance
 
   const styledTypes = []
   if (details.floodedTypes.length > 0) {

--- a/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
+++ b/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
@@ -30,13 +30,21 @@ function Details({ details }: { details: FloodDetails }) {
     for (let i = 0; i < details.floodedTypes.length; i++) {
       const type = details.floodedTypes[i]
       if (disallowFlooding.includes(type)) {
-        styledTypes.push(<span style={{ color: 'red' }}>{type}</span>)
+        styledTypes.push(
+          <span style={{ color: 'red' }} key={type}>
+            {type}
+          </span>
+        )
       } else {
-        styledTypes.push(<span style={{ color: 'lightgreen' }}>{type}</span>)
+        styledTypes.push(
+          <span style={{ color: 'lightgreen' }} key={type}>
+            {type}
+          </span>
+        )
       }
     }
   } else {
-    styledTypes.push(<span>none</span>)
+    styledTypes.push(<span key="none">none</span>)
   }
 
   return (

--- a/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
+++ b/client/src/plugins/coastmix/FloodingDebugOverlay.tsx
@@ -1,8 +1,9 @@
 import { convertMetricMeasurementToImperial } from '@streetmix/utils'
 import { SliceTypes } from '@streetmix/parts'
-import type { FloodDetails } from '@streetmix/types'
 
-import { useSelector } from '~src/store/hooks.js'
+import { useSelector } from '~/src/store/hooks.js'
+
+import type { FloodDetails } from '@streetmix/types'
 import './FloodingDebugOverlay.css'
 
 const disallowFlooding = [
@@ -20,10 +21,16 @@ function Details({
   details,
   remainingWidth,
 }: {
-  details: FloodDetails
+  details: FloodDetails | null
   remainingWidth: number
 }) {
-  if (details === null) return
+  if (details === null)
+    return (
+      <>
+        <br />
+        Not a waterfront
+      </>
+    )
 
   const distance =
     typeof details.distance === 'number'
@@ -58,6 +65,7 @@ function Details({
 
   return (
     <>
+      <br />
       Distance flooded: {distanceDisplay}
       <br />
       Flooded areas:{' '}
@@ -85,21 +93,11 @@ export function FloodingDebugOverlay() {
       <h2>Flooding debug</h2>
       <p>
         Left:
-        <br />
-        {left === null ? (
-          'Not a waterfront'
-        ) : (
-          <Details details={left} remainingWidth={remainingWidth} />
-        )}
+        <Details details={left} remainingWidth={remainingWidth} />
       </p>
       <p>
         Right:
-        <br />
-        {right === null ? (
-          'Not a waterfront'
-        ) : (
-          <Details details={right} remainingWidth={remainingWidth} />
-        )}
+        <Details details={right} remainingWidth={remainingWidth} />
       </p>
     </div>
   )

--- a/client/src/plugins/coastmix/SeaLevel.tsx
+++ b/client/src/plugins/coastmix/SeaLevel.tsx
@@ -20,9 +20,10 @@ const LIMBO_OPACITY = 0.2
 export function SeaLevel({ boundaryWidth, scrollPos }: SeaLevelProps) {
   const street = useSelector((state) => state.street)
   const draggingType = useSelector((state) => state.ui.draggingType)
-  const { seaLevelRise, stormSurge, floodDistance } = useSelector(
+  const { seaLevelRise, stormSurge, floodDetails } = useSelector(
     (state) => state.coastmix
   )
+  const [leftFlood, rightFlood] = floodDetails
 
   // When switching streets, don't transition sea level height
   const prevStreetId = usePrevious(street.id)
@@ -34,7 +35,7 @@ export function SeaLevel({ boundaryWidth, scrollPos }: SeaLevelProps) {
   // Only set visual parameters when there is a flood direction.
   // Do not set when we're at current sea level with no storm surge.
   if (
-    (floodDistance[0] !== null || floodDistance[1] !== null) &&
+    (leftFlood !== null || rightFlood !== null) &&
     !(seaLevelRise === 0 && stormSurge === false)
   ) {
     // Baseline height
@@ -87,8 +88,8 @@ export function SeaLevel({ boundaryWidth, scrollPos }: SeaLevelProps) {
   // section), or when something is being dragged (we don't calculate flooding
   // distance mid-drag). Note this doesn't animate the right side.
   if (
-    floodDistance[0] === 'max' ||
-    floodDistance[1] === 'max' ||
+    leftFlood?.distance === 'max' ||
+    rightFlood?.distance === 'max' ||
     draggingType
   ) {
     return (
@@ -100,14 +101,23 @@ export function SeaLevel({ boundaryWidth, scrollPos }: SeaLevelProps) {
     )
   }
 
+  // The flooding distance is calculated from slices, and doesn't include
+  // the remaining space (positive values is empty, negative values is overflow)
+  // so we also need to add that here, then multiply by TILE_SIZE for the
+  // pixel dimension
+  const leftDistance =
+    ((leftFlood?.distance ?? 0) + street.remainingWidth / 2) * TILE_SIZE
+  const rightDistance =
+    ((rightFlood?.distance ?? 0) + street.remainingWidth / 2) * TILE_SIZE
+
   return (
     <>
-      {floodDistance[0] !== null && (
+      {leftFlood !== null && (
         <div
           className="sea-level-rise sea-level-rise-left"
           style={{
             ...styles,
-            width: `${boundaryWidth + floodDistance[0]}px`,
+            width: `${boundaryWidth + leftDistance}px`,
             right: 'auto',
           }}
         >
@@ -116,12 +126,12 @@ export function SeaLevel({ boundaryWidth, scrollPos }: SeaLevelProps) {
           </div>
         </div>
       )}
-      {floodDistance[1] !== null && (
+      {leftFlood !== null && (
         <div
           className="sea-level-rise sea-level-rise-right"
           style={{
             ...styles,
-            width: `${boundaryWidth + floodDistance[1]}px`,
+            width: `${boundaryWidth + rightDistance}px`,
             left: 'auto',
           }}
         >

--- a/client/src/plugins/coastmix/SeaLevel.tsx
+++ b/client/src/plugins/coastmix/SeaLevel.tsx
@@ -126,7 +126,7 @@ export function SeaLevel({ boundaryWidth, scrollPos }: SeaLevelProps) {
           </div>
         </div>
       )}
-      {leftFlood !== null && (
+      {rightFlood !== null && (
         <div
           className="sea-level-rise sea-level-rise-right"
           style={{

--- a/client/src/plugins/coastmix/sea_level.test.ts
+++ b/client/src/plugins/coastmix/sea_level.test.ts
@@ -228,7 +228,7 @@ describe('flooding distance', () => {
         ).toEqual({
           direction,
           distance: 2,
-          types: ['PEDESTRIAN'],
+          floodedTypes: ['PEDESTRIAN'],
           flooded: false,
         })
       }
@@ -253,7 +253,7 @@ describe('flooding distance', () => {
         ).toEqual({
           direction,
           distance: 0,
-          types: [],
+          floodedTypes: [],
           flooded: false,
         })
       }
@@ -277,8 +277,8 @@ describe('flooding distance', () => {
           )
         ).toEqual({
           direction,
-          distance: Infinity,
-          types: ['PEDESTRIAN'],
+          distance: 'max',
+          floodedTypes: ['PEDESTRIAN'],
           flooded: false,
         })
       }
@@ -306,7 +306,7 @@ describe('flooding distance', () => {
         ).toEqual({
           direction,
           distance: 0,
-          types: [],
+          floodedTypes: [],
           flooded: false,
         })
       }
@@ -333,8 +333,8 @@ describe('flooding distance', () => {
           )
         ).toEqual({
           direction,
-          distance: Infinity,
-          types: ['PEDESTRIAN'],
+          distance: 'max',
+          floodedTypes: ['PEDESTRIAN'],
           flooded: false,
         })
       }
@@ -360,7 +360,7 @@ describe('flooding distance', () => {
       ).toEqual({
         direction,
         distance: 5,
-        types: ['PEDESTRIAN'],
+        floodedTypes: ['PEDESTRIAN'],
         flooded: false,
       })
     })
@@ -382,7 +382,7 @@ describe('flooding distance', () => {
       ).toEqual({
         direction: 'left',
         distance: 0,
-        types: [],
+        floodedTypes: [],
         flooded: false,
       })
     })

--- a/client/src/plugins/coastmix/sea_level.test.ts
+++ b/client/src/plugins/coastmix/sea_level.test.ts
@@ -1,5 +1,9 @@
 import { createStreetState } from '~/test/factories/street.js'
-import { calculateSeaLevelRise, checkSeaLevel } from './sea_level.js'
+import {
+  calculateSeaLevelRise,
+  checkSeaLevel,
+  calculateFloodDetails,
+} from './sea_level.js'
 
 describe('sea level rise', () => {
   describe('calculateSeaLevelRise', () => {
@@ -193,6 +197,192 @@ describe('sea level rise', () => {
 
       expect(leftFloodDistance).toBeNull()
       expect(rightFloodDistance).toBeCloseTo(20.56, 2)
+    })
+  })
+})
+
+describe('flooding distance', () => {
+  // These tests cover distance -- they don't cover types and flooded state
+  // TODO: types -- accurately include types from partially flooded slices,
+  // make sure values are unique and `undefined` is filtered out
+  describe('calculateFloodDetails', () => {
+    it.each([
+      ['left', [0, 1]],
+      ['right', [1, 0]],
+    ] as const)(
+      'detects a flooded distance from the %s',
+      (direction, elevations) => {
+        expect(
+          calculateFloodDetails(
+            elevations.map((elevation) => ({
+              width: elevation === 0 ? 2 : 3,
+              slope: { on: false, values: [] },
+              type: 'sidewalk',
+              elevation,
+            })),
+            1,
+            direction
+          )
+        ).toEqual({
+          direction,
+          distance: 2,
+          types: ['PEDESTRIAN'],
+          flooded: false,
+        })
+      }
+    )
+
+    it.each(['left', 'right'] as const)(
+      'detects zero flooding distance from the %s',
+      (direction) => {
+        expect(
+          calculateFloodDetails(
+            [
+              {
+                width: 2,
+                slope: { on: false, values: [] },
+                type: 'sidewalk',
+                elevation: 1.5,
+              },
+            ],
+            1,
+            direction
+          )
+        ).toEqual({
+          direction,
+          distance: 0,
+          types: [],
+          flooded: false,
+        })
+      }
+    )
+
+    it.each(['left', 'right'] as const)(
+      'detects infinite flooding distance from the %s',
+      (direction) => {
+        expect(
+          calculateFloodDetails(
+            [
+              {
+                width: 2,
+                slope: { on: false, values: [] },
+                type: 'sidewalk',
+                elevation: 0,
+              },
+            ],
+            1,
+            direction
+          )
+        ).toEqual({
+          direction,
+          distance: Infinity,
+          types: ['PEDESTRIAN'],
+          flooded: false,
+        })
+      }
+    )
+
+    it.each([
+      ['left', [2, 0]],
+      ['right', [0, 2]],
+    ] as const)(
+      'blocks flooding at a higher near slope edge from the %s',
+      (direction, values) => {
+        expect(
+          calculateFloodDetails(
+            [
+              {
+                width: 2,
+                slope: { on: true, values },
+                type: 'sidewalk',
+                elevation: 0,
+              },
+            ],
+            1,
+            direction
+          )
+        ).toEqual({
+          direction,
+          distance: 0,
+          types: [],
+          flooded: false,
+        })
+      }
+    )
+
+    it.each([
+      ['left', [0, 0.5]],
+      ['right', [0.5, 0]],
+    ] as const)(
+      'floods over a lower slope from the %s',
+      (direction, values) => {
+        expect(
+          calculateFloodDetails(
+            [
+              {
+                width: 2,
+                slope: { on: true, values },
+                type: 'sidewalk',
+                elevation: 0,
+              },
+            ],
+            1,
+            direction
+          )
+        ).toEqual({
+          direction,
+          distance: Infinity,
+          types: ['PEDESTRIAN'],
+          flooded: false,
+        })
+      }
+    )
+
+    it.each([
+      ['left', [0, 2]],
+      ['right', [2, 0]],
+    ] as const)('partially floods a slope from the %s', (direction, values) => {
+      expect(
+        calculateFloodDetails(
+          [
+            {
+              width: 10,
+              slope: { on: true, values },
+              type: 'sidewalk',
+              elevation: 0,
+            },
+          ],
+          1,
+          direction
+        )
+      ).toEqual({
+        direction,
+        distance: 5,
+        types: ['PEDESTRIAN'],
+        flooded: false,
+      })
+    })
+
+    it('does not divide by zero for a level slope at the flood height', () => {
+      expect(
+        calculateFloodDetails(
+          [
+            {
+              width: 2,
+              slope: { on: true, values: [1, 1] },
+              type: 'sidewalk',
+              elevation: 0,
+            },
+          ],
+          1,
+          'left'
+        )
+      ).toEqual({
+        direction: 'left',
+        distance: 0,
+        types: [],
+        flooded: false,
+      })
     })
   })
 })

--- a/client/src/plugins/coastmix/sea_level.test.ts
+++ b/client/src/plugins/coastmix/sea_level.test.ts
@@ -116,13 +116,14 @@ describe('sea level rise', () => {
 
       const canvasEl = document.createElement('div')
 
-      const [leftFloodDistance, rightFloodDistance] = checkSeaLevel(
+      const { floodDistance } = checkSeaLevel(
         street,
         streetEl,
         canvasEl,
         2030,
         false
       )
+      const [leftFloodDistance, rightFloodDistance] = floodDistance
 
       expect(leftFloodDistance).toBeCloseTo(20.56, 2)
       expect(rightFloodDistance).toBeNull()
@@ -187,13 +188,14 @@ describe('sea level rise', () => {
         value: 80,
       })
 
-      const [leftFloodDistance, rightFloodDistance] = checkSeaLevel(
+      const { floodDistance } = checkSeaLevel(
         street,
         streetEl,
         canvasEl,
         2030,
         false
       )
+      const [leftFloodDistance, rightFloodDistance] = floodDistance
 
       expect(leftFloodDistance).toBeNull()
       expect(rightFloodDistance).toBeCloseTo(20.56, 2)

--- a/client/src/plugins/coastmix/sea_level.test.ts
+++ b/client/src/plugins/coastmix/sea_level.test.ts
@@ -1,205 +1,57 @@
 import { createStreetState } from '~/test/factories/street.js'
-import {
-  calculateSeaLevelRise,
-  checkSeaLevel,
-  calculateFloodDetails,
-} from './sea_level.js'
+import { calculateSeaLevelRise, calculateFloodDetails } from './sea_level.js'
 
 describe('sea level rise', () => {
-  describe('calculateSeaLevelRise', () => {
-    it('calculates the correct sea level rises', () => {
-      const street = createStreetState({
-        boundary: {
-          left: {
-            variant: 'beach',
-            elevation: 0,
-          },
-          right: {
-            variant: 'grass',
-            elevation: 1,
-          },
+  it('calculates the correct sea level rises', () => {
+    const street = createStreetState({
+      boundary: {
+        left: {
+          variant: 'beach',
+          elevation: 0,
         },
-      })
-
-      // Sea level rise is off (current year, no storm surge)
-      const result1a = calculateSeaLevelRise(0, false, street)
-      expect(result1a).toBe(0)
-
-      // Sea level rise is at current year, with storm surge
-      const result1b = calculateSeaLevelRise(0, true, street)
-      expect(result1b).toBe(0.381)
-
-      // Sea level rise at various targets, no storm surge
-      const result2 = calculateSeaLevelRise(2030, false, street)
-      expect(result2).toBe(0.457)
-
-      const result3 = calculateSeaLevelRise(2050, false, street)
-      expect(result3).toBe(0.762)
-
-      const result4 = calculateSeaLevelRise(2070, false, street)
-      expect(result4).toBe(1.372)
-
-      // Sea level rise at various targets, with storm surge
-      const result5 = calculateSeaLevelRise(2030, true, street)
-      expect(result5).toBe(0.838)
-
-      const result6 = calculateSeaLevelRise(2050, true, street)
-      expect(result6).toBe(1.143)
-
-      const result7 = calculateSeaLevelRise(2070, true, street)
-      expect(result7).toBe(1.753)
-
-      // Sea level rise when sea level is raised
-      street.boundary.right.variant = 'beach'
-      street.boundary.left.elevation = 1
-      const result8 = calculateSeaLevelRise(2030, true, street)
-      expect(result8).toBe(1.838)
-
-      const result9 = calculateSeaLevelRise(2070, false, street)
-      expect(result9).toBe(2.372)
-    })
-  })
-
-  describe('checkSeaLevel', () => {
-    it('treats a slope with a higher far edge as blocking floodwater from the left', () => {
-      const street = createStreetState({
-        boundary: {
-          left: {
-            variant: 'beach',
-            elevation: 0,
-          },
-          right: {
-            variant: 'grass',
-            elevation: 0,
-          },
+        right: {
+          variant: 'grass',
+          elevation: 1,
         },
-        segments: [
-          {
-            width: 4,
-            type: 'path',
-            elevation: 0,
-            slope: {
-              on: true,
-              values: [0.2, 0.7],
-            },
-          },
-          {
-            width: 4,
-            type: 'path',
-            elevation: 0.1,
-            slope: {
-              on: false,
-              values: [],
-            },
-          },
-        ],
-      })
-
-      const streetEl = document.createElement('div')
-      const leftSlopeEl = document.createElement('div')
-      leftSlopeEl.dataset.sliceIndex = '0'
-      leftSlopeEl.dataset.sliceLeft = '0'
-      Object.defineProperty(leftSlopeEl, 'offsetWidth', {
-        configurable: true,
-        value: 40,
-      })
-      streetEl.appendChild(leftSlopeEl)
-
-      const lowerFlatEl = document.createElement('div')
-      lowerFlatEl.dataset.sliceIndex = '1'
-      lowerFlatEl.dataset.sliceLeft = '40'
-      Object.defineProperty(lowerFlatEl, 'offsetWidth', {
-        configurable: true,
-        value: 40,
-      })
-      streetEl.appendChild(lowerFlatEl)
-
-      const canvasEl = document.createElement('div')
-
-      const { floodDistance } = checkSeaLevel(
-        street,
-        streetEl,
-        canvasEl,
-        2030,
-        false
-      )
-      const [leftFloodDistance, rightFloodDistance] = floodDistance
-
-      expect(leftFloodDistance).toBeCloseTo(20.56, 2)
-      expect(rightFloodDistance).toBeNull()
+      },
     })
 
-    it('treats a slope with a higher far edge as blocking floodwater from the right', () => {
-      const street = createStreetState({
-        boundary: {
-          left: {
-            variant: 'grass',
-            elevation: 0,
-          },
-          right: {
-            variant: 'beach',
-            elevation: 0,
-          },
-        },
-        segments: [
-          {
-            width: 4,
-            type: 'path',
-            elevation: 0.1,
-            slope: {
-              on: false,
-              values: [],
-            },
-          },
-          {
-            width: 4,
-            type: 'path',
-            elevation: 0,
-            slope: {
-              on: true,
-              values: [0.7, 0.2],
-            },
-          },
-        ],
-      })
+    // Sea level rise is off (current year, no storm surge)
+    const result1a = calculateSeaLevelRise(0, false, street)
+    expect(result1a).toBe(0)
 
-      const streetEl = document.createElement('div')
-      const lowerFlatEl = document.createElement('div')
-      lowerFlatEl.dataset.sliceIndex = '0'
-      lowerFlatEl.dataset.sliceLeft = '0'
-      Object.defineProperty(lowerFlatEl, 'offsetWidth', {
-        configurable: true,
-        value: 40,
-      })
-      streetEl.appendChild(lowerFlatEl)
+    // Sea level rise is at current year, with storm surge
+    const result1b = calculateSeaLevelRise(0, true, street)
+    expect(result1b).toBe(0.381)
 
-      const rightSlopeEl = document.createElement('div')
-      rightSlopeEl.dataset.sliceIndex = '1'
-      rightSlopeEl.dataset.sliceLeft = '40'
-      Object.defineProperty(rightSlopeEl, 'offsetWidth', {
-        configurable: true,
-        value: 40,
-      })
-      streetEl.appendChild(rightSlopeEl)
+    // Sea level rise at various targets, no storm surge
+    const result2 = calculateSeaLevelRise(2030, false, street)
+    expect(result2).toBe(0.457)
 
-      const canvasEl = document.createElement('div')
-      Object.defineProperty(canvasEl, 'offsetWidth', {
-        configurable: true,
-        value: 80,
-      })
+    const result3 = calculateSeaLevelRise(2050, false, street)
+    expect(result3).toBe(0.762)
 
-      const { floodDistance } = checkSeaLevel(
-        street,
-        streetEl,
-        canvasEl,
-        2030,
-        false
-      )
-      const [leftFloodDistance, rightFloodDistance] = floodDistance
+    const result4 = calculateSeaLevelRise(2070, false, street)
+    expect(result4).toBe(1.372)
 
-      expect(leftFloodDistance).toBeNull()
-      expect(rightFloodDistance).toBeCloseTo(20.56, 2)
-    })
+    // Sea level rise at various targets, with storm surge
+    const result5 = calculateSeaLevelRise(2030, true, street)
+    expect(result5).toBe(0.838)
+
+    const result6 = calculateSeaLevelRise(2050, true, street)
+    expect(result6).toBe(1.143)
+
+    const result7 = calculateSeaLevelRise(2070, true, street)
+    expect(result7).toBe(1.753)
+
+    // Sea level rise when sea level is raised
+    street.boundary.right.variant = 'beach'
+    street.boundary.left.elevation = 1
+    const result8 = calculateSeaLevelRise(2030, true, street)
+    expect(result8).toBe(1.838)
+
+    const result9 = calculateSeaLevelRise(2070, false, street)
+    expect(result9).toBe(2.372)
   })
 })
 
@@ -207,148 +59,93 @@ describe('flooding distance', () => {
   // These tests cover distance -- they don't cover types and flooded state
   // TODO: types -- accurately include types from partially flooded slices,
   // make sure values are unique and `undefined` is filtered out
-  describe('calculateFloodDetails', () => {
-    it.each([
-      ['left', [0, 1]],
-      ['right', [1, 0]],
-    ] as const)(
-      'detects a flooded distance from the %s',
-      (direction, elevations) => {
-        expect(
-          calculateFloodDetails(
-            elevations.map((elevation) => ({
-              width: elevation === 0 ? 2 : 3,
-              slope: { on: false, values: [] },
-              type: 'sidewalk',
-              elevation,
-            })),
-            1,
-            direction
-          )
-        ).toEqual({
-          direction,
-          distance: 2,
-          floodedTypes: ['PEDESTRIAN'],
-          flooded: false,
-        })
-      }
-    )
+  it.each([
+    ['left', [0, 1]],
+    ['right', [1, 0]],
+  ] as const)(
+    'detects a flooded distance from the %s',
+    (direction, elevations) => {
+      expect(
+        calculateFloodDetails(
+          elevations.map((elevation) => ({
+            width: elevation === 0 ? 2 : 3,
+            slope: { on: false, values: [] },
+            type: 'sidewalk',
+            elevation,
+          })),
+          1,
+          direction
+        )
+      ).toEqual({
+        direction,
+        distance: 2,
+        floodedTypes: ['PEDESTRIAN'],
+        flooded: false,
+      })
+    }
+  )
 
-    it.each(['left', 'right'] as const)(
-      'detects zero flooding distance from the %s',
-      (direction) => {
-        expect(
-          calculateFloodDetails(
-            [
-              {
-                width: 2,
-                slope: { on: false, values: [] },
-                type: 'sidewalk',
-                elevation: 1.5,
-              },
-            ],
-            1,
-            direction
-          )
-        ).toEqual({
-          direction,
-          distance: 0,
-          floodedTypes: [],
-          flooded: false,
-        })
-      }
-    )
-
-    it.each(['left', 'right'] as const)(
-      'detects infinite flooding distance from the %s',
-      (direction) => {
-        expect(
-          calculateFloodDetails(
-            [
-              {
-                width: 2,
-                slope: { on: false, values: [] },
-                type: 'sidewalk',
-                elevation: 0,
-              },
-            ],
-            1,
-            direction
-          )
-        ).toEqual({
-          direction,
-          distance: 'max',
-          floodedTypes: ['PEDESTRIAN'],
-          flooded: false,
-        })
-      }
-    )
-
-    it.each([
-      ['left', [2, 0]],
-      ['right', [0, 2]],
-    ] as const)(
-      'blocks flooding at a higher near slope edge from the %s',
-      (direction, values) => {
-        expect(
-          calculateFloodDetails(
-            [
-              {
-                width: 2,
-                slope: { on: true, values },
-                type: 'sidewalk',
-                elevation: 0,
-              },
-            ],
-            1,
-            direction
-          )
-        ).toEqual({
-          direction,
-          distance: 0,
-          floodedTypes: [],
-          flooded: false,
-        })
-      }
-    )
-
-    it.each([
-      ['left', [0, 0.5]],
-      ['right', [0.5, 0]],
-    ] as const)(
-      'floods over a lower slope from the %s',
-      (direction, values) => {
-        expect(
-          calculateFloodDetails(
-            [
-              {
-                width: 2,
-                slope: { on: true, values },
-                type: 'sidewalk',
-                elevation: 0,
-              },
-            ],
-            1,
-            direction
-          )
-        ).toEqual({
-          direction,
-          distance: 'max',
-          floodedTypes: ['PEDESTRIAN'],
-          flooded: false,
-        })
-      }
-    )
-
-    it.each([
-      ['left', [0, 2]],
-      ['right', [2, 0]],
-    ] as const)('partially floods a slope from the %s', (direction, values) => {
+  it.each(['left', 'right'] as const)(
+    'detects zero flooding distance from the %s',
+    (direction) => {
       expect(
         calculateFloodDetails(
           [
             {
-              width: 10,
+              width: 2,
+              slope: { on: false, values: [] },
+              type: 'sidewalk',
+              elevation: 1.5,
+            },
+          ],
+          1,
+          direction
+        )
+      ).toEqual({
+        direction,
+        distance: 0,
+        floodedTypes: [],
+        flooded: false,
+      })
+    }
+  )
+
+  it.each(['left', 'right'] as const)(
+    'detects infinite flooding distance from the %s',
+    (direction) => {
+      expect(
+        calculateFloodDetails(
+          [
+            {
+              width: 2,
+              slope: { on: false, values: [] },
+              type: 'sidewalk',
+              elevation: 0,
+            },
+          ],
+          1,
+          direction
+        )
+      ).toEqual({
+        direction,
+        distance: 'max',
+        floodedTypes: ['PEDESTRIAN'],
+        flooded: false,
+      })
+    }
+  )
+
+  it.each([
+    ['left', [2, 0]],
+    ['right', [0, 2]],
+  ] as const)(
+    'blocks flooding at a higher near slope edge from the %s',
+    (direction, values) => {
+      expect(
+        calculateFloodDetails(
+          [
+            {
+              width: 2,
               slope: { on: true, values },
               type: 'sidewalk',
               elevation: 0,
@@ -359,32 +156,82 @@ describe('flooding distance', () => {
         )
       ).toEqual({
         direction,
-        distance: 5,
-        floodedTypes: ['PEDESTRIAN'],
-        flooded: false,
-      })
-    })
-
-    it('does not divide by zero for a level slope at the flood height', () => {
-      expect(
-        calculateFloodDetails(
-          [
-            {
-              width: 2,
-              slope: { on: true, values: [1, 1] },
-              type: 'sidewalk',
-              elevation: 0,
-            },
-          ],
-          1,
-          'left'
-        )
-      ).toEqual({
-        direction: 'left',
         distance: 0,
         floodedTypes: [],
         flooded: false,
       })
+    }
+  )
+
+  it.each([
+    ['left', [0, 0.5]],
+    ['right', [0.5, 0]],
+  ] as const)('floods over a lower slope from the %s', (direction, values) => {
+    expect(
+      calculateFloodDetails(
+        [
+          {
+            width: 2,
+            slope: { on: true, values },
+            type: 'sidewalk',
+            elevation: 0,
+          },
+        ],
+        1,
+        direction
+      )
+    ).toEqual({
+      direction,
+      distance: 'max',
+      floodedTypes: ['PEDESTRIAN'],
+      flooded: false,
+    })
+  })
+
+  it.each([
+    ['left', [0, 2]],
+    ['right', [2, 0]],
+  ] as const)('partially floods a slope from the %s', (direction, values) => {
+    expect(
+      calculateFloodDetails(
+        [
+          {
+            width: 10,
+            slope: { on: true, values },
+            type: 'sidewalk',
+            elevation: 0,
+          },
+        ],
+        1,
+        direction
+      )
+    ).toEqual({
+      direction,
+      distance: 5,
+      floodedTypes: ['PEDESTRIAN'],
+      flooded: false,
+    })
+  })
+
+  it('does not divide by zero for a level slope at the flood height', () => {
+    expect(
+      calculateFloodDetails(
+        [
+          {
+            width: 2,
+            slope: { on: true, values: [1, 1] },
+            type: 'sidewalk',
+            elevation: 0,
+          },
+        ],
+        1,
+        'left'
+      )
+    ).toEqual({
+      direction: 'left',
+      distance: 0,
+      floodedTypes: [],
+      flooded: false,
     })
   })
 })

--- a/client/src/plugins/coastmix/sea_level.test.ts
+++ b/client/src/plugins/coastmix/sea_level.test.ts
@@ -58,7 +58,8 @@ describe('sea level rise', () => {
 describe('flooding distance', () => {
   // These tests cover distance -- they don't cover types and flooded state
   // TODO: types -- accurately include types from partially flooded slices,
-  // make sure values are unique and `undefined` is filtered out
+  // make sure values are unique and `undefined` is filtered out, covers
+  // slices where sloping is not permitted
   it.each([
     ['left', [0, 1]],
     ['right', [1, 0]],
@@ -71,6 +72,7 @@ describe('flooding distance', () => {
             width: elevation === 0 ? 2 : 3,
             slope: { on: false, values: [] },
             type: 'sidewalk',
+            variantString: 'normal',
             elevation,
           })),
           1,
@@ -95,6 +97,7 @@ describe('flooding distance', () => {
               width: 2,
               slope: { on: false, values: [] },
               type: 'sidewalk',
+              variantString: 'normal',
               elevation: 1.5,
             },
           ],
@@ -120,6 +123,7 @@ describe('flooding distance', () => {
               width: 2,
               slope: { on: false, values: [] },
               type: 'sidewalk',
+              variantString: 'normal',
               elevation: 0,
             },
           ],
@@ -148,6 +152,7 @@ describe('flooding distance', () => {
               width: 2,
               slope: { on: true, values },
               type: 'sidewalk',
+              variantString: 'normal',
               elevation: 0,
             },
           ],
@@ -174,6 +179,7 @@ describe('flooding distance', () => {
             width: 2,
             slope: { on: true, values },
             type: 'sidewalk',
+            variantString: 'normal',
             elevation: 0,
           },
         ],
@@ -199,6 +205,7 @@ describe('flooding distance', () => {
             width: 10,
             slope: { on: true, values },
             type: 'sidewalk',
+            variantString: 'normal',
             elevation: 0,
           },
         ],
@@ -221,6 +228,7 @@ describe('flooding distance', () => {
             width: 2,
             slope: { on: true, values: [1, 1] },
             type: 'sidewalk',
+            variantString: 'normal',
             elevation: 0,
           },
         ],

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -1,5 +1,10 @@
 import { uniq, intersection } from 'es-toolkit/array'
-import { getBoundaryItem, getSegmentInfo, SliceTypes } from '@streetmix/parts'
+import {
+  getBoundaryItem,
+  getSegmentInfo,
+  getSegmentVariantInfo,
+  SliceTypes,
+} from '@streetmix/parts'
 import { convertImperialMeasurementToMetric } from '@streetmix/utils'
 
 import { SEA_LEVEL_RISE_FEET, SURGE_HEIGHT_FEET } from './constants.js'
@@ -80,10 +85,19 @@ export function calculateFloodDetails(
   ) {
     const slice = slices[i]
     const sliceInfo = getSegmentInfo(slice.type)
+    const variantInfo = getSegmentVariantInfo(slice.type, slice.variantString)
+
+    let isSloped = false
+    if (!('unknown' in variantInfo)) {
+      const allowSlope =
+        variantInfo.slope === 'path' || variantInfo.slope === 'berm'
+      isSloped = allowSlope && slice.slope.on
+    }
 
     // Slices can block a flood based on its elevation.
-    // First, check slope elevations.
-    if (slice.slope.on) {
+    // First, check slope elevations. Slice must be sloped (it is set, and
+    // the variant must allow slope)
+    if (isSloped) {
       const near = fromLeft ? 0 : 1
       const far = fromLeft ? 1 : 0
 

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -75,7 +75,7 @@ export function calculateFloodDetails(
   // elsewhere. this calc is only for the section and its slices, not regarding
   // street widths and street boundaries.
   let floodDistance = 0
-  const floodedTypes = [] // TODO; filter to unique values at the end
+  const floodedTypes = []
 
   // Loop direction changes depending on whether or not we are starting from
   // the left or the right. Doing n+1 / n-1 is faster than reversing the array
@@ -153,7 +153,9 @@ export function calculateFloodDetails(
     }
   }
 
+  // Collapse down to unique values and filter out `undefined`
   const filteredFloodedTypes = uniq(floodedTypes).filter((t) => t !== undefined)
+
   return {
     direction,
     distance: floodDistance,
@@ -172,9 +174,6 @@ function calculateFloodDistance(
   if (streetEl === null || canvasEl === null) {
     return null
   }
-
-  // New calc performed here.
-  calculateFloodDetails(slices, height, direction)
 
   // Depending on whether the flood comes from the left or right, set up
   // a compare loop that counts up or down
@@ -290,11 +289,15 @@ export function checkSeaLevel(
   canvasEl: HTMLElement | null,
   seaLevelRise: number,
   stormSurge: boolean
-): [FloodDistance, FloodDistance] {
+): {
+  floodDistance: [FloodDistance, FloodDistance]
+  floodDetails: [FloodDetails | null, FloodDetails | null]
+} {
   const height = calculateSeaLevelRise(seaLevelRise, stormSurge, street)
 
   const { boundary, segments: slices } = street
   const floodDistance = [null, null] as [FloodDistance, FloodDistance]
+  const floodDetails: [FloodDetails | null, FloodDetails | null] = [null, null]
 
   if (boundary.left.variant && boundary.right.variant) {
     if (getBoundaryItem(boundary.left.variant).waterfront) {
@@ -305,6 +308,7 @@ export function checkSeaLevel(
         streetEl,
         canvasEl
       )
+      floodDetails[0] = calculateFloodDetails(slices, height, 'left')
     }
     if (getBoundaryItem(boundary.right.variant).waterfront) {
       floodDistance[1] = calculateFloodDistance(
@@ -314,8 +318,9 @@ export function checkSeaLevel(
         streetEl,
         canvasEl
       )
+      floodDetails[1] = calculateFloodDetails(slices, height, 'right')
     }
   }
 
-  return floodDistance
+  return { floodDistance, floodDetails }
 }

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -59,21 +59,21 @@ export function calculateSeaLevelRise(
   return baseSeaLevel + height
 }
 
+// Given the slices of a street section, and sea level rise height, calculate
+// how far it floods before being blocked by a higher elevation, and collect
+// a list of affected slice types.
+//
+// Flooding distance will not take into account empty space in the section,
+// or overflow space beyond the street boundaries. This ONLY calculates distance
+// from the edge of the slices themselves.
 export function calculateFloodDetails(
   slices: SliceItem[],
   floodHeight: number,
   direction: 'left' | 'right'
 ): FloodDetails {
   const fromLeft = direction === 'left'
-
-  // NEW CALC!
-  // TODO: calculating distance in this way doesn't take into account
-  // empty space and overflow space. (note that existing method doesn't
-  // account for overflow width either) -- i think we have to account for this
-  // elsewhere. this calc is only for the section and its slices, not regarding
-  // street widths and street boundaries.
-  let floodDistance = 0
   const floodedTypes = []
+  let floodDistance = 0
 
   // Loop direction changes depending on whether or not we are starting from
   // the left or the right. Doing n+1 / n-1 is faster than reversing the array
@@ -156,7 +156,9 @@ export function calculateFloodDetails(
 
   return {
     direction,
-    distance: floodDistance,
+    // if `floodDistance` is infinite, return `max` instead because `Infinity`
+    // is not a serializable value in JSON.
+    distance: floodDistance === Infinity ? 'max' : floodDistance,
     floodedTypes: filteredFloodedTypes,
     flooded: intersection(disallowFlooding, filteredFloodedTypes).length > 0,
   }

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -1,4 +1,4 @@
-import { getBoundaryItem } from '@streetmix/parts'
+import { getBoundaryItem, getSegmentInfo, SliceTypes } from '@streetmix/parts'
 import { convertImperialMeasurementToMetric } from '@streetmix/utils'
 
 import { SEA_LEVEL_RISE_FEET, SURGE_HEIGHT_FEET } from './constants.js'
@@ -78,10 +78,12 @@ function calculateFloodDistance(
       compareElevation = slice.elevation
     }
 
+    const sliceInfo = getSegmentInfo(slice.type)
+
     // Walls are a special case that is capable of blocking a flood (like a
     // seawall, etc). So its compare elevation will be higher
     // TODO: Don't hardcode these height numbers
-    if (slice.type === 'wall') {
+    if (sliceInfo.owner === SliceTypes.WALL) {
       if (slice.variant['wall-height'] === 'low') {
         compareElevation += 1
       } else {

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -4,12 +4,7 @@ import { convertImperialMeasurementToMetric } from '@streetmix/utils'
 
 import { SEA_LEVEL_RISE_FEET, SURGE_HEIGHT_FEET } from './constants.js'
 
-import type {
-  FloodDistance,
-  FloodDetails,
-  SliceItem,
-  StreetState,
-} from '@streetmix/types'
+import type { FloodDetails, SliceItem, StreetState } from '@streetmix/types'
 
 const disallowFlooding = [
   SliceTypes.CAR,
@@ -164,163 +159,25 @@ export function calculateFloodDetails(
   }
 }
 
-function calculateFloodDistance(
-  slices: SliceItem[],
-  height: number,
-  direction: 'left' | 'right',
-  streetEl: HTMLDivElement | null,
-  canvasEl: HTMLElement | null
-): FloodDistance {
-  if (streetEl === null || canvasEl === null) {
-    return null
-  }
-
-  // Depending on whether the flood comes from the left or right, set up
-  // a compare loop that counts up or down
-  const fromLeft = direction === 'left'
-  const start = fromLeft ? 0 : slices.length - 1
-  const end = fromLeft ? slices.length : -1
-  const step = fromLeft ? 1 : -1
-
-  let slicePosition
-
-  for (let i = start; fromLeft ? i < end : i > end; i += step) {
-    const slice = slices[i]
-
-    let compareElevation: number
-
-    // Slices can block a flood based on its elevation.
-    // First, see if this slice is sloped.
-    // If sloped, a slice blocks a flood if any of its endpoints are higher
-    // than the height.
-    if (slice.slope.on) {
-      compareElevation = Math.max(slice.slope.values[0], slice.slope.values[1])
-    } else {
-      // If not sloped, we look at the slice's flat elevation.
-      compareElevation = slice.elevation
-    }
-
-    const sliceInfo = getSegmentInfo(slice.type)
-
-    // Walls are a special case that is capable of blocking a flood (like a
-    // seawall, etc). So its compare elevation will be higher
-    // TODO: Don't hardcode these height numbers
-    if (sliceInfo.owner === SliceTypes.WALL) {
-      if (slice.variant['wall-height'] === 'low') {
-        compareElevation += 1
-      } else {
-        // High wall variant
-        compareElevation += 2.15
-      }
-    }
-
-    // If this slice blocks a flood, record its position and exit loop
-    if (compareElevation >= height) {
-      slicePosition = i
-      break
-    }
-  }
-
-  // If no slice meets or exceeds flood height, use the value 'max' to stand in
-  // for "we will flood all of it." We don't want to return `Infinity` because
-  // that value is not serializable to JSON!
-  if (typeof slicePosition !== 'number') {
-    return 'max'
-  }
-
-  // Get the pixel position of the blocking element
-  const sliceEl = streetEl.querySelector<HTMLElement>(
-    `[data-slice-index="${slicePosition}"]`
-  )
-
-  if (fromLeft) {
-    const distance = Number(sliceEl?.dataset.sliceLeft)
-
-    // If sloped, how far does flood go before it hits the slope?
-    const slice = slices[slicePosition]
-    let extraDistance = 0
-    if (slice.slope.on) {
-      const rise = slice.slope.values[1] - slice.slope.values[0]
-      if (rise > 0 && height > slice.slope.values[0]) {
-        const run = sliceEl?.offsetWidth ?? 0 // This is the width of item
-        // This is a rise/run formula
-        extraDistance = (run / rise) * (slice.slope.values[0] - height)
-      }
-    }
-
-    // Clamp lower bound of return value to 0 (rounding errors may result
-    // in slightly negative values)
-    return Math.max(distance - extraDistance, 0)
-  } else {
-    // There are some extra steps for calculating the right-hand distance
-    // which is based on the width of the on-screen canvasEl element.
-    // The timing of when this function is called is important because
-    // putting it in the wrong place could cause the element to not be
-    // present, or not yet have an `offsetWidth` value. We can remove this
-    // by switching to calculating flood distance in real world values
-    // rather than on-screen pixel values.
-    const parentWidth = canvasEl.offsetWidth ?? 0
-    const offsetLeftPlusWidth =
-      Number(sliceEl?.dataset.sliceLeft) + (sliceEl?.offsetWidth ?? 0)
-
-    // If sloped, how far does flood go before it hits the slope?
-    const slice = slices[slicePosition]
-    let extraDistance = 0
-    if (slice.slope.on) {
-      const rise = slice.slope.values[0] - slice.slope.values[1]
-      if (rise > 0 && height > slice.slope.values[1]) {
-        const run = sliceEl?.offsetWidth ?? 0 // This is the width of item
-        // This is a rise/run formula
-        extraDistance = -(run / rise) * (height - slice.slope.values[1])
-      }
-    }
-
-    const distance = parentWidth - offsetLeftPlusWidth - extraDistance
-
-    // Clamp lower bound of return value to 0 (rounding errors may result
-    // in slightly negative values)
-    return Math.max(distance, 0)
-  }
-}
-
 export function checkSeaLevel(
   street: StreetState,
-  streetEl: HTMLDivElement | null,
-  canvasEl: HTMLElement | null,
   seaLevelRise: number,
   stormSurge: boolean
-): {
-  floodDistance: [FloodDistance, FloodDistance]
-  floodDetails: [FloodDetails | null, FloodDetails | null]
-} {
+): [FloodDetails | null, FloodDetails | null] {
   const height = calculateSeaLevelRise(seaLevelRise, stormSurge, street)
 
   const { boundary, segments: slices } = street
-  const floodDistance = [null, null] as [FloodDistance, FloodDistance]
+
   const floodDetails: [FloodDetails | null, FloodDetails | null] = [null, null]
 
   if (boundary.left.variant && boundary.right.variant) {
     if (getBoundaryItem(boundary.left.variant).waterfront) {
-      floodDistance[0] = calculateFloodDistance(
-        slices,
-        height,
-        'left',
-        streetEl,
-        canvasEl
-      )
       floodDetails[0] = calculateFloodDetails(slices, height, 'left')
     }
     if (getBoundaryItem(boundary.right.variant).waterfront) {
-      floodDistance[1] = calculateFloodDistance(
-        slices,
-        height,
-        'right',
-        streetEl,
-        canvasEl
-      )
       floodDetails[1] = calculateFloodDetails(slices, height, 'right')
     }
   }
 
-  return { floodDistance, floodDetails }
+  return floodDetails
 }

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -154,12 +154,6 @@ export function calculateFloodDetails(
   }
 
   const filteredFloodedTypes = uniq(floodedTypes).filter((t) => t !== undefined)
-  console.log({
-    direction,
-    distance: floodDistance,
-    types: filteredFloodedTypes,
-    flooded: intersection(disallowFlooding, filteredFloodedTypes).length > 0,
-  })
   return {
     direction,
     distance: floodDistance,

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -4,14 +4,12 @@ import { convertImperialMeasurementToMetric } from '@streetmix/utils'
 
 import { SEA_LEVEL_RISE_FEET, SURGE_HEIGHT_FEET } from './constants.js'
 
-import type { FloodDistance, SliceItem, StreetState } from '@streetmix/types'
-
-interface FloodDetails {
-  direction: 'left' | 'right'
-  distance: FloodDistance
-  types: Array<(typeof SliceTypes)[keyof typeof SliceTypes]>
-  flooded: boolean
-}
+import type {
+  FloodDistance,
+  FloodDetails,
+  SliceItem,
+  StreetState,
+} from '@streetmix/types'
 
 const disallowFlooding = [
   SliceTypes.CAR,
@@ -159,7 +157,7 @@ export function calculateFloodDetails(
   return {
     direction,
     distance: floodDistance,
-    types: filteredFloodedTypes,
+    floodedTypes: filteredFloodedTypes,
     flooded: intersection(disallowFlooding, filteredFloodedTypes).length > 0,
   }
 }

--- a/client/src/plugins/coastmix/sea_level.ts
+++ b/client/src/plugins/coastmix/sea_level.ts
@@ -1,9 +1,28 @@
+import { uniq, intersection } from 'es-toolkit/array'
 import { getBoundaryItem, getSegmentInfo, SliceTypes } from '@streetmix/parts'
 import { convertImperialMeasurementToMetric } from '@streetmix/utils'
 
 import { SEA_LEVEL_RISE_FEET, SURGE_HEIGHT_FEET } from './constants.js'
 
 import type { FloodDistance, SliceItem, StreetState } from '@streetmix/types'
+
+interface FloodDetails {
+  direction: 'left' | 'right'
+  distance: FloodDistance
+  types: Array<(typeof SliceTypes)[keyof typeof SliceTypes]>
+  flooded: boolean
+}
+
+const disallowFlooding = [
+  SliceTypes.CAR,
+  SliceTypes.BIKE,
+  SliceTypes.TRANSIT,
+  SliceTypes.BIKE,
+  // Maybe okay to flood, if we're lax about it!
+  // SliceTypes.FURNITURE,
+  // SliceTypes.FLEX,
+  SliceTypes.UTILITY,
+]
 
 // Returns total sea level rise in metric values
 // Takes into account storm surge levels
@@ -42,6 +61,113 @@ export function calculateSeaLevelRise(
   return baseSeaLevel + height
 }
 
+export function calculateFloodDetails(
+  slices: SliceItem[],
+  floodHeight: number,
+  direction: 'left' | 'right'
+): FloodDetails {
+  const fromLeft = direction === 'left'
+
+  // NEW CALC!
+  // TODO: calculating distance in this way doesn't take into account
+  // empty space and overflow space. (note that existing method doesn't
+  // account for overflow width either) -- i think we have to account for this
+  // elsewhere. this calc is only for the section and its slices, not regarding
+  // street widths and street boundaries.
+  let floodDistance = 0
+  const floodedTypes = [] // TODO; filter to unique values at the end
+
+  // Loop direction changes depending on whether or not we are starting from
+  // the left or the right. Doing n+1 / n-1 is faster than reversing the array
+  // just to keep the loop counting in one direction.
+  for (
+    let i = fromLeft ? 0 : slices.length - 1;
+    fromLeft ? i < slices.length : i >= 0;
+    fromLeft ? i++ : i--
+  ) {
+    const slice = slices[i]
+    const sliceInfo = getSegmentInfo(slice.type)
+
+    // Slices can block a flood based on its elevation.
+    // First, check slope elevations.
+    if (slice.slope.on) {
+      const near = fromLeft ? 0 : 1
+      const far = fromLeft ? 1 : 0
+
+      // If the nearest slope endpoint is higher than the flood height, the
+      // slice blocks the flood. We can stop checking this slice
+      if (slice.slope.values[near] >= floodHeight) break
+
+      // If the farthest slope endpoint is higher than the flood height, the
+      // slice partially blocks the flood.
+      if (slice.slope.values[far] >= floodHeight) {
+        // Calculate partial distance based on slope
+        const rise = slice.slope.values[far] - slice.slope.values[near]
+
+        // This is a rise/run formula
+        // This does not handle a divide-by-zero (rise = 0), but we should never
+        // reach this point (it gets blocked by earlier break)
+        const partialDistance =
+          (slice.width / rise) * (floodHeight - slice.slope.values[near])
+
+        floodDistance += partialDistance
+        floodedTypes.push(sliceInfo.owner)
+        break
+      } else {
+        // If neither slope endpoint is higher than the flood height, this
+        // slice is fully flooded.
+        floodDistance += slice.width
+        floodedTypes.push(sliceInfo.owner)
+      }
+    } else {
+      // If not sloped, check the slice's flat elevation.
+      let compareElevation = slice.elevation
+
+      // The elevation to check is modified by an additional value if the
+      // slice owner type is WALL.
+      // Walls are a special case that is capable of blocking a flood (like a
+      // seawall, etc).
+      // TODO: Don't hardcode these height numbers
+      if (sliceInfo.owner === SliceTypes.WALL) {
+        if (slice.variant['wall-height'] === 'low') {
+          compareElevation += 1
+        } else {
+          // High wall variant
+          compareElevation += 2.15
+        }
+      }
+
+      // If the elevation is greater, then the slice blocks the flood. We can
+      // stop checking
+      if (compareElevation >= floodHeight) break
+
+      // If the elevation is less, then the slice is fully flooded.
+      floodDistance += slice.width
+      floodedTypes.push(sliceInfo.owner)
+    }
+
+    // If we've come here, then the flood distance is beyond the section,
+    // so we assign a value of Infinity.
+    if (i === (fromLeft ? slices.length - 1 : 0)) {
+      floodDistance += Infinity
+    }
+  }
+
+  const filteredFloodedTypes = uniq(floodedTypes).filter((t) => t !== undefined)
+  console.log({
+    direction,
+    distance: floodDistance,
+    types: filteredFloodedTypes,
+    flooded: intersection(disallowFlooding, filteredFloodedTypes).length > 0,
+  })
+  return {
+    direction,
+    distance: floodDistance,
+    types: filteredFloodedTypes,
+    flooded: intersection(disallowFlooding, filteredFloodedTypes).length > 0,
+  }
+}
+
 function calculateFloodDistance(
   slices: SliceItem[],
   height: number,
@@ -52,6 +178,9 @@ function calculateFloodDistance(
   if (streetEl === null || canvasEl === null) {
     return null
   }
+
+  // New calc performed here.
+  calculateFloodDetails(slices, height, direction)
 
   // Depending on whether the flood comes from the left or right, set up
   // a compare loop that counts up or down

--- a/client/src/segments/README.md
+++ b/client/src/segments/README.md
@@ -4,16 +4,16 @@ Each segment is an object. It is named with a string, e.g. 'parklet' that Street
 
 How to fill in the data for a segment:
 
-| property         | type               | required? | description                                                                                                                                                                                                    |
+| property | type | required? | description |
 | ---------------- | ------------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `name`           | _String_           | required  | Display name of a segment. Always use sentence case. 'Parking lot', not 'Parking Lot'                                                                                                                          |
-| `owner`          | _String_           | optional  | See `SegmentTypes` constant variable container. Segments without an owner or type should default to `SegmentTypes.NONE`.                                                                                       |
-| `zIndex`         | _Integer_          | required  | Layering priority. Higher numbers will always display overlapping those with lower numbers. If zIndex is equal, DOM order will determine what is overlapping something else.                                   |
-| `defaultWidth`   | Object             | required  | Default width in metric and imperial values. Decimal numbers are allowed. In many cases, though not always, there is a simple conversion rate of `ft = m * (10 / 3)`.                                          |
-| `variants`       | Array of _strings_ | required  | Sub-types of the segment, e.g. 'orientation' and 'color'. If there are no variants, use an array of a single empty string, `['']`.                                                                             |
-| `enableWithFlag` | String             | optional  | Default value: none. If set, the segment is hidden from users unless the its corresponding flag is set to `true`. These segments may not be ready for production or are only enabled under certain conditions. |
-| `description`    | Object             | optional  | If present, a "learn more" feature is added to the segment's info box. For more info see below.                                                                                                                |
-| `details`        | Object             | required  | Details of every variant of the segment. Each variant is named with a string. For segments that have multiple variants, separate each variant with the variant separator '                                     | ' (pipe) |
+| `name` | _String_ | required | Display name of a segment. Always use sentence case. 'Parking lot', not 'Parking Lot' |
+| `owner` | _String_ | optional | See `SliceTypes` constant variable container. Segments without an owner or type should default to `SliceTypes.NONE`. |
+| `zIndex` | _Integer_ | required | Layering priority. Higher numbers will always display overlapping those with lower numbers. If zIndex is equal, DOM order will determine what is overlapping something else. |
+| `defaultWidth` | Object | required | Default width in metric and imperial values. Decimal numbers are allowed. In many cases, though not always, there is a simple conversion rate of `ft = m * (10 / 3)`. |
+| `variants` | Array of _strings_ | required | Sub-types of the segment, e.g. 'orientation' and 'color'. If there are no variants, use an array of a single empty string, `['']`. |
+| `enableWithFlag` | String | optional | Default value: none. If set, the segment is hidden from users unless the its corresponding flag is set to `true`. These segments may not be ready for production or are only enabled under certain conditions. |
+| `description` | Object | optional | If present, a "learn more" feature is added to the segment's info box. For more info see below. |
+| `details` | Object | required | Details of every variant of the segment. Each variant is named with a string. For segments that have multiple variants, separate each variant with the variant separator ' | ' (pipe) |
 
 ### Settings for description
 

--- a/client/src/segments/Segment.test.tsx
+++ b/client/src/segments/Segment.test.tsx
@@ -49,7 +49,10 @@ describe('Segment', () => {
       ui: { activeSegment: activeElement },
       street: {
         showAnalytics: true,
-        boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+        boundary: {
+          left: { variant: 'wide', elevation: 0 },
+          right: { variant: 'wide', elevation: 0 },
+        },
         segments: [segment],
         width: 5,
       },

--- a/client/src/segments/drag_and_drop.ts
+++ b/client/src/segments/drag_and_drop.ts
@@ -1,24 +1,24 @@
 import { nanoid } from 'nanoid'
 import {
-  SegmentTypes,
+  SliceTypes,
   getSegmentInfo,
   getSegmentVariantInfo,
 } from '@streetmix/parts'
 import { getWidthInMetric } from '@streetmix/utils'
 
-import { setIgnoreStreetChanges } from '../streets/data_model'
-import { getElAbsolutePos } from '../util/helpers'
+import { setIgnoreStreetChanges } from '../streets/data_model.js'
+import { getElAbsolutePos } from '../util/helpers.js'
 import store, { observeStore } from '../store'
-import { addSegment, moveSegment } from '../store/slices/street'
-import { removeSegmentAction } from '../store/actions/street'
+import { addSegment, moveSegment } from '../store/slices/street.js'
+import { removeSegmentAction } from '../store/actions/street.js'
 import {
   initDraggingState,
   updateDraggingState,
   clearDraggingState,
   setActiveSegment,
   setDraggingType,
-} from '../store/slices/ui'
-import { generateRandSeed } from '../util/random'
+} from '../store/slices/ui.js'
+import { generateRandSeed } from '../util/random.js'
 import {
   RESIZE_TYPE_INITIAL,
   RESIZE_TYPE_DRAGGING,
@@ -28,8 +28,8 @@ import {
   resolutionForResizeType,
   normalizeSegmentWidth,
   cancelSegmentResizeTransitions,
-} from './resizing'
-import { getVariantInfo, getVariantString } from './variant_utils'
+} from './resizing.js'
+import { getVariantInfo, getVariantString } from './variant_utils.js'
 import {
   TILE_SIZE,
   MIN_SEGMENT_WIDTH,
@@ -38,8 +38,8 @@ import {
   DRAGGING_TYPE_MOVE,
   DRAGGING_TYPE_RESIZE,
   CURB_HEIGHT,
-} from './constants'
-import { segmentsChanged } from './view'
+} from './constants.js'
+import { segmentsChanged } from './view.js'
 
 import type {
   SliceItem,
@@ -174,7 +174,9 @@ function handleSegmentResizeStart(event: MouseEvent | TouchEvent): void {
   draggingResize.segmentEl.classList.add('hover')
 
   window.setTimeout(function () {
-    draggingResize.segmentEl.classList.add('hover')
+    if (draggingResize.segmentEl) {
+      draggingResize.segmentEl.classList.add('hover')
+    }
   }, 0)
 }
 
@@ -331,17 +333,17 @@ function doDropHeuristics(
   const right =
     segmentBeforeEl !== null ? (street.segments[segmentBeforeEl] ?? null) : null
 
-  const leftOwner = left && SegmentTypes[getSegmentInfo(left.type).owner]
-  const rightOwner = right && SegmentTypes[getSegmentInfo(right.type).owner]
+  const leftOwner = left && SliceTypes[getSegmentInfo(left.type).owner]
+  const rightOwner = right && SliceTypes[getSegmentInfo(right.type).owner]
 
   const leftOwnerAsphalt =
-    leftOwner === SegmentTypes.CAR ||
-    leftOwner === SegmentTypes.BIKE ||
-    leftOwner === SegmentTypes.TRANSIT
+    leftOwner === SliceTypes.CAR ||
+    leftOwner === SliceTypes.BIKE ||
+    leftOwner === SliceTypes.TRANSIT
   const rightOwnerAsphalt =
-    rightOwner === SegmentTypes.CAR ||
-    rightOwner === SegmentTypes.BIKE ||
-    rightOwner === SegmentTypes.TRANSIT
+    rightOwner === SliceTypes.CAR ||
+    rightOwner === SliceTypes.BIKE ||
+    rightOwner === SliceTypes.TRANSIT
 
   const leftVariant = left && getVariantInfo(left.type, left.variantString)
   const rightVariant = right && getVariantInfo(right.type, right.variantString)
@@ -351,7 +353,7 @@ function doDropHeuristics(
 
   // Direction
 
-  if (segmentInfo.variants.indexOf('direction') !== -1) {
+  if (segmentInfo.variants?.indexOf('direction') !== -1) {
     if (leftVariant && leftVariant.direction) {
       variant.direction = leftVariant.direction
     } else if (rightVariant && rightVariant.direction) {
@@ -361,7 +363,7 @@ function doDropHeuristics(
 
   // Parking lane orientation
 
-  if (segmentInfo.variants.indexOf('parking-lane-orientation') !== -1) {
+  if (segmentInfo.variants?.indexOf('parking-lane-orientation') !== -1) {
     if (!right || !rightOwnerAsphalt) {
       variant['parking-lane-orientation'] = 'right'
     } else if (!left || !leftOwnerAsphalt) {
@@ -381,7 +383,7 @@ function doDropHeuristics(
 
   // Turn lane orientation
 
-  if (segmentInfo.variants.indexOf('turn-lane-orientation') !== -1) {
+  if (segmentInfo.variants?.indexOf('turn-lane-orientation') !== -1) {
     if (!right || !rightOwnerAsphalt) {
       variant['turn-lane-orientation'] = 'right'
     } else if (!left || !leftOwnerAsphalt) {
@@ -392,14 +394,14 @@ function doDropHeuristics(
   // Transit shelter orientation and elevation
 
   if (type === 'transit-shelter') {
-    if (left && leftOwner === SegmentTypes.TRANSIT) {
+    if (left && leftOwner === SliceTypes.TRANSIT) {
       variant.orientation = 'right'
-    } else if (right && rightOwner === SegmentTypes.TRANSIT) {
+    } else if (right && rightOwner === SliceTypes.TRANSIT) {
       variant.orientation = 'left'
     }
   }
 
-  if (segmentInfo.variants.indexOf('transit-shelter-elevation') !== -1) {
+  if (segmentInfo.variants?.indexOf('transit-shelter-elevation') !== -1) {
     if (variant.orientation === 'right' && left && left.type === 'light-rail') {
       variant['transit-shelter-elevation'] = 'light-rail'
     } else if (
@@ -416,9 +418,9 @@ function doDropHeuristics(
   if (type === 'brt-station') {
     // Default orientation is center
     variant['brt-station-orientation'] = 'center'
-    if (left && leftOwner === SegmentTypes.TRANSIT) {
+    if (left && leftOwner === SliceTypes.TRANSIT) {
       variant['brt-station-orientation'] = 'right'
-    } else if (right && rightOwner === SegmentTypes.TRANSIT) {
+    } else if (right && rightOwner === SliceTypes.TRANSIT) {
       variant['brt-station-orientation'] = 'left'
     }
   }
@@ -426,16 +428,16 @@ function doDropHeuristics(
   // Bike rack orientation
 
   if (type === 'sidewalk-bike-rack') {
-    if (left && leftOwner !== SegmentTypes.PEDESTRIAN) {
+    if (left && leftOwner !== SliceTypes.PEDESTRIAN) {
       variant.orientation = 'left'
-    } else if (right && rightOwner !== SegmentTypes.PEDESTRIAN) {
+    } else if (right && rightOwner !== SliceTypes.PEDESTRIAN) {
       variant.orientation = 'right'
     }
   }
 
   // Lamp orientation
 
-  if (segmentInfo.variants.indexOf('lamp-orientation') !== -1) {
+  if (segmentInfo.variants?.indexOf('lamp-orientation') !== -1) {
     if (left && right && leftOwnerAsphalt && rightOwnerAsphalt) {
       variant['lamp-orientation'] = 'both'
     } else if (left && leftOwnerAsphalt) {

--- a/client/src/segments/resizing.ts
+++ b/client/src/segments/resizing.ts
@@ -1,11 +1,11 @@
 import { round } from '@streetmix/utils'
 
-import { setIgnoreStreetChanges } from '../streets/data_model'
-import { SETTINGS_UNITS_IMPERIAL } from '../users/constants'
+import { setIgnoreStreetChanges } from '../streets/data_model.js'
+import { SETTINGS_UNITS_IMPERIAL } from '../users/constants.js'
 import store from '../store'
 import { segmentsChanged } from '../store/actions/street.js'
-import { changeSegmentWidth } from '../store/slices/street'
-import { setDraggingType } from '../store/slices/ui'
+import { changeSegmentWidth } from '../store/slices/street.js'
+import { setDraggingType } from '../store/slices/ui.js'
 import {
   TILE_SIZE,
   MIN_SEGMENT_WIDTH,
@@ -21,8 +21,8 @@ import {
   SEGMENT_WIDTH_CLICK_INCREMENT_METRIC,
   SEGMENT_WIDTH_DRAGGING_RESOLUTION_METRIC,
   BUILDING_SPACE,
-} from './constants'
-import { draggingResize } from './drag_and_drop'
+} from './constants.js'
+import { draggingResize } from './drag_and_drop.js'
 
 import type { Segment, UnitsSetting } from '@streetmix/types'
 

--- a/client/src/store/__tests__/street.integration.test.js
+++ b/client/src/store/__tests__/street.integration.test.js
@@ -54,7 +54,10 @@ describe('street integration test', () => {
       it('by resolution (metric)', async () => {
         const initialState = {
           street: {
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [
               { width: 10, slope: { on: false, values: [] } },
               { width: 10, slope: { on: false, values: [] } },
@@ -74,7 +77,10 @@ describe('street integration test', () => {
       it('by resolution (imperial)', async () => {
         const initialState = {
           street: {
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [
               { width: 3.048, slope: { on: false, values: [] } },
               { width: 3.048, slope: { on: false, values: [] } },
@@ -94,7 +100,10 @@ describe('street integration test', () => {
       it('by clickIncrement', async () => {
         const initialState = {
           street: {
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [
               { width: 6.05, slope: { on: false, values: [] } },
               { width: 6.05, slope: { on: false, values: [] } },
@@ -115,7 +124,10 @@ describe('street integration test', () => {
         const initialState = {
           street: {
             width: 24,
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [
               { width: 12, slope: { on: false, values: [] } },
               { width: 12, slope: { on: false, values: [] } },
@@ -136,7 +148,10 @@ describe('street integration test', () => {
       it('handles decrementing an imprecise value to nearest precise value', async () => {
         const initialState = {
           street: {
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [{ width: 2.123, slope: { on: false, values: [] } }],
             width: 2.5,
             units: 0,
@@ -155,7 +170,10 @@ describe('street integration test', () => {
       it('by resolution', async () => {
         const initialState = {
           street: {
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [
               { width: 5, slope: { on: false, values: [] } },
               { width: 5, slope: { on: false, values: [] } },
@@ -175,7 +193,10 @@ describe('street integration test', () => {
       it('by clickIncrement', async () => {
         const initialState = {
           street: {
-            boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+            boundary: {
+              left: { variant: 'wide', elevation: 0 },
+              right: { variant: 'wide', elevation: 0 },
+            },
             segments: [
               { width: 3.658, slope: { on: false, values: [] } },
               { width: 3.658, slope: { on: false, values: [] } },
@@ -197,7 +218,10 @@ describe('street integration test', () => {
     it('saves to server', async () => {
       const initialState = {
         street: {
-          boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+          boundary: {
+            left: { variant: 'wide', elevation: 0 },
+            right: { variant: 'wide', elevation: 0 },
+          },
           segments: [
             { width: 200, slope: { on: false, values: [] } },
             { width: 200, slope: { on: false, values: [] } },
@@ -216,7 +240,10 @@ describe('street integration test', () => {
     it('handles incrementing an imprecise value to nearest precise value', async () => {
       const initialState = {
         street: {
-          boundary: { left: { elevation: 0 }, right: { elevation: 0 } },
+          boundary: {
+            left: { variant: 'wide', elevation: 0 },
+            right: { variant: 'wide', elevation: 0 },
+          },
           segments: [{ width: 2.147, slope: { on: false, values: [] } }],
           width: 2.5,
           units: 0,

--- a/client/src/store/actions/street.ts
+++ b/client/src/store/actions/street.ts
@@ -2,6 +2,7 @@ import clone from 'just-clone'
 
 import { ERRORS } from '~/src/app/errors.js'
 import { formatMessage } from '~/src/locales/locale.js'
+import { checkSeaLevel } from '~/src/plugins/coastmix/sea_level.js'
 import {
   RESIZE_TYPE_INCREMENT,
   RESIZE_TYPE_PRECISE_DRAGGING,
@@ -38,6 +39,7 @@ import {
 import { setInfoBubbleMouseInside } from '../slices/infoBubble.js'
 import { setActiveSegment, setImmediateRemoval } from '../slices/ui.js'
 
+import { setFloodDetails } from '../slices/coastmix.js'
 import type { Dispatch, RootState } from '../index.js'
 import type {
   SliceItem,
@@ -69,7 +71,8 @@ export function updateStreetDataAction(data: Partial<StreetState>) {
 
 export const segmentsChanged = (force = false) => {
   return async (dispatch: Dispatch, getState: () => RootState) => {
-    const { street } = getState()
+    const { street, coastmix } = getState()
+    const { seaLevelRise, stormSurge } = coastmix
 
     const calculatedWidths = recalculateWidth(street)
 
@@ -113,6 +116,10 @@ export const segmentsChanged = (force = false) => {
         calculatedWidths.remainingWidth.toNumber()
       )
     )
+
+    // Calculate flood details
+    const floodDetails = checkSeaLevel(street, seaLevelRise, stormSurge)
+    dispatch(setFloodDetails(floodDetails))
 
     // ToDo: Refactor this out to be dispatched as well
     // Forcing a save is necessary when the data to be saved is not in the

--- a/client/src/store/actions/street.ts
+++ b/client/src/store/actions/street.ts
@@ -118,6 +118,9 @@ export const segmentsChanged = (force = false) => {
     )
 
     // Calculate flood details
+    // This is using a stale version of `street` and might not include
+    // the updated occupiedWidth, remainingWidth etc? but it still seems to
+    // be okay.
     const floodDetails = checkSeaLevel(street, seaLevelRise, stormSurge)
     dispatch(setFloodDetails(floodDetails))
 

--- a/client/src/store/slices/coastmix.test.ts
+++ b/client/src/store/slices/coastmix.test.ts
@@ -3,18 +3,16 @@ import coastmix, {
   showCoastalFloodingPanel,
   hideCoastalFloodingPanel,
   setSeaLevelRise,
-  setFloodDistance,
   setStormSurge,
   toggleCoastalFloodingPanel,
 } from './coastmix.js'
-import type { FloodDetails, FloodDistance } from '@streetmix/types'
+import type { FloodDetails } from '@streetmix/types'
 
 describe('coastmix reducer', () => {
   const initialState = {
     controlsVisible: false,
     seaLevelRise: 0,
     stormSurge: false,
-    floodDistance: [null, null] as [FloodDistance, FloodDistance],
     floodDetails: [null, null] as [FloodDetails | null, FloodDetails | null],
   }
 
@@ -25,7 +23,6 @@ describe('coastmix reducer', () => {
           controlsVisible: true,
           seaLevelRise: 2030,
           stormSurge: true,
-          floodDistance: [1, null],
           floodDetails: [
             {
               direction: 'left',
@@ -92,50 +89,6 @@ describe('coastmix reducer', () => {
       const action = coastmix(initialState, setStormSurge(false))
 
       expect(action.stormSurge).toEqual(false)
-    })
-  })
-
-  describe('setFloodDistance()', () => {
-    it('should set left flood distance to a value', () => {
-      const action = coastmix(initialState, setFloodDistance([1, null]))
-
-      expect(action.floodDistance).toEqual([1, null])
-    })
-
-    it('should set left flood distance to a zero value', () => {
-      const action = coastmix(initialState, setFloodDistance([0, null]))
-
-      expect(action.floodDistance).toEqual([0, null])
-    })
-
-    it('should set right flood distance to a value', () => {
-      const action = coastmix(initialState, setFloodDistance([null, 1]))
-
-      expect(action.floodDistance).toEqual([null, 1])
-    })
-
-    it('should set right flood distance to a zero value', () => {
-      const action = coastmix(initialState, setFloodDistance([null, 0]))
-
-      expect(action.floodDistance).toEqual([null, 0])
-    })
-
-    it('should set both flood distance to a value', () => {
-      const action = coastmix(initialState, setFloodDistance([3, 2]))
-
-      expect(action.floodDistance).toEqual([3, 2])
-    })
-
-    it('should set both flood distance to a zero value', () => {
-      const action = coastmix(initialState, setFloodDistance([0, 0]))
-
-      expect(action.floodDistance).toEqual([0, 0])
-    })
-
-    it('should reset both flood distance to null', () => {
-      const action = coastmix(initialState, setFloodDistance([null, null]))
-
-      expect(action.floodDistance).toEqual([null, null])
     })
   })
 })

--- a/client/src/store/slices/coastmix.test.ts
+++ b/client/src/store/slices/coastmix.test.ts
@@ -3,6 +3,7 @@ import coastmix, {
   showCoastalFloodingPanel,
   hideCoastalFloodingPanel,
   setSeaLevelRise,
+  setFloodDetails,
   setStormSurge,
   toggleCoastalFloodingPanel,
 } from './coastmix.js'
@@ -75,6 +76,78 @@ describe('coastmix reducer', () => {
       const action = coastmix(initialState, setSeaLevelRise(0))
 
       expect(action.seaLevelRise).toEqual(0)
+    })
+  })
+
+  describe('setFloodDetails()', () => {
+    it('sets flood details for the left side', () => {
+      const left: FloodDetails = {
+        direction: 'left',
+        distance: 1,
+        floodedTypes: [],
+        flooded: false,
+      }
+
+      const action = coastmix(initialState, setFloodDetails([left, null]))
+
+      expect(action.floodDetails).toEqual([left, null])
+    })
+
+    it('sets flood details for the right side', () => {
+      const right: FloodDetails = {
+        direction: 'right',
+        distance: 2,
+        floodedTypes: ['BIKE'],
+        flooded: true,
+      }
+
+      const action = coastmix(initialState, setFloodDetails([null, right]))
+
+      expect(action.floodDetails).toEqual([null, right])
+    })
+
+    it('sets flood details for both sides', () => {
+      const left: FloodDetails = {
+        direction: 'left',
+        distance: 2,
+        floodedTypes: ['BIKE'],
+        flooded: true,
+      }
+      const right: FloodDetails = {
+        direction: 'right',
+        distance: 1,
+        floodedTypes: [],
+        flooded: false,
+      }
+
+      const action = coastmix(initialState, setFloodDetails([left, right]))
+
+      expect(action.floodDetails).toEqual([left, right])
+    })
+
+    it('resets flood details', () => {
+      const action = coastmix(
+        {
+          ...initialState,
+          floodDetails: [
+            {
+              direction: 'left',
+              distance: 1,
+              floodedTypes: [],
+              flooded: false,
+            },
+            {
+              direction: 'right',
+              distance: 2,
+              floodedTypes: ['BIKE'],
+              flooded: true,
+            },
+          ],
+        },
+        setFloodDetails([null, null])
+      )
+
+      expect(action.floodDetails).toEqual([null, null])
     })
   })
 

--- a/client/src/store/slices/coastmix.test.ts
+++ b/client/src/store/slices/coastmix.test.ts
@@ -7,7 +7,7 @@ import coastmix, {
   setStormSurge,
   toggleCoastalFloodingPanel,
 } from './coastmix.js'
-import type { FloodDistance } from '@streetmix/types'
+import type { FloodDetails, FloodDistance } from '@streetmix/types'
 
 describe('coastmix reducer', () => {
   const initialState = {
@@ -15,6 +15,7 @@ describe('coastmix reducer', () => {
     seaLevelRise: 0,
     stormSurge: false,
     floodDistance: [null, null] as [FloodDistance, FloodDistance],
+    floodDetails: [null, null] as [FloodDetails | null, FloodDetails | null],
   }
 
   describe('reset state', () => {
@@ -25,6 +26,15 @@ describe('coastmix reducer', () => {
           seaLevelRise: 2030,
           stormSurge: true,
           floodDistance: [1, null],
+          floodDetails: [
+            {
+              direction: 'left',
+              distance: 1,
+              floodedTypes: [],
+              flooded: false,
+            },
+            null,
+          ],
         },
         resetCoastmixState()
       )

--- a/client/src/store/slices/coastmix.ts
+++ b/client/src/store/slices/coastmix.ts
@@ -8,6 +8,7 @@ const initialState: CoastmixState = {
   seaLevelRise: 0,
   stormSurge: false,
   floodDistance: [null, null],
+  floodDetails: [null, null],
 }
 
 const coastmixSlice = createSlice({
@@ -51,6 +52,13 @@ const coastmixSlice = createSlice({
       state.floodDistance = action.payload
     },
 
+    setFloodDetails(
+      state,
+      action: PayloadAction<CoastmixState['floodDetails']>
+    ) {
+      state.floodDetails = action.payload
+    },
+
     setStormSurge(state, action: PayloadAction<boolean>) {
       state.stormSurge = action.payload
     },
@@ -65,6 +73,7 @@ export const {
   toggleCoastalFloodingPanel,
   setSeaLevelRise,
   setFloodDistance,
+  setFloodDetails,
   setStormSurge,
 } = coastmixSlice.actions
 

--- a/client/src/store/slices/coastmix.ts
+++ b/client/src/store/slices/coastmix.ts
@@ -1,13 +1,12 @@
 import { createSlice } from '@reduxjs/toolkit'
 
 import type { PayloadAction } from '@reduxjs/toolkit'
-import type { CoastmixState, FloodDistance } from '@streetmix/types'
+import type { CoastmixState } from '@streetmix/types'
 
 const initialState: CoastmixState = {
   controlsVisible: false,
   seaLevelRise: 0,
   stormSurge: false,
-  floodDistance: [null, null],
   floodDetails: [null, null],
 }
 
@@ -45,13 +44,6 @@ const coastmixSlice = createSlice({
       state.seaLevelRise = action.payload
     },
 
-    setFloodDistance(
-      state,
-      action: PayloadAction<[FloodDistance, FloodDistance]>
-    ) {
-      state.floodDistance = action.payload
-    },
-
     setFloodDetails(
       state,
       action: PayloadAction<CoastmixState['floodDetails']>
@@ -72,7 +64,6 @@ export const {
   hideCoastalFloodingPanel,
   toggleCoastalFloodingPanel,
   setSeaLevelRise,
-  setFloodDistance,
   setFloodDetails,
   setStormSurge,
 } = coastmixSlice.actions

--- a/client/src/streets/xhr.ts
+++ b/client/src/streets/xhr.ts
@@ -301,31 +301,15 @@ export function unpackServerStreetData(
 
     // some handling of legacy data from development.
     // TODO: clean up in production
-    if (
-      // @ts-expect-error using old property types
-      coastmixState.floodDirection === 'left' ||
-      // @ts-expect-error using old property types
-      coastmixState.floodDirection === 1
-    ) {
-      // @ts-expect-error using old property types
-      coastmixState.floodDistance = [coastmixState.floodDistance, null]
-    } else if (
-      // @ts-expect-error using old property types
-      coastmixState.floodDirection === 'right' ||
-      // @ts-expect-error using old property types
-      coastmixState.floodDirection === 2
-    ) {
-      // @ts-expect-error using old property types
-      coastmixState.floodDistance = [null, coastmixState.floodDistance]
-      // @ts-expect-error using old property types
-    } else if (typeof coastmixState.floodDirection !== 'undefined') {
-      coastmixState.floodDistance = [null, null]
-    }
-
     // @ts-expect-error using old property types
     if (typeof coastmixState.floodDirection !== 'undefined') {
       // @ts-expect-error using old property types
       delete coastmixState.floodDirection
+    }
+    // @ts-expect-error using old property types
+    if (typeof coastmixState.floodDistance !== 'undefined') {
+      // @ts-expect-error using old property types
+      delete coastmixState.floodDistance
     }
 
     store.dispatch(setCoastmixState(transmission.data.plugins.coastmix))

--- a/client/src/streets/xhr.ts
+++ b/client/src/streets/xhr.ts
@@ -301,17 +301,18 @@ export function unpackServerStreetData(
 
     // some handling of legacy data from development.
     // TODO: clean up in production
-    // @ts-expect-error using old property types
     if (
+      // @ts-expect-error using old property types
       coastmixState.floodDirection === 'left' ||
+      // @ts-expect-error using old property types
       coastmixState.floodDirection === 1
     ) {
       // @ts-expect-error using old property types
       coastmixState.floodDistance = [coastmixState.floodDistance, null]
-    }
-    // @ts-expect-error using old property types
-    else if (
+    } else if (
+      // @ts-expect-error using old property types
       coastmixState.floodDirection === 'right' ||
+      // @ts-expect-error using old property types
       coastmixState.floodDirection === 2
     ) {
       // @ts-expect-error using old property types

--- a/client/src/streets/xhr.ts
+++ b/client/src/streets/xhr.ts
@@ -297,21 +297,6 @@ export function unpackServerStreetData(
     store.getState().flags.COASTMIX_MODE.value === true &&
     transmission.data.plugins.coastmix !== undefined
   ) {
-    const coastmixState = transmission.data.plugins.coastmix
-
-    // some handling of legacy data from development.
-    // TODO: clean up in production
-    // @ts-expect-error using old property types
-    if (typeof coastmixState.floodDirection !== 'undefined') {
-      // @ts-expect-error using old property types
-      delete coastmixState.floodDirection
-    }
-    // @ts-expect-error using old property types
-    if (typeof coastmixState.floodDistance !== 'undefined') {
-      // @ts-expect-error using old property types
-      delete coastmixState.floodDistance
-    }
-
     store.dispatch(setCoastmixState(transmission.data.plugins.coastmix))
   }
 

--- a/client/src/ui/Tours/coastmix-practice.ts
+++ b/client/src/ui/Tours/coastmix-practice.ts
@@ -224,15 +224,17 @@ export const steps2: StepOptions[] = [
           activeTour: (this as unknown as { tour?: Tour }).tour ?? null,
           select: (state) => state.coastmix,
           shouldAdvance: (coastmix) => {
-            if (coastmix.seaLevelRise === 0) return false
-            if (
-              coastmix.floodDistance[0] === null &&
-              coastmix.floodDistance[1] === null
-            ) {
+            const { seaLevelRise, floodDetails } = coastmix
+
+            if (seaLevelRise === 0) return false
+            if (floodDetails[0] === null && floodDetails[1] === null) {
               return false
             }
 
-            return !coastmix.floodDistance.includes('max')
+            return (
+              floodDetails[0]?.distance !== 'max' &&
+              floodDetails[1]?.distance !== 'max'
+            )
           },
         })
       },

--- a/packages/parts/data/components.yaml
+++ b/packages/parts/data/components.yaml
@@ -205,7 +205,7 @@ objects:
   pickup-sign:
     name: Pickup sign
     nameKey: pickup-sign
-    owner: FLEX
+    owner: FURNITURE
     zIndex: 30
     variants:
       orientation:
@@ -230,7 +230,7 @@ objects:
   utility-pole:
     name: Utility pole
     nameKey: utility-pole
-    owner: NONE
+    owner: UTILITY
     zIndex: 10
     variants:
       orientation:
@@ -277,7 +277,7 @@ objects:
   bench:
     name: Bench
     nameKey: bench
-    owner: PEDESTRIAN
+    owner: FURNITURE
     zIndex: 24
     variants:
       orientation:
@@ -293,7 +293,7 @@ objects:
   outdoor-dining:
     name: Outdoor dining
     nameKey: outdoor-dining
-    owner: PEDESTRIAN
+    owner: FURNITURE
     zIndex: 20
     variants:
       occupants:
@@ -306,7 +306,7 @@ objects:
   wayfinding-sign:
     name: Wayfinding sign
     nameKey: wayfinding-sign
-    owner: PEDESTRIAN
+    owner: FURNITURE
     zIndex: 21
     variants:
       type:
@@ -322,7 +322,7 @@ objects:
   lamp:
     name: Lamp
     nameKey: lamp
-    owner: PEDESTRIAN
+    owner: FURNITURE
     zIndex: 19
     variants:
       type|orientation:
@@ -365,7 +365,7 @@ objects:
   parklet:
     name: Parklet
     nameKey: parklet
-    owner: NATURE
+    owner: FURNITURE
     zIndex: 15
     variants:
       orientation:
@@ -396,7 +396,7 @@ objects:
   bikeshare:
     name: Bikeshare station
     nameKey: bikeshare-station
-    owner: FLEX
+    owner: FURNITURE
     zIndex: 21
     variants:
       orientation:
@@ -450,7 +450,7 @@ objects:
   planter-box:
     name: Planter box
     nameKey: planter-box
-    owner: NATURE
+    owner: FURNITURE
     zIndex: 20
     variants:
       type:
@@ -649,7 +649,7 @@ objects:
   wall:
     name: Wall
     nameKey: wall
-    owner: NONE
+    owner: WALL
     variants:
       wall-height:
         low:
@@ -747,7 +747,7 @@ vehicles:
   taxi:
     name: Taxi
     nameKey: taxi
-    owner: FLEX
+    owner: CAR
     zIndex: 15
     variants:
       direction|orientation:
@@ -768,7 +768,7 @@ vehicles:
   rideshare:
     name: Rideshare
     nameKey: rideshare
-    owner: FLEX
+    owner: CAR
     zIndex: 15
     variants:
       direction|orientation:
@@ -950,7 +950,7 @@ vehicles:
   food-truck:
     name: Food truck
     nameKey: foodtruck
-    owner: FLEX
+    owner: CAR
     zIndex: 20
     variants:
       orientation:

--- a/packages/parts/data/segment-lookup.yaml
+++ b/packages/parts/data/segment-lookup.yaml
@@ -180,7 +180,7 @@ sidewalk-bike-rack:
 sidewalk-bench:
   name: Bench
   nameKey: bench
-  owner: PEDESTRIAN
+  owner: FURNITURE
   zIndex: 24
   coastmixPaletteOrder: 23
   defaultWidth:
@@ -224,7 +224,7 @@ sidewalk-bench:
 outdoor-dining:
   name: Outdoor dining
   nameKey: outdoor-dining
-  owner: PEDESTRIAN
+  owner: FURNITURE
   zIndex: 24
   coastmixPaletteOrder: 24
   defaultWidth:
@@ -286,7 +286,7 @@ outdoor-dining:
 sidewalk-wayfinding:
   name: Wayfinding sign
   nameKey: wayfinding-sign
-  owner: PEDESTRIAN
+  owner: FURNITURE
   zIndex: 21
   coastmixPaletteOrder: 25
   defaultWidth:
@@ -333,7 +333,7 @@ sidewalk-wayfinding:
 sidewalk-lamp:
   name: Lamp
   nameKey: sidewalk-lamp
-  owner: PEDESTRIAN
+  owner: FURNITURE
   zIndex: 19
   coastmixPaletteOrder: 26
   defaultWidth:
@@ -466,7 +466,7 @@ sidewalk-lamp:
 utilities:
   name: Utility pole
   nameKey: utility-pole
-  owner: NONE
+  owner: UTILITY
   zIndex: 10
   defaultWidth:
     metric: 1.2
@@ -500,7 +500,7 @@ utilities:
 parklet:
   name: Parklet
   nameKey: parklet
-  owner: NATURE
+  owner: FURNITURE
   zIndex: 15
   defaultWidth:
     metric: 2.4
@@ -905,7 +905,7 @@ temporary:
 drainage-channel:
   name: Drainage channel
   nameKey: drainage-channel
-  owner: UTILITY
+  owner: DRAINAGE
   unlockWithFlag: SEGMENT_DRAINAGE_CHANNEL_UNLOCKED
   unlockCondition: SUBSCRIBE
   defaultWidth:
@@ -941,7 +941,7 @@ drainage-channel:
 bioswale:
   name: Rain garden
   nameKey: rain-garden
-  owner: NATURE
+  owner: DRAINAGE
   enableWithFlag: COASTMIX_MODE
   coastmixPaletteOrder: 3
   unlockCondition: SUBSCRIBE
@@ -1789,7 +1789,7 @@ bike-lane:
 bikeshare:
   name: Bikeshare station
   nameKey: bikeshare-station
-  owner: FLEX
+  owner: FURNITURE
   zIndex: 21
   coastmixPaletteOrder: 31
   defaultWidth:
@@ -1855,7 +1855,7 @@ bikeshare:
 food-truck:
   name: Food truck
   nameKey: foodtruck
-  owner: FLEX
+  owner: CAR
   zIndex: 20
   coastmixPaletteOrder: 32
   defaultWidth:
@@ -3926,7 +3926,7 @@ marsh:
 wall:
   name: Wall
   nameKey: wall
-  owner: NONE
+  owner: WALL
   zIndex: 35
   defaultWidth:
     metric: 0.75

--- a/packages/parts/src/info.ts
+++ b/packages/parts/src/info.ts
@@ -32,18 +32,18 @@ const SEGMENT_LOOKUP: Record<string, SegmentDefinition> =
  * up by different modes or uses.
  */
 export const SliceTypes = {
-  NONE: 'none', // nothing should use this if possible
-  CAR: 'car', // all motor vehicles, including ridesharing
-  TRANSIT: 'transit', // all public transit vehicles
-  BIKE: 'bike', // "micromobility" vehicles which include scooters and e-bikes
-  PEDESTRIAN: 'pedestrian', // people walking on foot
-  FURNITURE: 'furniture', // temporary or permanent objects in pedestrian zones
-  FLEX: 'flex', // areas defined as a "flex zone". objects in this zone should
+  NONE: 'NONE', // nothing should use this if possible
+  CAR: 'CAR', // all motor vehicles, including ridesharing
+  TRANSIT: 'TRANSIT', // all public transit vehicles
+  BIKE: 'BIKE', // "micromobility" vehicles which include scooters and e-bikes
+  PEDESTRIAN: 'PEDESTRIAN', // people walking on foot
+  FURNITURE: 'FURNITURE', // temporary or permanent objects in pedestrian zones
+  FLEX: 'FLEX', // areas defined as a "flex zone". objects in this zone should
   // be classified as car, bike, furniture, etc.
-  UTILITY: 'utility', // infrastructure, like power lines
-  WALL: 'wall', // specific infrastructure type for walls
-  DRAINAGE: 'drainage', // specific infrastructure for drainage, bioswales
-  NATURE: 'nature', // landscaped or natural areas
+  UTILITY: 'UTILITY', // infrastructure, like power lines
+  WALL: 'WALL', // specific infrastructure type for walls
+  DRAINAGE: 'DRAINAGE', // specific infrastructure for drainage, bioswales
+  NATURE: 'NATURE', // landscaped or natural areas
 }
 
 /**

--- a/packages/parts/src/info.ts
+++ b/packages/parts/src/info.ts
@@ -31,7 +31,7 @@ const SEGMENT_LOOKUP: Record<string, SegmentDefinition> =
  * in visualizations and data to calculate how much space is taken
  * up by different modes or uses.
  */
-export const SegmentTypes = {
+export const SliceTypes = {
   NONE: 'none', // nothing should use this if possible
   CAR: 'car', // all motor vehicles, including ridesharing
   TRANSIT: 'transit', // all public transit vehicles

--- a/packages/parts/src/info.ts
+++ b/packages/parts/src/info.ts
@@ -32,14 +32,18 @@ const SEGMENT_LOOKUP: Record<string, SegmentDefinition> =
  * up by different modes or uses.
  */
 export const SegmentTypes = {
-  NONE: 'none',
-  CAR: 'car',
-  BIKE: 'bike',
-  PEDESTRIAN: 'pedestrian',
-  TRANSIT: 'transit',
-  NATURE: 'nature',
-  FLEX: 'flex',
-  UTILITY: 'utility',
+  NONE: 'none', // nothing should use this if possible
+  CAR: 'car', // all motor vehicles, including ridesharing
+  TRANSIT: 'transit', // all public transit vehicles
+  BIKE: 'bike', // "micromobility" vehicles which include scooters and e-bikes
+  PEDESTRIAN: 'pedestrian', // people walking on foot
+  FURNITURE: 'furniture', // temporary or permanent objects in pedestrian zones
+  FLEX: 'flex', // areas defined as a "flex zone". objects in this zone should
+  // be classified as car, bike, furniture, etc.
+  UTILITY: 'utility', // infrastructure, like power lines
+  WALL: 'wall', // specific infrastructure type for walls
+  DRAINAGE: 'drainage', // specific infrastructure for drainage, bioswales
+  NATURE: 'nature', // landscaped or natural areas
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -180,7 +180,6 @@ export interface CoastmixState {
   controlsVisible: boolean
   seaLevelRise: number
   stormSurge: boolean
-  floodDistance: [FloodDistance, FloodDistance]
   floodDetails: [FloodDetails | null, FloodDetails | null]
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -181,6 +181,7 @@ export interface CoastmixState {
   seaLevelRise: number
   stormSurge: boolean
   floodDistance: [FloodDistance, FloodDistance]
+  floodDetails: [FloodDetails | null, FloodDetails | null]
 }
 
 // Flood distance is a number expressed in pixels (for now, I don't think
@@ -190,6 +191,13 @@ export interface CoastmixState {
 // flooding. Infinity is normally a good number to use, but that value is
 // not serializable to JSON!
 export type FloodDistance = number | null | 'max'
+
+export interface FloodDetails {
+  direction: 'left' | 'right'
+  distance: FloodDistance
+  floodedTypes: string[]
+  flooded: boolean
+}
 
 export interface HistoryState {
   stack: Delta[]


### PR DESCRIPTION
The primary goal of this PR is to improve the logic behind the messaging of the coastal flooding panel. In its current (existing) form, the panel says a street is addressing sea level rise if any portion of the section has an elevation greater than sea level rise — even if certain parts of the section should not be flooded (e.g. roads). A better way to do this for the flood calculation to see what portions of the section is flooded, and then base its messaging on that. A very basic version of this looks something like this:

- If road infrastructure is being flooded, this condition is very likely not ideal
- If natural areas are being flooded, this condition is very likely intentional
- Pedestrian areas may be flooded temporarily.

To get there, the flood calculation functionality needed to be rebuilt. In its current (existing) implementation, flood distance is determined by looping over the slices. When it encounters a slice that could potentially block a flood (one or more of its sloped points, or its flat elevation, is higher than sea level rise), it records that position. There were a couple of challenges with this implementation. The first is that the position recorded might be partially flooded or not flooded at all. In other words the number of flooded slices is either `n` or `n+1`. Because we are gathering information on flooded or partially flooded slices, we needed a loop that instead records the position of the slice containing the farthest flood distance (so there is just `n` without the additional `+1` check), not the slice that contains a flood-blocking elevation.

The second challenge is that the loop ran twice, and there was no ideal point to insert logic that stored information on flooded slices.

The existing implementation had to be completely replaced, and in doing so solved several other important issues:
1. Number of loops that run per check reduced by half.
2. Flood distance calculation no longer relies on DOM position. The calculation can be performed on street data.
3. Flood distance calculation can be moved to a different part of the logic flow and not tied to a street resize event.

The flood details calculation now accrues information about what types of slices are being flooded. To do so we use the `owner` property of slices, which have been gently used for things like drag-and-drop heuristics. To make `owner` more useful for flood analysis, some new groups were created and some existing slices were reclassified.

New groups:
- **Furniture** — previously a subclass of "pedestrian", focused on temporary or permanent objects that may be in (but does not have to be in) areas where pedestrians walk. Also, objects previously classified as "nature" (like a planter box or a parklet) because they include plants have been reclassified as "furniture" because of their constructed components.
- **Wall** — a special type for walls, which can have special properties (e.g. higher flood blocking above ground elevation)
- **Drainage** — previously a subclass of "nature", but could allow for greater resilience in flooding situations

Reclassifications:
- **Utility** — not super well defined previously, now used for critical infrastructure like power lines
- **Flex** — this has been shrunk. vehicles have been reclassified as their respective types (e.g. "car"), objects have been reclassified as "furniture", and "flex" only remains for zones with mixed purposes.
- **None** — should not be used specifically, only as a placeholder for slices without defined owners.

The areas where flooding is currently permitted are: none, pedestrian, furniture, flex, wall, drainage, and nature.

## Other stuff

- **Bug fixes**
  - Flooding distance now takes into account slice position that overflow the width of the street
- **Known issues to be addressed later**
  - Wall flood height blocking are still hardcoded values and should be moved to slice definitions
  - If a flood reaches "max" flooding but hits a far boundary at a higher elevation, that boundary does not block the flood 
  - Improved messaging conditionally based on data we now have will be added later
    - Including considerations for when something is not just good/bad but "maybe"
 
